### PR TITLE
Feat/tagging

### DIFF
--- a/app/shared/cms/cms.mocks.ts
+++ b/app/shared/cms/cms.mocks.ts
@@ -33,6 +33,23 @@ export class MockHalDoc extends HalDoc {
     this.ERRORS[rel] = msg;
   }
 
+  update(data: any): HalObservable<MockHalDoc> {
+    for (let key of Object.keys(data)) {
+      this[key] = data[key];
+    }
+    return <HalObservable<MockHalDoc>> Observable.of(this);
+  }
+
+  create(rel: string, params: any = {}, data: any): HalObservable<MockHalDoc> {
+    let doc = this.mock(rel, data); // TODO: params?
+    return <HalObservable<MockHalDoc>> Observable.of(doc);
+  }
+
+  destroy(): HalObservable<HalDoc> {
+    this['_destroyed'] = true; // TODO: something better
+    return <HalObservable<MockHalDoc>> Observable.of(this);
+  }
+
   follow(rel: string, params: {} = null): HalObservable<MockHalDoc> {
     if (this.ERRORS[rel]) {
       return <HalObservable<MockHalDoc>> this.nonLoggingError(this.ERRORS[rel]);

--- a/app/shared/date/timeago.pipe.spec.ts
+++ b/app/shared/date/timeago.pipe.spec.ts
@@ -1,0 +1,35 @@
+import {it, describe, beforeEach, expect} from 'angular2/testing';
+import {TimeAgoPipe} from './timeago.pipe';
+
+describe('TimeAgoPipe', () => {
+
+  let pipe = new TimeAgoPipe();
+  let baseTime = new Date('2000-01-01 12:00:00');
+
+  const transform = (dateStr: string): string => {
+    return pipe.transform(new Date(dateStr));
+  };
+
+  beforeEach(() => {
+    jasmine.clock().mockDate(baseTime);
+  });
+
+  it('returns seconds for things in the past minute', () => {
+    expect(transform('2000-01-01 11:59:59')).toMatch('1 second ago');
+    expect(transform('2000-01-01 11:59:31')).toMatch('29 seconds ago');
+    expect(transform('2000-01-01 11:59:01')).toMatch('59 seconds ago');
+  });
+
+  it('returns minutes for things in the past hour', () => {
+    expect(transform('2000-01-01 11:59:00')).toMatch('1 minute ago');
+    expect(transform('2000-01-01 11:31:14')).toMatch('28 minutes ago');
+    expect(transform('2000-01-01 11:00:01')).toMatch('59 minutes ago');
+  });
+
+  it('returns full datetimes for things further back than an hour', () => {
+    expect(transform('2000-01-01 11:00:00')).toMatch('1/1/2000, 11:00am');
+    expect(transform('1999-12-28 23:59:32')).toMatch('12/28/1999, 11:59pm');
+    expect(transform('1989-04-10 00:16:49')).toMatch('4/10/1989, 12:16am');
+  });
+
+});

--- a/app/shared/date/timeago.pipe.spec.ts
+++ b/app/shared/date/timeago.pipe.spec.ts
@@ -4,7 +4,7 @@ import {TimeAgoPipe} from './timeago.pipe';
 describe('TimeAgoPipe', () => {
 
   let pipe = new TimeAgoPipe();
-  let baseTime = new Date('2000-01-01 12:00:00');
+  let baseTime = new Date('2000-01-01T12:00:00');
 
   const transform = (dateStr: string): string => {
     return pipe.transform(new Date(dateStr));
@@ -15,21 +15,21 @@ describe('TimeAgoPipe', () => {
   });
 
   it('returns seconds for things in the past minute', () => {
-    expect(transform('2000-01-01 11:59:59')).toMatch('1 second ago');
-    expect(transform('2000-01-01 11:59:31')).toMatch('29 seconds ago');
-    expect(transform('2000-01-01 11:59:01')).toMatch('59 seconds ago');
+    expect(transform('2000-01-01T11:59:59')).toMatch('1 second ago');
+    expect(transform('2000-01-01T11:59:31')).toMatch('29 seconds ago');
+    expect(transform('2000-01-01T11:59:01')).toMatch('59 seconds ago');
   });
 
   it('returns minutes for things in the past hour', () => {
-    expect(transform('2000-01-01 11:59:00')).toMatch('1 minute ago');
-    expect(transform('2000-01-01 11:31:14')).toMatch('28 minutes ago');
-    expect(transform('2000-01-01 11:00:01')).toMatch('59 minutes ago');
+    expect(transform('2000-01-01T11:59:00')).toMatch('1 minute ago');
+    expect(transform('2000-01-01T11:31:14')).toMatch('28 minutes ago');
+    expect(transform('2000-01-01T11:00:01')).toMatch('59 minutes ago');
   });
 
   it('returns full datetimes for things further back than an hour', () => {
-    expect(transform('2000-01-01 11:00:00')).toMatch('1/1/2000, 11:00am');
-    expect(transform('1999-12-28 23:59:32')).toMatch('12/28/1999, 11:59pm');
-    expect(transform('1989-04-10 00:16:49')).toMatch('4/10/1989, 12:16am');
+    expect(transform('2000-01-01T11:00:00')).toMatch('1/1/2000, 11:00am');
+    expect(transform('1999-12-28T23:59:32')).toMatch('12/28/1999, 11:59pm');
+    expect(transform('1989-04-10T00:16:49')).toMatch('4/10/1989, 12:16am');
   });
 
 });

--- a/app/shared/date/timeago.pipe.ts
+++ b/app/shared/date/timeago.pipe.ts
@@ -1,0 +1,24 @@
+import {Pipe, PipeTransform} from 'angular2/core';
+
+@Pipe({
+  name: 'timeago'
+})
+export class TimeAgoPipe implements PipeTransform {
+
+  transform(value: Date): string {
+    let now = new Date();
+    let elapsed = Math.floor((now.getTime() - value.getTime()) / 1000);
+
+    if (elapsed < 60) {
+      return `about ${elapsed} seconds ago`;
+    } else if (elapsed < 3600) {
+      let minutes = Math.floor(elapsed / 60);
+      return `about ${minutes} minutes ago`;
+    } else {
+      let date = (value.getMonth() + 1) + '/' + value.getDate() + '/' + value.getFullYear();
+      let time = value.getHours() + ':' + value.getMinutes();
+      return `at ${date}, ${time}`;
+    }
+  }
+
+}

--- a/app/shared/date/timeago.pipe.ts
+++ b/app/shared/date/timeago.pipe.ts
@@ -10,14 +10,25 @@ export class TimeAgoPipe implements PipeTransform {
     let elapsed = Math.floor((now.getTime() - value.getTime()) / 1000);
 
     if (elapsed < 60) {
-      return `about ${elapsed} seconds ago`;
+      let noun = (elapsed === 1) ? 'second' : 'seconds';
+      return `about ${elapsed} ${noun} ago`;
     } else if (elapsed < 3600) {
       let minutes = Math.floor(elapsed / 60);
-      return `about ${minutes} minutes ago`;
+      let noun = (minutes === 1) ? 'minute' : 'minutes';
+      return `about ${minutes} ${noun} ago`;
     } else {
       let date = (value.getMonth() + 1) + '/' + value.getDate() + '/' + value.getFullYear();
-      let time = value.getHours() + ':' + value.getMinutes();
-      return `at ${date}, ${time}`;
+      let hours = value.getHours(), minutes: any = value.getMinutes(), ampm = 'am';
+      if (hours > 12) {
+        hours = hours - 12;
+        ampm = 'pm';
+      } else if (hours < 1) {
+        hours = 12;
+      }
+      if (minutes < 10) {
+        minutes = `0${minutes}`;
+      }
+      return `at ${date}, ${hours}:${minutes}${ampm}`;
     }
   }
 

--- a/app/storyedit/directives/edit.component.css
+++ b/app/storyedit/directives/edit.component.css
@@ -1,0 +1,22 @@
+/**
+ * Story basic editing
+ */
+hr {
+  width: 100%;
+  border-top: 1px solid #aaa;
+  border-bottom: 1px solid #ccc;
+  margin: 0 0 30px;
+}
+.uploads-box {
+  border: 4px solid purple;
+  height: 300px;
+  text-align: center;
+  line-height: 300px;
+  color: purple;
+}
+@media screen and (min-width: 768px) {
+  .span-fields > * {
+    display: inline-block;
+    width: 40%;
+  }
+}

--- a/app/storyedit/directives/edit.component.spec.ts
+++ b/app/storyedit/directives/edit.component.spec.ts
@@ -1,0 +1,25 @@
+import {it, describe, expect} from 'angular2/testing';
+import {setupComponent, buildComponent, mockDirective} from '../../../util/test-helper';
+import {EditComponent} from './edit.component';
+import {StoryFieldComponent} from './storyfield.component';
+
+import {Component} from 'angular2/core';
+@Component({selector: 'story-field', template: '<i>nothing</i>'})
+class EmptyComponent {}
+
+describe('EditComponent', () => {
+
+  setupComponent(EditComponent);
+  mockDirective(StoryFieldComponent, EmptyComponent);
+
+  it('does not render until the story is loaded', buildComponent((fix, el, edit) => {
+    expect(el.textContent.trim()).toEqual('');
+    edit.story = {isLoaded: false};
+    fix.detectChanges();
+    expect(el.querySelector('story-field')).toBeNull();
+    edit.story.isLoaded = true;
+    fix.detectChanges();
+    expect(el.querySelector('story-field')).not.toBeNull();
+  }));
+
+});

--- a/app/storyedit/directives/edit.component.ts
+++ b/app/storyedit/directives/edit.component.ts
@@ -1,66 +1,44 @@
 import {Component, Input} from 'angular2/core';
-import {NgForm} from 'angular2/common';
 import {StoryModel} from '../models/story.model';
 import {CATEGORIES, SUBCATEGORIES} from '../models/story.categories';
+import {StoryFieldComponent} from './storyfield.component';
 
 @Component({
-  directives: [NgForm],
+  directives: [StoryFieldComponent],
   selector: 'newstory-edit',
-  styleUrls: ['app/storyedit/storyedit.forms.css'],
+  styleUrls: ['app/storyedit/directives/edit.component.css'],
   template: `
     <form *ngIf="story && story.isLoaded">
 
-      <div [class]="fieldClasses('title')">
-        <h3><label for="title" required>Story Title</label></h3>
-        <p class="hint">Write a short, Tweetable title like a newspaper headline.
-          Make viewers want to click on your piece from the title alone.</p>
-        <textarea id="title" [(ngModel)]="story.title"></textarea>
-        <p class="error">Title {{story.invalid('title')}}</p>
-      </div>
+      <story-field [story]="story" textarea="true" name="title" label="Story Title" required>
+        <hint>Write a short, Tweetable title like a newspaper headline. Make viewers
+          want to click on your piece from the title alone.</hint>
+      </story-field>
 
-      <div [class]="fieldClasses('shortDescription')">
-        <h3><label for="teaser" required>Teaser</label></h3>
-        <p class="hint">A first impression; think of this as the single-item
-          lead of a piece.</p>
-        <textarea id="teaser" [(ngModel)]="story.shortDescription"></textarea>
-        <p class="error">Teaser {{story.invalid('shortDescription')}}</p>
-      </div>
+      <story-field [story]="story" textarea="true" name="shortDescription" label="Teaser" required>
+        <hint>A first impression; think of this as the single-item lead of a piece.</hint>
+      </story-field>
 
       <hr/>
 
-      <div class="field">
-        <h3><label required>Story Versions</label></h3>
+      <story-field label="Story Versions" required>
         <div class="uploads-box">uploads goes heres</div>
-      </div>
+      </story-field>
 
       <hr/>
 
-      <div class="field">
-        <h3><label required>Tag your Story</label></h3>
-        <p class="hint">Adding tags that are relevant to your piece helps people
-          find your work on PRX and can help you be licensed and heard.</p>
-
-        <div [class]="fieldClasses('genre', 'stack')">
-          <h4><label for="genre" required>Genre</label></h4>
-          <select id="genre" [(ngModel)]="story.genre">
-            <option *ngFor="#genre of GENRES" [value]="genre">{{genre}}</option>
-          </select>
+      <story-field [story]="story" label="Tag your Story" invalid="tags" invalidlabel="" required>
+        <hint>Adding tags that are relevant to your piece helps people find your work
+          on PRX and can help you be licensed and heard.</hint>
+        <div class="span-fields">
+          <story-field [story]="story" [select]="GENRES" name="genre" label="Genre"
+            small="true" required></story-field>
+          <story-field [story]="story" [select]="SUBGENRES" name="subGenre" label="SubGenre"
+            small="true" required></story-field>
         </div>
-
-        <div [class]="fieldClasses('subGenre', 'stack')">
-          <h4><label for="subGenre" required>SubGenre</label></h4>
-          <select id="subGenre" [(ngModel)]="story.subGenre" [disabled]="!SUBGENRES">
-            <option *ngFor="#subGenre of SUBGENRES" [value]="subGenre">{{subGenre}}</option>
-          </select>
-        </div>
-
-        <div [class]="fieldClasses('extraTags')">
-          <h4><label for="extraTags">Extra Tags</label></h4>
-          <input id="extraTags" type="text" [(ngModel)]="story.extraTags"/>
-        </div>
-
-        <p class="error" [class.show]="story.invalid('tags')">{{story.invalid('tags')}}</p>
-      </div>
+        <story-field [story]="story" textinput="true" name="extraTags"
+          label="Extra Tags" small="true"></story-field>
+      </story-field>
 
     </form>
   `
@@ -76,17 +54,6 @@ export class EditComponent {
     if (this.story && this.story.genre) {
       return SUBCATEGORIES[this.story.genre];
     }
-  }
-
-  fieldClasses(name: string, extra?: string): string {
-    let classes = ['field', extra || ''];
-    if (this.story.changed(name)) {
-      classes.push('changed');
-    }
-    if (this.story.invalid(name)) {
-      classes.push('invalid');
-    }
-    return classes.join(' ');
   }
 
 }

--- a/app/storyedit/directives/edit.component.ts
+++ b/app/storyedit/directives/edit.component.ts
@@ -1,6 +1,7 @@
 import {Component, Input} from 'angular2/core';
 import {NgForm} from 'angular2/common';
 import {StoryModel} from '../models/story.model';
+import {CATEGORIES, SUBCATEGORIES} from '../models/story.categories';
 
 @Component({
   directives: [NgForm],
@@ -14,7 +15,7 @@ import {StoryModel} from '../models/story.model';
         <p class="hint">Write a short, Tweetable title like a newspaper headline.
           Make viewers want to click on your piece from the title alone.</p>
         <textarea id="title" [(ngModel)]="story.title"></textarea>
-        <p class="error">Title {{story.invalid.title}}</p>
+        <p class="error">Title {{story.invalid('title')}}</p>
       </div>
 
       <div [class]="fieldClasses('shortDescription')">
@@ -22,7 +23,7 @@ import {StoryModel} from '../models/story.model';
         <p class="hint">A first impression; think of this as the single-item
           lead of a piece.</p>
         <textarea id="teaser" [(ngModel)]="story.shortDescription"></textarea>
-        <p class="error">Teaser {{story.invalid.shortDescription}}</p>
+        <p class="error">Teaser {{story.invalid('shortDescription')}}</p>
       </div>
 
       <hr/>
@@ -38,6 +39,27 @@ import {StoryModel} from '../models/story.model';
         <h3><label required>Tag your Story</label></h3>
         <p class="hint">Adding tags that are relevant to your piece helps people
           find your work on PRX and can help you be licensed and heard.</p>
+
+        <div [class]="fieldClasses('genre', 'stack')">
+          <h4><label for="genre" required>Genre</label></h4>
+          <select id="genre" [(ngModel)]="story.genre">
+            <option *ngFor="#genre of GENRES" [value]="genre">{{genre}}</option>
+          </select>
+        </div>
+
+        <div [class]="fieldClasses('subGenre', 'stack')">
+          <h4><label for="subGenre" required>SubGenre</label></h4>
+          <select id="subGenre" [(ngModel)]="story.subGenre" [disabled]="!SUBGENRES">
+            <option *ngFor="#subGenre of SUBGENRES" [value]="subGenre">{{subGenre}}</option>
+          </select>
+        </div>
+
+        <div [class]="fieldClasses('extraTags')">
+          <h4><label for="extraTags">Extra Tags</label></h4>
+          <input id="extraTags" type="text" [(ngModel)]="story.extraTags"/>
+        </div>
+
+        <p class="error" [class.show]="story.invalid('tags')">{{story.invalid('tags')}}</p>
       </div>
 
     </form>
@@ -46,14 +68,22 @@ import {StoryModel} from '../models/story.model';
 
 export class EditComponent {
 
-  @Input() public story: StoryModel;
+  GENRES: string[] = CATEGORIES;
 
-  fieldClasses(name: string): string {
-    let classes = ['field'];
-    if (this.story.changed[name]) {
+  @Input() story: StoryModel;
+
+  get SUBGENRES(): string[] {
+    if (this.story && this.story.genre) {
+      return SUBCATEGORIES[this.story.genre];
+    }
+  }
+
+  fieldClasses(name: string, extra?: string): string {
+    let classes = ['field', extra || ''];
+    if (this.story.changed(name)) {
       classes.push('changed');
     }
-    if (this.story.invalid[name]) {
+    if (this.story.invalid(name)) {
       classes.push('invalid');
     }
     return classes.join(' ');

--- a/app/storyedit/directives/hero.component.ts
+++ b/app/storyedit/directives/hero.component.ts
@@ -2,9 +2,11 @@ import {Component, Input} from 'angular2/core';
 import {Router} from 'angular2/router';
 import {StoryModel} from '../models/story.model';
 import {SpinnerComponent}  from '../../shared/spinner/spinner.component';
+import {TimeAgoPipe} from '../../shared/date/timeago.pipe';
 
 @Component({
   directives: [SpinnerComponent],
+  pipes: [TimeAgoPipe],
   selector: 'publish-story-hero',
   styleUrls: ['app/storyedit/directives/hero.component.css'],
   template: `
@@ -18,18 +20,18 @@ import {SpinnerComponent}  from '../../shared/spinner/spinner.component';
         <spinner *ngIf="!story.isLoaded" inverse=true></spinner>
         <div class="info" *ngIf="story.isLoaded">
           <h2>{{story.title || '(Untitled)'}}</h2>
-          <p *ngIf="story.modifiedAt">Last saved at {{story.modifiedAt | date}}</p>
+          <p *ngIf="story.updatedAt">Last saved at {{story.updatedAt | timeago}}</p>
         </div>
         <div class="actions">
           <button class="preview">Preview</button>
-          <button *ngIf="!story.id" class="create"
-            [disabled]="!story.isValid"
+          <button *ngIf="story.isNew" class="create"
+            [disabled]="story.invalid()"
             (click)="save()">Create</button>
-          <button *ngIf="story.id" class="save"
-            [disabled]="!story.isValid || !story.isChanged"
+          <button *ngIf="!story.isNew" class="save"
+            [disabled]="story.invalid() || !story.changed()"
             (click)="save()">Save</button>
-          <button *ngIf="story.id" class="publish"
-            [disabled]="!story.isValid || story.isChanged">Publish</button>
+          <button *ngIf="!story.isNew" class="publish"
+            [disabled]="story.invalid() || story.changed()">Publish</button>
         </div>
       </section>
     </div>

--- a/app/storyedit/directives/storyfield.component.css
+++ b/app/storyedit/directives/storyfield.component.css
@@ -1,9 +1,14 @@
 /**
- * Common form styling
+ * Form fields
  */
-.field {
+:host {
   width: 100%;
+}
+.field {
   margin-bottom: 40px;
+}
+.field.small {
+  margin-bottom: 20px;
 }
 h3 {
   font-size: 24px;
@@ -32,15 +37,6 @@ p.error {
   display: none;
   margin-top: 6px;
   color: #e32;
-}
-p.error.show {
-  display: block;
-}
-hr {
-  width: 100%;
-  border-top: 1px solid #aaa;
-  border-bottom: 1px solid #ccc;
-  margin: 0 0 30px;
 }
 input, textarea {
   width: 100%;
@@ -72,29 +68,15 @@ select[disabled] {
   background: #efefef;
 }
 
-@media screen and (min-width: 768px) {
-  .field > .field.stack {
-    display: inline-block;
-    width: 40%;
-  }
-}
+/**
+ * Valid/changed indicators
+ */
 .field.changed input, .field.changed textarea, .field.changed select {
   outline: 5px auto #f09b4c;
 }
 .field.changed.invalid input, .field.changed.invalid textarea, .field.changed.invalid select {
   outline: 5px auto #e32;
 }
-.field.changed.invalid p.error {
+.field.changed.invalid p.error, .field.invalid-explicit p.error {
   display: block;
-}
-
-/*.ng-dirty, .ng-dirty:focus {}
-.ng-invalid:not(.ng-pristine), .ng-invalid:focus:not(.ng-pristine) {}*/
-
-.uploads-box {
-  border: 4px solid purple;
-  height: 300px;
-  text-align: center;
-  line-height: 300px;
-  color: purple;
 }

--- a/app/storyedit/directives/storyfield.component.spec.ts
+++ b/app/storyedit/directives/storyfield.component.spec.ts
@@ -1,0 +1,139 @@
+import {it, describe, expect} from 'angular2/testing';
+import {setupComponent, buildComponent} from '../../../util/test-helper';
+import {StoryFieldComponent} from './storyfield.component';
+
+// fake container, with all @Inputs bound
+import {Component} from 'angular2/core';
+@Component({
+  directives: [StoryFieldComponent],
+  template: `
+    <story-field [story]="mockStory" [name]="name" [changed]="changed" [invalid]="invalid"
+      [textinput]="textinput" [textarea]="textarea" [select]="select" [label]="label"
+      [invalidlabel]="invalidlabel" [small]="small" [required]="required">
+      <hint *ngIf="hint">{{hint}}</hint>
+      <h1 *ngIf="nested">{{nested}}</h1>
+    </story-field>
+  `
+})
+class MiniContainer {
+  _changed: boolean = false;
+  _invalid: boolean = false;
+  mockStory: any = {
+    changed: () => { return this._changed; },
+    invalid: () => { return this._invalid; }
+  };
+}
+
+describe('StoryFieldComponent', () => {
+
+  setupComponent(MiniContainer);
+
+  it('renders a blank story field', buildComponent((fix, el, mini) => {
+    expect(el.querySelector('.field')).not.toBeNull();;
+    expect(el.querySelector('h1')).toBeNull();
+    expect(el.querySelector('h3')).toBeNull();
+    expect(el.querySelector('label')).toBeNull();
+    expect(el.querySelector('p.hint')).toHaveText('');
+  }));
+
+  it('renders a small label', buildComponent((fix, el, mini) => {
+    mini['label'] = 'small label';
+    mini['small'] = true;
+    fix.detectChanges();
+    expect(el.querySelector('h4 label')).toHaveText('small label');
+  }));
+
+  it('renders a large label', buildComponent((fix, el, mini) => {
+    mini['label'] = 'large label';
+    fix.detectChanges();
+    expect(el.querySelector('h3 label')).toHaveText('large label');
+  }));
+
+  it('renders a required label', buildComponent((fix, el, mini) => {
+    mini['label'] = 'the label';
+    fix.detectChanges();
+    expect(el.querySelector('label[required]')).toBeNull();
+    mini['required'] = true;
+    fix.detectChanges();
+    expect(el.querySelector('label[required]')).not.toBeNull();
+  }));
+
+  it('renders hint content', buildComponent((fix, el, mini) => {
+    mini['hint'] = 'the hint content';
+    fix.detectChanges();
+    expect(el.querySelector('p.hint')).toHaveText('the hint content');
+  }));
+
+  it('renders arbitrary nested content', buildComponent((fix, el, mini) => {
+    mini['nested'] = 'some nested content';
+    fix.detectChanges();
+    expect(el.querySelector('h1')).toHaveText('some nested content');
+  }));
+
+  it('can have a text field', buildComponent((fix, el, mini) => {
+    mini.mockStory.foobar = 'some value';
+    mini['name'] = 'foobar';
+    mini['textinput'] = true;
+    fix.detectChanges();
+    let field = el.querySelector('input');
+    expect(field.id).toEqual('foobar');
+    expect(field['value']).toEqual('some value');
+  }));
+
+  it('can have a text area', buildComponent((fix, el, mini) => {
+    mini.mockStory.foobar = 'some textarea value';
+    mini['name'] = 'foobar';
+    mini['textarea'] = true;
+    fix.detectChanges();
+    let field = el.querySelector('textarea');
+    expect(field.id).toEqual('foobar');
+    expect(field['value']).toEqual('some textarea value');
+  }));
+
+  it('can have a select with options', buildComponent((fix, el, mini) => {
+    mini.mockStory.foobar = 'theselected';
+    mini['name'] = 'foobar';
+    mini['select'] = ['foo', 'bar', 'theselected'];
+    fix.detectChanges();
+    let field = el.querySelector('select');
+    expect(field.id).toEqual('foobar');
+    expect(field.querySelectorAll('option').length).toEqual(3);
+  }));
+
+  it('indicates changed fields', buildComponent((fix, el, mini) => {
+    mini['name'] = 'foobar';
+    fix.detectChanges();
+    expect(el.querySelector('.field.changed')).toBeNull();
+    mini._changed = true;
+    fix.detectChanges();
+    expect(el.querySelector('.field.changed')).not.toBeNull();
+  }));
+
+  it('explicitly overrides changed fieldnames', buildComponent((fix, el, mini) => {
+    mini['changed'] = 'somethingelse';
+    fix.detectChanges();
+    expect(el.querySelector('.field.changed-explicit')).toBeNull();
+    mini._changed = true;
+    fix.detectChanges();
+    expect(el.querySelector('.field.changed-explicit')).not.toBeNull();
+  }));
+
+  it('indicates invalid fields', buildComponent((fix, el, mini) => {
+    mini['name'] = 'foobar';
+    fix.detectChanges();
+    expect(el.querySelector('.field.invalid')).toBeNull();
+    mini._invalid = true;
+    fix.detectChanges();
+    expect(el.querySelector('.field.invalid')).not.toBeNull();
+  }));
+
+  it('explicitly overrides invalid fieldnames', buildComponent((fix, el, mini) => {
+    mini['invalid'] = 'somethingelse';
+    fix.detectChanges();
+    expect(el.querySelector('.field.invalid-explicit')).toBeNull();
+    mini._invalid = true;
+    fix.detectChanges();
+    expect(el.querySelector('.field.invalid-explicit')).not.toBeNull();
+  }));
+
+});

--- a/app/storyedit/directives/storyfield.component.ts
+++ b/app/storyedit/directives/storyfield.component.ts
@@ -1,0 +1,84 @@
+import {Component, Input} from 'angular2/core';
+import {NgForm} from 'angular2/common';
+import {StoryModel} from '../models/story.model';
+
+@Component({
+  directives: [NgForm],
+  selector: 'story-field',
+  styleUrls: ['app/storyedit/directives/storyfield.component.css'],
+  template: `
+    <div [class]="fieldClasses" [class.small]="small">
+      <h3 *ngIf="label && !small">
+        <label [attr.for]="name" [attr.required]="required">{{label}}</label>
+      </h3>
+      <h4 *ngIf="label && small">
+        <label [attr.for]="name" [attr.required]="required">{{label}}</label>
+      </h4>
+
+      <p class="hint"><ng-content select="hint"></ng-content></p>
+
+      <div class="nested">
+        <ng-content></ng-content>
+      </div>
+
+      <input *ngIf="textinput" [id]="name" [(ngModel)]="story[name]" type="text"/>
+
+      <textarea *ngIf="textarea" [id]="name" [(ngModel)]="story[name]"></textarea>
+
+      <select *ngIf="select" [id]="name" [(ngModel)]="story[name]">
+        <option *ngFor="#opt of select" [value]="opt">{{opt}}</option>
+      </select>
+
+      <p *ngIf="invalidFieldName" class="error">
+        {{invalidFieldLabel}} {{story.invalid(invalidFieldName)}}
+      </p>
+    </div>
+  `
+})
+
+export class StoryFieldComponent {
+
+  @Input() story: StoryModel;
+
+  // Name of story attribute, and optional explicit changed/invalid bindings
+  @Input() name: string;
+  @Input() changed: string = null;
+  @Input() invalid: string = null;
+
+  // Form field options
+  @Input() textinput: boolean;
+  @Input() textarea: boolean;
+  @Input() select: string[];
+  @Input() label: string;
+  @Input() invalidlabel: string;
+  @Input() small: boolean;
+  @Input() required: boolean;
+
+  get changedFieldName(): string {
+    return (this.changed === undefined) ? this.name : this.changed;
+  }
+
+  get invalidFieldName(): string {
+    return (this.invalid === undefined) ? this.name : this.invalid;
+  }
+
+  get invalidFieldLabel(): string {
+    return (this.invalidlabel === undefined) ? this.label : this.invalidlabel;
+  }
+
+  get fieldClasses(): string {
+    let classes = ['field'];
+    let changed = this.changedFieldName && this.story.changed(this.changedFieldName);
+    let invalid = this.invalidFieldName && this.story.invalid(this.invalidFieldName);
+
+    // explicit changed/invalid inputs get different classes
+    if (changed) {
+      classes.push(this.name ? 'changed' : 'changed-explicit');
+    }
+    if (invalid) {
+      classes.push(this.name ? 'invalid' : 'invalid-explicit');
+    }
+    return classes.join(' ');
+  }
+
+}

--- a/app/storyedit/models/story.categories.ts
+++ b/app/storyedit/models/story.categories.ts
@@ -1,0 +1,97 @@
+/*
+ * Itunes podcast categories
+ */
+export const CATEGORIES = [
+  'Arts',
+  'Business',
+  'Comedy',
+  'Education',
+  'Games & Hobbies',
+  'Government & Organizations',
+  'Health',
+  'Kids & Family',
+  'Music',
+  'News & Politics',
+  'Religion & Spirituality',
+  'Science & Medicine',
+  'Society & Culture',
+  'Sports & Recreation',
+  'Technology',
+  'TV & Film'
+];
+
+export const SUBCATEGORIES = {
+  'Arts': [
+    'Design',
+    'Fashion & Beauty',
+    'Food',
+    'Literature',
+    'Performing Arts',
+    'Visual Arts'
+  ],
+  'Business': [
+    'Business News',
+    'Careers',
+    'Investing',
+    'Management & Marketing',
+    'Shopping'
+  ],
+  'Education': [
+    'Educational Technology',
+    'Higher Education',
+    'K-12',
+    'Language Courses',
+    'Training'
+  ],
+  'Games & Hobbies': [
+    'Automotive',
+    'Aviation',
+    'Hobbies',
+    'Other Games',
+    'Video Games'
+  ],
+  'Government & Organizations': [
+    'Local',
+    'National',
+    'Non-Profit',
+    'Regional'
+  ],
+  'Health': [
+    'Alternative Health',
+    'Fitness & Nutrition',
+    'Self-Help',
+    'Sexuality'
+  ],
+  'Religion & Spirituality': [
+    'Buddhism',
+    'Christianity',
+    'Hinduism',
+    'Islam',
+    'Judaism',
+    'Other',
+    'Spirituality'
+  ],
+  'Science & Medicine': [
+    'Medicine',
+    'Natural Sciences',
+    'Social Sciences'
+  ],
+  'Society & Culture': [
+    'History',
+    'Personal Journals',
+    'Philosophy',
+    'Places & Travel'
+  ],
+  'Sports & Recreation': [
+    'Amateur',
+    'College & High School',
+    'Outdoor',
+    'Professional'
+  ],
+  'Technology': [
+    'Gadgets',
+    'Tech News',
+    'Podcasting',
+    'Software How-To'
+  ]
+};

--- a/app/storyedit/models/story.model.spec.ts
+++ b/app/storyedit/models/story.model.spec.ts
@@ -1,0 +1,235 @@
+import {it, describe, beforeEach, expect} from 'angular2/testing';
+import {MockCmsService} from '../../shared/cms/cms.mocks';
+import {StoryModel} from './story.model';
+
+describe('StoryModel', () => {
+
+  let cms = <any> new MockCmsService();
+
+  let auth: any;
+  beforeEach(() => {
+    auth = cms.mock('prx:authorization', {}); // clears mocks
+  });
+
+  const makeStory = (data = {}) => {
+    auth.mock('prx:story', data);
+    return new StoryModel(cms, 'any-story-id');
+  };
+
+  describe('constructor', () => {
+
+    it('loads existing stories from the CMS', () => {
+      let story = makeStory({title: 'Hello World'});
+      expect(story.title).toEqual('Hello World');
+      expect(story.isLoaded).toBeTruthy();
+      expect(story.isNew).toBeFalsy();
+    });
+
+    it('looks up the default account for new stories', () => {
+      auth.mock('prx:default-account', {});
+      let story = new StoryModel(cms);
+      expect(story.title).toBeUndefined();
+      expect(story.isLoaded).toBeTruthy();
+      expect(story.isNew).toBeTruthy();
+    });
+
+  });
+
+  describe('setDoc', () => {
+
+    it('sets attributes on the story', () => {
+      let story = makeStory();
+      story.setDoc(<any> {id: 12, title: 'hello'});
+      expect(story.id).toEqual(12);
+      expect(story.title).toEqual('hello');
+    });
+
+    it('parses dates', () => {
+      let story = makeStory();
+      story.setDoc(<any> {
+        publishedAt: '2002-02-02T02:02:02.000Z',
+        updatedAt: '2004-04-04T04:04:04'
+      });
+      expect(story.publishedAt).toBeAnInstanceOf(Date);
+      expect(story.updatedAt).toBeAnInstanceOf(Date);
+      expect(story.publishedAt.getFullYear()).toEqual(2002);
+      expect(story.updatedAt.getMonth()).toEqual(3);
+    });
+
+    it('parses tags', () => {
+      let story = makeStory();
+      story.setDoc(<any> {tags: ['Foo', 'Arts', 'Bar', 'Food']});
+      expect(story.genre).toEqual('Arts');
+      expect(story.subGenre).toEqual('Food');
+      expect(story.extraTags).toEqual('Foo, Bar');
+    });
+
+    it('allows only a single genre', () => {
+      let story = makeStory();
+      story.setDoc(<any> {tags: ['Business', 'Arts', 'Education']});
+      expect(story.genre).toEqual('Business');
+      expect(story.subGenre).toBeUndefined();
+      expect(story.extraTags).toBeUndefined();
+    });
+
+    it('allows only subGenres of the parent', () => {
+      let story = makeStory();
+      story.setDoc(<any> {tags: ['Arts', 'Business News']});
+      expect(story.subGenre).toBeUndefined();
+      story.setDoc(<any> {tags: ['Business News']});
+      expect(story.subGenre).toBeUndefined();
+      story.setDoc(<any> {tags: ['Business News', 'Business']});
+      expect(story.subGenre).toEqual('Business News');
+    });
+
+  });
+
+  describe('toJSON', () => {
+
+    it('returns only saveable attributes', () => {
+      let story = makeStory({id: 1, title: '2', shortDescription: '3', tags: ['4'],
+        publishedAt: '2002-02-02T02:02:02', updatedAt: '2004-04-04T04:04:04'});
+      let json = story.toJSON();
+      expect(Object.keys(json).sort()).toEqual(['shortDescription', 'tags', 'title']);
+    });
+
+    it('combines tag fields', () => {
+      let story = makeStory();
+      story.genre = 'Hello';
+      story.subGenre = 'World';
+      story.extraTags = 'And,Some ,   More tags, Go here';
+      let json = <any> story.toJSON();
+      let tags = json.tags.sort();
+      expect(tags).toEqual(['And', 'Go here', 'Hello', 'More tags', 'Some', 'World']);
+    });
+
+  });
+
+  describe('save', () => {
+
+    it('updates existing docs with json', () => {
+      let story = makeStory({title: 'Start title'});
+      spyOn(story, 'toJSON').and.returnValue({title: 'Changed it'});
+      story.save().subscribe((wasNew) => {
+        expect(wasNew).toBeFalsy();
+        expect(story.title).toEqual('Changed it');
+      });
+      expect(story.toJSON).toHaveBeenCalled();
+    });
+
+    it('creates new docs on the default account', () => {
+      let account = auth.mock('prx:default-account', {});
+      let story = new StoryModel(cms);
+      spyOn(story, 'toJSON').and.returnValue({title: 'Created it'});
+      expect(account.MOCKS['prx:stories']).toBeUndefined();
+      story.save().subscribe((wasNew) => {
+        expect(wasNew).toBeTruthy();
+        expect(story.title).toEqual('Created it');
+      });
+      expect(story.toJSON).toHaveBeenCalled();
+      expect(account.MOCKS['prx:stories']).toBeDefined();
+    });
+
+  });
+
+  describe('destroy', () => {
+
+    it('deletes the underlying haldoc', () => {
+      let story = makeStory();
+      expect(story['_destroyed']).toBeUndefined();
+      story.destroy().subscribe((deleted) => {
+        expect(deleted).toBeTruthy();
+      });
+      expect(story.doc['_destroyed']).toEqual(true);
+    });
+
+  });
+
+  describe('invalid', () => {
+
+    const invalidate = (field: string, value: any): string => {
+      let story = makeStory();
+      story[field] = value;
+      return story.invalid(field);
+    };
+
+    it('validates title', () => {
+      expect(invalidate('title', null)).toMatch('is required');
+      expect(invalidate('title', '')).toMatch('is required');
+      expect(invalidate('title', 'a')).toMatch('is too short');
+      expect(invalidate('title', 'hello world')).toBeUndefined();
+    });
+
+    it('validates short description', () => {
+      expect(invalidate('shortDescription', null)).toMatch('is required');
+      expect(invalidate('shortDescription', '')).toMatch('is required');
+      expect(invalidate('shortDescription', 'a')).toMatch('is too short');
+      expect(invalidate('shortDescription', 'hello world')).toBeUndefined();
+    });
+
+    it('validates genre', () => {
+      expect(invalidate('genre', null)).toMatch('is required');
+      expect(invalidate('genre', '')).toMatch('is required');
+      expect(invalidate('genre', 'hello world')).toBeUndefined();
+    });
+
+    it('validates sub genre', () => {
+      expect(invalidate('subGenre', null)).toMatch('is required');
+      expect(invalidate('subGenre', '')).toMatch('is required');
+      expect(invalidate('subGenre', 'hello world')).toBeUndefined();
+    });
+
+    it('validates extra tags', () => {
+      expect(invalidate('extraTags', null)).toBeUndefined();
+      expect(invalidate('extraTags', '')).toBeUndefined();
+      expect(invalidate('extraTags', 'tag1,  tag2 , andtag4,')).toBeUndefined();
+      expect(invalidate('extraTags', 'tag1,  t2')).toMatch('must contain at least 3 char');
+    });
+
+    it('validates genre/sub/extra tags', () => {
+      let story = makeStory();
+      story.genre = 'hello world';
+      story.subGenre = '';
+      story.extraTags = 'something, e';
+      expect(story.invalid('tags')).toMatch('SubGenre is required');
+      story.subGenre = 'hello world';
+      expect(story.invalid('tags')).toMatch('Tags must contain at least');
+      story.extraTags = 'something, else';
+      expect(story.invalid('tags')).toBeUndefined();
+    });
+
+    it('validates the whole story', () => {
+      let story = makeStory({title: 'hello world', shortDescription: 'hello world'});
+      expect(story.invalid()).toBeTruthy();
+      story.genre = 'foo';
+      story.subGenre = 'bar';
+      expect(story.invalid()).toBeFalsy();
+    });
+
+  });
+
+  describe('changed', () => {
+
+    it('compares fields against their initial values', () => {
+      let story = makeStory({title: 'hello world', tags: ['foo']});
+      expect(story.changed('title')).toBeFalsy();
+      expect(story.changed('genre')).toBeFalsy();
+      expect(story.changed('extraTags')).toBeFalsy();
+      story.title = 'something else';
+      story.genre = 'world';
+      story.extraTags = 'foo';
+      expect(story.changed('title')).toBeTruthy();
+      expect(story.changed('genre')).toBeTruthy();
+      expect(story.changed('extraTags')).toBeFalsy();
+    });
+
+    it('checks the whole story for changes', () => {
+      let story = makeStory({title: 'hello world', tags: ['foo']});
+      expect(story.changed()).toBeFalsy();
+      story.subGenre = 'a';
+      expect(story.changed()).toBeTruthy();
+    });
+
+  });
+
+});

--- a/app/storyedit/models/story.model.spec.ts
+++ b/app/storyedit/models/story.model.spec.ts
@@ -11,8 +11,9 @@ describe('StoryModel', () => {
     auth = cms.mock('prx:authorization', {}); // clears mocks
   });
 
+  let storyMock: any;
   const makeStory = (data = {}) => {
-    auth.mock('prx:story', data);
+    storyMock = auth.mock('prx:story', data);
     return new StoryModel(cms, 'any-story-id');
   };
 
@@ -140,7 +141,7 @@ describe('StoryModel', () => {
       story.destroy().subscribe((deleted) => {
         expect(deleted).toBeTruthy();
       });
-      expect(story.doc['_destroyed']).toEqual(true);
+      expect(storyMock['_destroyed']).toEqual(true);
     });
 
   });

--- a/app/storyedit/models/story.model.ts
+++ b/app/storyedit/models/story.model.ts
@@ -70,8 +70,6 @@ export class StoryModel {
       return tags.find((val) => {
         return SUBCATEGORIES[genre].indexOf(val) > -1;
       });
-    } else {
-      return null;
     }
   }
 
@@ -86,7 +84,7 @@ export class StoryModel {
         }
       }
       return true;
-    }).join(', ');
+    }).join(', ') || undefined;
   }
 
   toJSON(): {} {
@@ -95,8 +93,8 @@ export class StoryModel {
     data['shortDescription'] = this.shortDescription;
     data['tags'] = [];
     if (this.extraTags) {
-      for (let tag of this.extraTags.replace(/\s*,\s*/, ',').split(',')) {
-        data['tags'].push(tag);
+      for (let tag of this.extraTags.split(',')) {
+        data['tags'].push(tag.trim());
       }
     }
     if (this.genre) {

--- a/app/storyedit/storyedit.component.ts
+++ b/app/storyedit/storyedit.component.ts
@@ -19,18 +19,18 @@ import {SellComponent}     from './directives/sell.component';
     <div class="main">
       <section>
         <div class="subnav">
-          <nav *ngIf="story.id">
+          <nav *ngIf="!story.isNew">
             <a [routerLink]="['Default']">STEP 1: Edit your story</a>
             <a [routerLink]="['Decorate']">STEP 2: Decorate your story</a>
             <a [routerLink]="['Sell']">STEP 3: Sell your story</a>
           </nav>
-          <nav *ngIf="!story.id">
+          <nav *ngIf="story.isNew">
             <a [routerLink]="['Default']">STEP 1: Create your story</a>
             <a disabled>STEP 2: Decorate your story</a>
             <a disabled>STEP 3: Sell your story</a>
           </nav>
           <div class="extras">
-            <button *ngIf="story.id" class="delete" (click)="confirmDelete()">Delete</button>
+            <button *ngIf="!story.isNew" class="delete" (click)="confirmDelete()">Delete</button>
           </div>
         </div>
         <div class="page">

--- a/app/storyedit/storyedit.forms.css
+++ b/app/storyedit/storyedit.forms.css
@@ -11,6 +11,13 @@ h3 {
   font-weight: 400;
   margin-bottom: 6px;
 }
+h4 {
+  font-size: 18px;
+  line-height: 22px;
+  font-weight: 400;
+  margin-bottom: 6px;
+  color: #343434;
+}
 label[required]::after {
   content: '*';
   color: #e32;
@@ -26,27 +33,55 @@ p.error {
   margin-top: 6px;
   color: #e32;
 }
+p.error.show {
+  display: block;
+}
 hr {
   width: 100%;
   border-top: 1px solid #aaa;
   border-bottom: 1px solid #ccc;
   margin: 0 0 30px;
 }
-textarea {
+input, textarea {
   width: 100%;
   max-width: 600px;
-  height: 100px;
   padding: 6px;
   color: #939393;
+  background: #fff;
 }
-textarea:focus {
+input:focus, textarea:focus {
   color: #000;
 }
+textarea {
+  height: 100px;
+}
+select {
+  width: 100%;
+  max-width: 250px;
+  font-size: 16px;
+  border-color: #939393;
+  color: #343434;
+  background: #fff;
+}
+select:focus {
+  color: #000;
+}
+select[disabled] {
+  border-color: #bebebe;
+  color: #bebebe;
+  background: #efefef;
+}
 
-.field.changed textarea {
+@media screen and (min-width: 768px) {
+  .field > .field.stack {
+    display: inline-block;
+    width: 40%;
+  }
+}
+.field.changed input, .field.changed textarea, .field.changed select {
   outline: 5px auto #f09b4c;
 }
-.field.changed.invalid textarea {
+.field.changed.invalid input, .field.changed.invalid textarea, .field.changed.invalid select {
   outline: 5px auto #e32;
 }
 .field.changed.invalid p.error {

--- a/config/karma.dev.js
+++ b/config/karma.dev.js
@@ -15,10 +15,9 @@ module.exports = function(config) {
 
 
     jspm: {
-      loadFiles: [
-        'app/**/*.spec.ts',
-        'util/**/*.spec.ts'
-      ],
+      loadFiles: process.env['TESTONLY'] ?
+        ['**/' + process.env['TESTONLY'] + '.spec.ts'] :
+        ['app/**/*.spec.ts', 'util/**/*.spec.ts'],
       serveFiles: [
         'app/**/*!(*.spec).ts',
         'app/**/*.css',

--- a/config/karma.dev.js
+++ b/config/karma.dev.js
@@ -84,7 +84,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['PhantomJS'],
+    browsers: ['Chrome'],
 
 
     // Continuous Integration mode

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "jasmine-core": "2.4.1",
     "jspm": "^0.16.31",
     "karma": "0.13.22",
+    "karma-chrome-launcher": "^0.2.3",
     "karma-jasmine": "0.3.8",
     "karma-jspm": "2.1.0",
     "karma-phantomjs-launcher": "1.0.0",


### PR DESCRIPTION
Init tagging on the first story-edit page.  The designs show this including:

- "Genre" (I'm using the [itunes podcast categories](https://help.apple.com/itc/podcasts_connect/#/itc9267a2f12))
- "Type" (TODO because I'm not sure what this is)
- "Free Tags"

Also added "SubGenre", for itunes subcategories.  All are being stored on the story `tags` array - I just hardcode the ones in the dropdowns.

This PR also includes some refactoring of form components.