### PR TITLE
Edit audio templates

### DIFF
--- a/src/app/series/directives/file-template.component.css
+++ b/src/app/series/directives/file-template.component.css
@@ -1,0 +1,20 @@
+/**
+ * Audio file templates
+ */
+:host {
+  display: block;
+  padding: 16px 24px 0;
+  border: 1px solid #ccc;
+  margin-bottom: -1px;
+}
+.length >>> publish-fancy-field {
+  display: inline-block;
+  width: auto;
+  margin-right: 10px;
+}
+.length >>> input {
+  max-width: 80px;
+}
+.length >>> .nested label {
+  font-size: 15px;
+}

--- a/src/app/series/directives/file-template.component.css
+++ b/src/app/series/directives/file-template.component.css
@@ -1,7 +1,7 @@
 /**
  * Audio file templates
  */
-:host {
+div {
   display: block;
   padding: 16px 24px 0;
   border: 1px solid #ccc;

--- a/src/app/series/directives/file-template.component.spec.ts
+++ b/src/app/series/directives/file-template.component.spec.ts
@@ -1,0 +1,18 @@
+import { cit, create } from '../../../testing';
+import { FileTemplateComponent } from './file-template.component';
+
+describe('FileTemplateComponent', () => {
+
+  create(FileTemplateComponent);
+
+  cit('renders undestroyed file templates', (fix, el, comp) => {
+    expect(el).not.toQuery('publish-fancy-field');
+    comp.file = {isDestroy: true};
+    fix.detectChanges();
+    expect(el).not.toQuery('publish-fancy-field');
+    comp.file = {isDestroy: false};
+    fix.detectChanges();
+    expect(el).toQuery('publish-fancy-field');
+  });
+
+});

--- a/src/app/series/directives/file-template.component.ts
+++ b/src/app/series/directives/file-template.component.ts
@@ -1,0 +1,24 @@
+import { Component, Input } from '@angular/core';
+import { AudioFileTemplateModel } from '../../shared';
+
+@Component({
+  selector: 'publish-file-template',
+  styleUrls: ['file-template.component.css'],
+  template: `
+    <publish-fancy-field textinput small required [model]="file" name="label" label="Segment {{file.position}} Label">
+    </publish-fancy-field>
+
+    <publish-fancy-field small class="length" [model]="file" label="Segment length in seconds" invalid="lengthAny">
+      <publish-fancy-field number small inline hideinvalid [model]="file" name="lengthMinimum" label="Minimum">
+      </publish-fancy-field>
+      <publish-fancy-field number small inline hideinvalid [model]="file" name="lengthMaximum" label="Maximum">
+      </publish-fancy-field>
+    </publish-fancy-field>
+  `
+})
+
+export class FileTemplateComponent {
+
+  @Input() file: AudioFileTemplateModel;
+
+}

--- a/src/app/series/directives/file-template.component.ts
+++ b/src/app/series/directives/file-template.component.ts
@@ -5,15 +5,22 @@ import { AudioFileTemplateModel } from '../../shared';
   selector: 'publish-file-template',
   styleUrls: ['file-template.component.css'],
   template: `
-    <publish-fancy-field textinput small required [model]="file" name="label" label="Segment {{file.position}} Label">
-    </publish-fancy-field>
+    <div *ngIf="file && !file.isDestroy">
 
-    <publish-fancy-field small class="length" [model]="file" label="Segment length in seconds" invalid="lengthAny">
-      <publish-fancy-field number small inline hideinvalid [model]="file" name="lengthMinimum" label="Minimum">
+      <publish-fancy-field textinput small required [model]="file" name="label" label="Segment {{file.position}} Label">
       </publish-fancy-field>
-      <publish-fancy-field number small inline hideinvalid [model]="file" name="lengthMaximum" label="Maximum">
+
+      <publish-fancy-field small class="length" [model]="file" label="Segment length in seconds" invalid="lengthAny">
+
+        <publish-fancy-field number small inline hideinvalid [model]="file" name="lengthMinimum" label="Minimum">
+        </publish-fancy-field>
+
+        <publish-fancy-field number small inline hideinvalid [model]="file" name="lengthMaximum" label="Maximum">
+        </publish-fancy-field>
+
       </publish-fancy-field>
-    </publish-fancy-field>
+
+    </div>
   `
 })
 

--- a/src/app/series/directives/series-basic.component.ts
+++ b/src/app/series/directives/series-basic.component.ts
@@ -6,15 +6,15 @@ import { SeriesModel, TabService } from '../../shared';
   styleUrls: [],
   template: `
     <form *ngIf="series">
-      <publish-fancy-field [model]="series" textarea="true" name="title" label="Series Title" required>
+      <publish-fancy-field textarea required [model]="series" name="title" label="Series Title">
         <div class="fancy-hint">A short headline to describe this series.</div>
       </publish-fancy-field>
 
-      <publish-fancy-field [model]="series" textarea="true" name="shortDescription" label="Teaser" required>
+      <publish-fancy-field textarea required [model]="series" name="shortDescription" label="Teaser">
         <div class="fancy-hint">A first impression for your series.</div>
       </publish-fancy-field>
 
-      <publish-fancy-field [model]="series" textarea="true" name="description" label="Description" required>
+      <publish-fancy-field textarea [model]="series" name="description" label="Description">
         <div class="fancy-hint">A longer version of your teaser.</div>
       </publish-fancy-field>
     </form>

--- a/src/app/series/directives/series-templates.component.css
+++ b/src/app/series/directives/series-templates.component.css
@@ -18,3 +18,13 @@
 .length >>> input {
   max-width: 80px;
 }
+.empty {
+  border: 1px solid #ccc;
+  text-align: center;
+}
+.empty h4 {
+  padding: 20px 0;
+  color: #bbb;
+  font-size: 20px;
+  font-weight: 600;
+}

--- a/src/app/series/directives/series-templates.component.css
+++ b/src/app/series/directives/series-templates.component.css
@@ -23,8 +23,23 @@
   text-align: center;
 }
 .empty h4 {
-  padding: 20px 0;
+  padding: 74px 0;
   color: #bbb;
-  font-size: 20px;
+  font-size: 18px;
   font-weight: 600;
+}
+.add-version {
+  margin-top: 6px;
+}
+.actions {
+  position: absolute;
+  top: 6px;
+  right: 0;
+}
+.actions a {
+  cursor: pointer;
+  margin-left: 6px;
+}
+.actions a:hover, .actions a:focus {
+  text-decoration: underline;
 }

--- a/src/app/series/directives/series-templates.component.css
+++ b/src/app/series/directives/series-templates.component.css
@@ -1,0 +1,20 @@
+/**
+ * Series version/file templates
+ */
+.version {
+  width: 100%;
+  border-bottom: 1px solid #ddd;
+  margin-bottom: 22px;
+}
+.version:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+}
+.length >>> publish-fancy-field {
+  display: inline-block;
+  width: auto;
+  margin-right: 10px;
+}
+.length >>> input {
+  max-width: 80px;
+}

--- a/src/app/series/directives/series-templates.component.css
+++ b/src/app/series/directives/series-templates.component.css
@@ -36,10 +36,6 @@
   top: 6px;
   right: 0;
 }
-.actions a {
-  cursor: pointer;
+.actions button {
   margin-left: 6px;
-}
-.actions a:hover, .actions a:focus {
-  text-decoration: underline;
 }

--- a/src/app/series/directives/series-templates.component.spec.ts
+++ b/src/app/series/directives/series-templates.component.spec.ts
@@ -32,7 +32,7 @@ describe('SeriesTemplatesComponent', () => {
     comp.series = {versionTemplates: [{fileTemplates: []}]};
     fix.detectChanges();
     expect(el).toQuery('[label="Version Label"]');
-    el.query(By.css('.actions a')).nativeElement.click();
+    el.query(By.css('.actions button')).nativeElement.click();
     fix.detectChanges();
     expect(el).not.toQuery('[label="Version Label"]');
   });

--- a/src/app/series/directives/series-templates.component.spec.ts
+++ b/src/app/series/directives/series-templates.component.spec.ts
@@ -1,4 +1,4 @@
-import { cit, create, provide } from '../../../testing';
+import { cit, create, provide, By } from '../../../testing';
 import { SeriesTemplatesComponent } from './series-templates.component';
 import { TabService } from '../../shared';
 
@@ -8,8 +8,85 @@ describe('SeriesTemplatesComponent', () => {
 
   provide(TabService);
 
-  cit('renders', (fix, el, comp) => {
-    expect(el).toContainText('These are some templates');
+  cit('renders a placeholder if you have no version templates', (fix, el, comp) => {
+    comp.series = {versionTemplates: []};
+    fix.detectChanges();
+    expect(el).toContainText('You have no templates');
+  });
+
+  cit('ignores deleted version templates', (fix, el, comp) => {
+    comp.series = {versionTemplates: [{isDestroy: true}]};
+    fix.detectChanges();
+    expect(el).toContainText('You have no templates');
+  });
+
+  cit('adds a new version template', (fix, el, comp) => {
+    comp.series = {versionTemplates: []};
+    fix.detectChanges();
+    el.query(By.css('.add-version')).nativeElement.click();
+    fix.detectChanges();
+    expect(el).toQuery('[label="Version Label"]');
+  });
+
+  cit('removes a version template', (fix, el, comp) => {
+    comp.series = {versionTemplates: [{fileTemplates: []}]};
+    fix.detectChanges();
+    expect(el).toQuery('[label="Version Label"]');
+    el.query(By.css('.actions a')).nativeElement.click();
+    fix.detectChanges();
+    expect(el).not.toQuery('[label="Version Label"]');
+  });
+
+  cit('adds a file template', (fix, el, comp) => {
+    let files = [];
+    comp.series = {versionTemplates: [{fileTemplates: files}]};
+    fix.detectChanges();
+    expect(el).toContainText('No segments defined');
+    el.query(By.css('[label="Audio Segments"] .icon-plus')).nativeElement.click();
+    fix.detectChanges();
+    expect(el).not.toContainText('No segments defined');
+    expect(files[0].label).toEqual('Segment A');
+  });
+
+  cit('adds a destroyed file template', (fix, el, comp) => {
+    let files = [{label: 'Foo', isDestroy: true}];
+    comp.series = {versionTemplates: [{fileTemplates: files}]};
+    fix.detectChanges();
+    expect(el).toContainText('No segments defined');
+    el.query(By.css('[label="Audio Segments"] .icon-plus')).nativeElement.click();
+    fix.detectChanges();
+    expect(el).not.toContainText('No segments defined');
+    expect(files[0].isDestroy).toEqual(false);
+  });
+
+  cit('removes a file template by destroying', (fix, el, comp) => {
+    let files = [{label: 'Foo', isDestroy: false}];
+    comp.series = {versionTemplates: [{fileTemplates: files}]};
+    fix.detectChanges();
+    el.query(By.css('[label="Audio Segments"] .icon-cancel')).nativeElement.click();
+    fix.detectChanges();
+    expect(el).toContainText('No segments defined');
+    expect(files[0].isDestroy).toEqual(true);
+  });
+
+  cit('completely removes a new file template', (fix, el, comp) => {
+    let files = [{label: 'Foo', isNew: true, unstore: () => null}];
+    comp.series = {versionTemplates: [{fileTemplates: files}]};
+    fix.detectChanges();
+    el.query(By.css('[label="Audio Segments"] .icon-cancel')).nativeElement.click();
+    fix.detectChanges();
+    expect(el).toContainText('No segments defined');
+    expect(files.length).toEqual(0);
+  });
+
+  cit('hides the remove button until there is a file', (fix, el, comp) => {
+    let files = [{label: 'Foo', isDestroy: true}];
+    comp.series = {versionTemplates: [{fileTemplates: files}]};
+    fix.detectChanges();
+    expect(el).not.toQuery('[label="Audio Segments"] .icon-cancel');
+    files[0].isDestroy = false;
+    fix.detectChanges();
+    expect(el).toQuery('[label="Audio Segments"] .icon-cancel');
   });
 
 });

--- a/src/app/series/directives/series-templates.component.ts
+++ b/src/app/series/directives/series-templates.component.ts
@@ -1,32 +1,53 @@
 import { Component, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { SeriesModel, TabService } from '../../shared';
+import {
+  SeriesModel,
+  TabService,
+  AudioVersionTemplateModel,
+  AudioFileTemplateModel
+} from '../../shared';
 
 @Component({
   styleUrls: ['series-templates.component.css'],
   template: `
     <form *ngIf="series">
 
-      <div *ngFor="let v of series.versionTemplates" class="version">
-
-        <publish-fancy-field textinput required [model]="v" name="label" label="Version Label">
-        </publish-fancy-field>
-
-        <publish-fancy-field class="length" [model]="v" label="Total length in seconds" invalid="lengthAny">
-          <publish-fancy-field number small inline hideinvalid [model]="v" name="lengthMinimum" label="Minimum">
+      <template ngFor let-v [ngForOf]="series.versionTemplates">
+        <div *ngIf="!v.isDestroy" class="version">
+          <publish-fancy-field textinput required [model]="v" name="label" label="Version Label">
+            <div class="actions">
+              <a (click)="removeVersion(v)"><i class="icon-cancel"></i>Remove Template</a>
+            </div>
           </publish-fancy-field>
-          <publish-fancy-field number small inline hideinvalid [model]="v" name="lengthMaximum" label="Maximum">
+
+          <publish-fancy-field class="length" [model]="v" label="Total length in seconds" invalid="lengthAny">
+            <publish-fancy-field number small inline hideinvalid [model]="v" name="lengthMinimum" label="Minimum">
+            </publish-fancy-field>
+            <publish-fancy-field number small inline hideinvalid [model]="v" name="lengthMaximum" label="Maximum">
+            </publish-fancy-field>
           </publish-fancy-field>
-        </publish-fancy-field>
 
-        <publish-fancy-field label="Audio Segments">
-          <publish-file-template *ngFor="let t of v.fileTemplates" [file]="t">
-          </publish-file-template>
-          <div *ngIf="!v.fileTemplates.length" class="empty">
-            <h4>No segments defined</h4>
-          </div>
-        </publish-fancy-field>
+          <publish-fancy-field label="Audio Segments">
+            <div class="actions">
+              <a *ngIf="canAddFile(v)" (click)="addFile(v)"><i class="icon-plus"></i>Add Segment</a>
+              <a *ngIf="canRemoveFile(v)" (click)="removeFile(v)"><i class="icon-cancel"></i>Remove Segment</a>
+            </div>
+            <publish-file-template *ngFor="let t of v.fileTemplates" [file]="t">
+            </publish-file-template>
+            <div *ngIf="!canRemoveFile(v)" class="empty">
+              <h4>No segments defined</h4>
+            </div>
+          </publish-fancy-field>
+        </div>
+      </template>
 
+      <div *ngIf="!hasVersions()">
+        <publish-fancy-field label="No Templates">
+          <div class="fancy-hint">You have no templates defined for your series.
+            Defining a template can help validate that your audio has the correct
+            duration and number of segments.</div>
+          <button class="add-version" (click)="addVersion()"><i class="icon-plus"></i> Create a template</button>
+        </publish-fancy-field>
       </div>
 
     </form>
@@ -44,6 +65,56 @@ export class SeriesTemplatesComponent implements OnDestroy {
 
   ngOnDestroy(): any {
     this.tabSub.unsubscribe();
+  }
+
+  hasVersions() {
+    return this.series.versionTemplates.some(f => !f.isDestroy);
+  }
+
+  addVersion() {
+    let draft = new AudioVersionTemplateModel(this.series.doc);
+    draft.set('label', 'Podcast Audio');
+    this.series.versionTemplates.push(draft);
+  }
+
+  removeVersion(version: AudioVersionTemplateModel) {
+    version.isDestroy = true;
+    if (version.isNew) {
+      this.series.versionTemplates.splice(this.series.versionTemplates.indexOf(version), 1);
+      version.unstore();
+    }
+  }
+
+  canAddFile(version: AudioVersionTemplateModel): boolean {
+    return version.fileTemplates.filter(f => !f.isDestroy).length < 10;
+  }
+
+  canRemoveFile(version: AudioVersionTemplateModel): boolean {
+    return version.fileTemplates.some(f => !f.isDestroy);
+  }
+
+  addFile(version: AudioVersionTemplateModel) {
+    let existing = version.fileTemplates.find(f => f.isDestroy);
+    if (existing) {
+      existing.isDestroy = false;
+    } else {
+      let count = version.fileTemplates.length;
+      let segLetter = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'[count % 26];
+      let draft = new AudioFileTemplateModel(version.parent, version.doc, count + 1);
+      draft.set('label', `Segment ${segLetter}`);
+      version.fileTemplates.push(draft);
+    }
+  }
+
+  removeFile(version: AudioVersionTemplateModel) {
+    let last = version.fileTemplates.filter(f => !f.isDestroy).pop();
+    if (last) {
+      last.isDestroy = true;
+      if (last.isNew) {
+        version.fileTemplates.splice(version.fileTemplates.indexOf(last), 1);
+        last.unstore();
+      }
+    }
   }
 
 }

--- a/src/app/series/directives/series-templates.component.ts
+++ b/src/app/series/directives/series-templates.component.ts
@@ -9,21 +9,22 @@ import { SeriesModel, TabService } from '../../shared';
 
       <div *ngFor="let v of series.versionTemplates" class="version">
 
-        <publish-fancy-field [model]="v" textinput=true name="label" label="Version Label" required>
+        <publish-fancy-field textinput required [model]="v" name="label" label="Version Label">
         </publish-fancy-field>
 
-        <publish-fancy-field [model]="v" label="Total Length" class="length" invalid="lengthAny">
-          <div class="fancy-hint">The total length of all audio in this version, in seconds.</div>
-          <publish-fancy-field [model]="v" name="lengthMinimum" label="Minimum" number=true small=true inline=true>
+        <publish-fancy-field class="length" [model]="v" label="Total length in seconds" invalid="lengthAny">
+          <publish-fancy-field number small inline hideinvalid [model]="v" name="lengthMinimum" label="Minimum">
           </publish-fancy-field>
-          <publish-fancy-field [model]="v" name="lengthMaximum" label="Maximum" number=true small=true inline=true>
+          <publish-fancy-field number small inline hideinvalid [model]="v" name="lengthMaximum" label="Maximum">
           </publish-fancy-field>
         </publish-fancy-field>
 
-        <publish-fancy-field [model]="v" label="Audio Segments">
-
-          <b>No Segments</b>
-
+        <publish-fancy-field label="Audio Segments">
+          <publish-file-template *ngFor="let t of v.fileTemplates" [file]="t">
+          </publish-file-template>
+          <div *ngIf="!v.fileTemplates.length" class="empty">
+            <h4>No segments defined</h4>
+          </div>
         </publish-fancy-field>
 
       </div>

--- a/src/app/series/directives/series-templates.component.ts
+++ b/src/app/series/directives/series-templates.component.ts
@@ -16,7 +16,7 @@ import {
         <div *ngIf="!v.isDestroy" class="version">
           <publish-fancy-field textinput required [model]="v" name="label" label="Version Label">
             <div class="actions">
-              <a (click)="removeVersion(v)"><i class="icon-cancel"></i>Remove Template</a>
+              <button class="btn-link" (click)="removeVersion(v)"><i class="icon-cancel"></i>Remove Template</button>
             </div>
           </publish-fancy-field>
 
@@ -29,8 +29,8 @@ import {
 
           <publish-fancy-field label="Audio Segments">
             <div class="actions">
-              <a *ngIf="canAddFile(v)" (click)="addFile(v)"><i class="icon-plus"></i>Add Segment</a>
-              <a *ngIf="canRemoveFile(v)" (click)="removeFile(v)"><i class="icon-cancel"></i>Remove Segment</a>
+              <button class="btn-link" *ngIf="canAddFile(v)" (click)="addFile(v)"><i class="icon-plus"></i>Add Segment</button>
+              <button class="btn-link" *ngIf="canRemoveFile(v)" (click)="removeFile(v)"><i class="icon-cancel"></i>Remove Segment</button>
             </div>
             <publish-file-template *ngFor="let t of v.fileTemplates" [file]="t">
             </publish-file-template>

--- a/src/app/series/directives/series-templates.component.ts
+++ b/src/app/series/directives/series-templates.component.ts
@@ -3,9 +3,32 @@ import { Subscription } from 'rxjs';
 import { SeriesModel, TabService } from '../../shared';
 
 @Component({
-  styleUrls: [],
+  styleUrls: ['series-templates.component.css'],
   template: `
-    <h1>These are some templates</h1>
+    <form *ngIf="series">
+
+      <div *ngFor="let v of series.versionTemplates" class="version">
+
+        <publish-fancy-field [model]="v" textinput=true name="label" label="Version Label" required>
+        </publish-fancy-field>
+
+        <publish-fancy-field [model]="v" label="Total Length" class="length" invalid="lengthAny">
+          <div class="fancy-hint">The total length of all audio in this version, in seconds.</div>
+          <publish-fancy-field [model]="v" name="lengthMinimum" label="Minimum" number=true small=true inline=true>
+          </publish-fancy-field>
+          <publish-fancy-field [model]="v" name="lengthMaximum" label="Maximum" number=true small=true inline=true>
+          </publish-fancy-field>
+        </publish-fancy-field>
+
+        <publish-fancy-field [model]="v" label="Audio Segments">
+
+          <b>No Segments</b>
+
+        </publish-fancy-field>
+
+      </div>
+
+    </form>
   `
 })
 

--- a/src/app/series/series.routing.ts
+++ b/src/app/series/series.routing.ts
@@ -7,6 +7,7 @@ import { SeriesBasicComponent } from './directives/series-basic.component';
 import { SeriesImageComponent } from './directives/series-image.component';
 import { SeriesTemplatesComponent } from './directives/series-templates.component';
 import { SeriesAdvancedComponent } from './directives/series-advanced.component';
+import { FileTemplateComponent } from './directives/file-template.component';
 
 const seriesChildRoutes = [
   { path: '',          component: SeriesBasicComponent },
@@ -35,7 +36,8 @@ export const seriesComponents: any[] = [
   SeriesBasicComponent,
   SeriesImageComponent,
   SeriesTemplatesComponent,
-  SeriesAdvancedComponent
+  SeriesAdvancedComponent,
+  FileTemplateComponent
 ];
 
 export const seriesProviders: any[] = [];

--- a/src/app/shared/form/fancy-field.component.css
+++ b/src/app/shared/form/fancy-field.component.css
@@ -2,7 +2,9 @@
  * Form fields
  */
 :host {
+  display: block;
   width: 100%;
+  position: relative;
 }
 .field {
   margin-bottom: 30px;

--- a/src/app/shared/form/fancy-field.component.css
+++ b/src/app/shared/form/fancy-field.component.css
@@ -10,6 +10,12 @@
 .field.small {
   margin-bottom: 20px;
 }
+.field.inline {
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+  margin-bottom: 0;
+}
 h3 {
   font-size: 24px;
   line-height: 30px;
@@ -22,6 +28,10 @@ h4 {
   font-weight: 400;
   margin-bottom: 6px;
   color: #343434;
+}
+.inline h4 {
+  margin-top: 6px;
+  margin-right: 12px;
 }
 label[required]::after {
   content: '*';

--- a/src/app/shared/form/fancy-field.component.css
+++ b/src/app/shared/form/fancy-field.component.css
@@ -15,6 +15,7 @@
   display: -webkit-flex;
   display: flex;
   margin-bottom: 0;
+  margin-top: 3px;
 }
 h3 {
   font-size: 24px;

--- a/src/app/shared/form/fancy-field.component.html
+++ b/src/app/shared/form/fancy-field.component.html
@@ -1,4 +1,4 @@
-<div [class]="fieldClasses" [class.small]="small">
+<div [class]="fieldClasses">
   <h3 *ngIf="label && !small">
     <label [attr.for]="name" [attr.required]="required">{{label}}</label>
   </h3>
@@ -14,6 +14,8 @@
 
   <template [ngIf]="model">
     <input *ngIf="textinput" [id]="name" type="text" [disabled]="!model"
+      [ngModel]="model[name]" (ngModelChange)="onChange($event)"/>
+    <input *ngIf="number" [id]="name" type="number" [disabled]="!model"
       [ngModel]="model[name]" (ngModelChange)="onChange($event)"/>
     <textarea *ngIf="textarea" [id]="name" [disabled]="!model"
       [(ngModel)]="model[name]" (ngModelChange)="onChange($event)"></textarea>

--- a/src/app/shared/form/fancy-field.component.html
+++ b/src/app/shared/form/fancy-field.component.html
@@ -13,23 +13,23 @@
   </div>
 
   <template [ngIf]="model">
-    <input *ngIf="textinput" [id]="name" type="text" [disabled]="!model"
+    <input *ngIf="type == 'textinput'" [id]="name" type="text" [disabled]="!model"
       [ngModel]="model[name]" (ngModelChange)="onChange($event)"/>
-    <input *ngIf="number" [id]="name" type="number" [disabled]="!model"
+    <input *ngIf="type == 'number'" [id]="name" type="number" [disabled]="!model"
       [ngModel]="model[name]" (ngModelChange)="onChange($event)"/>
-    <textarea *ngIf="textarea" [id]="name" [disabled]="!model"
+    <textarea *ngIf="type == 'textarea'" [id]="name" [disabled]="!model"
       [(ngModel)]="model[name]" (ngModelChange)="onChange($event)"></textarea>
-    <select *ngIf="select" [id]="name" [disabled]="!model"
+    <select *ngIf="type == 'select'" [id]="name" [disabled]="!model"
       [(ngModel)]="model[name]" (ngModelChange)="onChange($event)">
       <option *ngFor="let opt of select" [value]="opt">{{opt}}</option>
     </select>
   </template>
 
   <template [ngIf]="!model">
-    <input *ngIf="textinput" [id]="name" type="text" disabled=true/>
-    <textarea *ngIf="textarea" [id]="name" disabled=true></textarea>
-    <select *ngIf="select" [id]="name" disabled=true></select>
+    <input *ngIf="type == 'textinput'" [id]="name" type="text" disabled=true/>
+    <textarea *ngIf="type == 'textarea'" [id]="name" disabled=true></textarea>
+    <select *ngIf="type == 'select'" [id]="name" disabled=true></select>
   </template>
 
-  <p *ngIf="formattedInvalid && !small" class="error">{{formattedInvalid | capitalize}}</p>
+  <p *ngIf="formattedInvalid" class="error">{{formattedInvalid | capitalize}}</p>
 </div>

--- a/src/app/shared/form/fancy-field.component.spec.ts
+++ b/src/app/shared/form/fancy-field.component.spec.ts
@@ -6,8 +6,8 @@ describe('FancyFieldComponent', () => {
   contain(FancyFieldComponent, {
     template: `
       <publish-fancy-field [model]="model" [name]="name" [changed]="changed" [invalid]="invalid"
-        [textinput]="textinput" [textarea]="textarea" [select]="select" [label]="label"
-        [invalidlabel]="invalidlabel" [small]="small" [required]="required">
+        [textinput]="textinput" [number]="number" [textarea]="textarea" [select]="select"
+        [label]="label" [invalidlabel]="invalidlabel" [small]="small" [required]="required">
         <div class="fancy-hint" *ngIf="hint">{{hint}}</div>
         <h1 *ngIf="nested">{{nested}}</h1>
       </publish-fancy-field>
@@ -65,6 +65,15 @@ describe('FancyFieldComponent', () => {
     fix.detectChanges();
     expect(el).toQueryAttr('input', 'id', 'foobar');
     expect(el).toQueryAttr('input', 'value', 'some value');
+  });
+
+  cit('can have a number field', (fix, el, comp) => {
+    comp.model = {foobar: 'some value', changed: () => false, invalid: () => false};
+    comp.name = 'foobar';
+    comp.number = true;
+    fix.detectChanges();
+    expect(el).toQueryAttr('input', 'type', 'number');
+    expect(el).not.toQueryAttr('input', 'type', 'text');
   });
 
   cit('can have a text area', (fix, el, comp) => {

--- a/src/app/shared/form/fancy-field.component.ts
+++ b/src/app/shared/form/fancy-field.component.ts
@@ -15,17 +15,36 @@ export class FancyFieldComponent {
   @Input() name: string;
   @Input() changed: string;
   @Input() invalid: string;
-
-  // Form field options
-  @Input() textinput: boolean;
-  @Input() number: boolean;
-  @Input() textarea: boolean;
-  @Input() select: string[];
   @Input() label: string;
   @Input() invalidlabel: string;
-  @Input() small: boolean;
-  @Input() inline: boolean;
-  @Input() required: boolean;
+  @Input() hideinvalid: boolean;
+
+  // Form field types (intercepted with defaults)
+  type: string;
+  _select: string[];
+  @Input()
+  set textinput(any: any) { this.type = 'textinput'; }
+  @Input()
+  set number(any: any) { this.type = 'number'; }
+  @Input()
+  set textarea(any: any) { this.type = 'textarea'; }
+  @Input()
+  set select(opts: string[]) { this.type = 'select'; this._select = opts || []; }
+  get select() { return this._select; }
+
+  // Field attributes
+  _small = false;
+  _inline = false;
+  _required = null;
+  @Input()
+  set small(small: boolean) { this._small = !(small === false); }
+  get small() { return this._small; }
+  @Input()
+  set inline(inline: boolean) { this._inline = !(inline === false); }
+  get inline() { return this._inline; }
+  @Input()
+  set required(required: boolean) { this._required = (required === false) ? null : true; }
+  get required() { return this._required; }
 
   get changedFieldName(): string {
     return (this.changed === undefined) ? this.name : this.changed;
@@ -40,7 +59,7 @@ export class FancyFieldComponent {
   }
 
   get formattedInvalid(): string {
-    if (this.invalidFieldName && this.model) {
+    if (this.invalidFieldName && this.model && this.hideinvalid === undefined) {
       let msg = this.model.invalid(this.invalidFieldName);
       if (msg) {
         if (this.invalidFieldLabel) {

--- a/src/app/shared/form/fancy-field.component.ts
+++ b/src/app/shared/form/fancy-field.component.ts
@@ -1,6 +1,8 @@
 import { Component, Input } from '@angular/core';
 import { BaseModel } from '../model/base.model';
 
+const isset = (val: any): boolean => val !== false && val !== undefined;
+
 @Component({
   selector: 'publish-fancy-field',
   styleUrls: ['fancy-field.component.css'],
@@ -37,13 +39,13 @@ export class FancyFieldComponent {
   _inline = false;
   _required = null;
   @Input()
-  set small(small: boolean) { this._small = !(small === false); }
+  set small(small: boolean) { this._small = isset(small); }
   get small() { return this._small; }
   @Input()
-  set inline(inline: boolean) { this._inline = !(inline === false); }
+  set inline(inline: boolean) { this._inline = isset(inline); }
   get inline() { return this._inline; }
   @Input()
-  set required(required: boolean) { this._required = (required === false) ? null : true; }
+  set required(required: boolean) { this._required = isset(required) ? true : null; }
   get required() { return this._required; }
 
   get changedFieldName(): string {

--- a/src/app/shared/form/fancy-field.component.ts
+++ b/src/app/shared/form/fancy-field.component.ts
@@ -18,11 +18,13 @@ export class FancyFieldComponent {
 
   // Form field options
   @Input() textinput: boolean;
+  @Input() number: boolean;
   @Input() textarea: boolean;
   @Input() select: string[];
   @Input() label: string;
   @Input() invalidlabel: string;
   @Input() small: boolean;
+  @Input() inline: boolean;
   @Input() required: boolean;
 
   get changedFieldName(): string {
@@ -50,12 +52,14 @@ export class FancyFieldComponent {
   }
 
   get fieldClasses(): string {
-    if (!this.model) { return 'field'; }
     let classes = ['field'];
-    let changed = this.changedFieldName && this.model.changed(this.changedFieldName);
-    let invalid = this.invalidFieldName && this.model.invalid(this.invalidFieldName);
+    if (this.small) { classes.push('small'); }
+    if (this.inline) { classes.push('inline'); }
+    if (!this.model) { return classes.join(' '); }
 
     // explicit changed/invalid inputs get different classes
+    let changed = this.changedFieldName && this.model.changed(this.changedFieldName);
+    let invalid = this.invalidFieldName && this.model.invalid(this.invalidFieldName);
     if (changed) {
       classes.push(this.name ? 'changed' : 'changed-explicit');
     }

--- a/src/app/shared/model/audio-file-template.model.ts
+++ b/src/app/shared/model/audio-file-template.model.ts
@@ -1,0 +1,58 @@
+import { Observable} from 'rxjs';
+import { HalDoc } from '../../core';
+import { BaseModel } from './base.model';
+import { REQUIRED, LENGTH } from './invalid';
+
+export class AudioFileTemplateModel extends BaseModel {
+
+  public id: number;
+  public position: number;
+  public label: string;
+  public lengthMinimum: number;
+  public lengthMaximum: number;
+
+  SETABLE = ['position', 'label', 'lengthMinimum', 'lengthMaximum'];
+
+  VALIDATORS = {
+    label: [REQUIRED(), LENGTH(3)]
+  };
+
+  constructor(versionTemplate: HalDoc, fileTemplate?: HalDoc, loadRelated = true) {
+    super();
+    this.init(versionTemplate, fileTemplate, loadRelated);
+  }
+
+  key() {
+    if (this.doc) {
+      return `prx.audio-file-template.${this.doc.id}`;
+    } else {
+      return `prx.audio-file-template.new.${this.parent.id}`;
+    }
+  }
+
+  related() {
+    return {};
+  }
+
+  decode() {
+    this.id = this.doc['id'];
+    this.position = this.doc['position'];
+    this.label = this.doc['label'] || '';
+    this.lengthMinimum = this.doc['lengthMinimum'] || '';
+    this.lengthMaximum = this.doc['lengthMaximum'] || '';
+  }
+
+  encode(): {} {
+    let data = <any> {};
+    data.position = this.position;
+    data.label = this.label;
+    data.lengthMinimum = this.lengthMinimum;
+    data.lengthMaximum = this.lengthMaximum;
+    return data;
+  }
+
+  saveNew(data: {}): Observable<HalDoc> {
+    return this.parent.create('prx:audio-file-templates', {}, data);
+  }
+
+}

--- a/src/app/shared/model/audio-file-template.model.ts
+++ b/src/app/shared/model/audio-file-template.model.ts
@@ -6,10 +6,12 @@ import { REQUIRED, LENGTH, FILE_LENGTH } from './invalid';
 export class AudioFileTemplateModel extends BaseModel {
 
   public id: number;
-  public position: number;
-  public label: string;
-  public lengthMinimum: number;
-  public lengthMaximum: number;
+  public position: number = null;
+  public label: string = null;
+  public lengthMinimum: number = null;
+  public lengthMaximum: number = null;
+
+  private series: HalDoc;
 
   SETABLE = ['position', 'label', 'lengthMinimum', 'lengthMaximum'];
 
@@ -19,16 +21,26 @@ export class AudioFileTemplateModel extends BaseModel {
     lengthMaximum: [FILE_LENGTH(this)]
   };
 
-  constructor(versionTemplate: HalDoc, fileTemplate?: HalDoc, loadRelated = true) {
+  constructor(series: HalDoc, versionTemplate?: HalDoc, fileOrPosition?: HalDoc | number) {
     super();
-    this.init(versionTemplate, fileTemplate, loadRelated);
+    this.series = series;
+    if (typeof(fileOrPosition) === 'number') {
+      this.position = fileOrPosition;
+      this.init(versionTemplate);
+    } else {
+      this.init(versionTemplate, fileOrPosition);
+    }
   }
 
   key() {
     if (this.doc) {
       return `prx.audio-file-template.${this.doc.id}`;
-    } else {
-      return `prx.audio-file-template.new.${this.parent.id}`;
+    } else if (this.parent && this.position) {
+      return `prx.audio-file-template.${this.parent.id}.${this.position}`;
+    } else if (this.series && this.position) {
+      return `prx.audio-file-template.series.${this.series.id}.${this.position}`;
+    } else if (this.position) {
+      return `prx.audio-file-template.series.new.${this.position}`;
     }
   }
 
@@ -38,7 +50,7 @@ export class AudioFileTemplateModel extends BaseModel {
 
   decode() {
     this.id = this.doc['id'];
-    this.position = this.doc['position'];
+    this.position = this.doc['position'] || null;
     this.label = this.doc['label'] || '';
     this.lengthMinimum = this.doc['lengthMinimum'] || null;
     this.lengthMaximum = this.doc['lengthMaximum'] || null;

--- a/src/app/shared/model/audio-file-template.model.ts
+++ b/src/app/shared/model/audio-file-template.model.ts
@@ -1,7 +1,7 @@
 import { Observable} from 'rxjs';
 import { HalDoc } from '../../core';
 import { BaseModel } from './base.model';
-import { REQUIRED, LENGTH } from './invalid';
+import { REQUIRED, LENGTH, FILE_LENGTH } from './invalid';
 
 export class AudioFileTemplateModel extends BaseModel {
 
@@ -14,7 +14,9 @@ export class AudioFileTemplateModel extends BaseModel {
   SETABLE = ['position', 'label', 'lengthMinimum', 'lengthMaximum'];
 
   VALIDATORS = {
-    label: [REQUIRED(), LENGTH(3)]
+    label: [REQUIRED(), LENGTH(3)],
+    lengthMinimum: [FILE_LENGTH(this)],
+    lengthMaximum: [FILE_LENGTH(this)]
   };
 
   constructor(versionTemplate: HalDoc, fileTemplate?: HalDoc, loadRelated = true) {
@@ -38,21 +40,29 @@ export class AudioFileTemplateModel extends BaseModel {
     this.id = this.doc['id'];
     this.position = this.doc['position'];
     this.label = this.doc['label'] || '';
-    this.lengthMinimum = this.doc['lengthMinimum'] || '';
-    this.lengthMaximum = this.doc['lengthMaximum'] || '';
+    this.lengthMinimum = this.doc['lengthMinimum'] || null;
+    this.lengthMaximum = this.doc['lengthMaximum'] || null;
   }
 
   encode(): {} {
     let data = <any> {};
     data.position = this.position;
     data.label = this.label;
-    data.lengthMinimum = this.lengthMinimum;
-    data.lengthMaximum = this.lengthMaximum;
+    data.lengthMinimum = this.lengthMinimum || 0;
+    data.lengthMaximum = this.lengthMaximum || 0;
     return data;
   }
 
   saveNew(data: {}): Observable<HalDoc> {
     return this.parent.create('prx:audio-file-templates', {}, data);
+  }
+
+  invalid(field?: string | string[]): string {
+    if (field === 'lengthAny') {
+      return this.invalid('lengthMinimum') || this.invalid('lengthMaximum');
+    } else {
+      return super.invalid(field);
+    }
   }
 
 }

--- a/src/app/shared/model/audio-version-template.model.ts
+++ b/src/app/shared/model/audio-version-template.model.ts
@@ -1,7 +1,7 @@
 import { Observable} from 'rxjs';
 import { HalDoc } from '../../core';
 import { BaseModel } from './base.model';
-import { REQUIRED, LENGTH } from './invalid';
+import { REQUIRED, LENGTH, VERSION_LENGTH } from './invalid';
 import { AudioFileTemplateModel } from './audio-file-template.model';
 
 export class AudioVersionTemplateModel extends BaseModel {
@@ -15,13 +15,13 @@ export class AudioVersionTemplateModel extends BaseModel {
   SETABLE = ['label', 'lengthMinimum', 'lengthMaximum'];
 
   VALIDATORS = {
-    label: [REQUIRED(), LENGTH(3)]
+    label: [REQUIRED(), LENGTH(3)],
+    lengthMinimum: [VERSION_LENGTH(this)],
+    lengthMaximum: [VERSION_LENGTH(this)]
   };
 
   constructor(series: HalDoc, versionTemplate?: HalDoc, loadRelated = true) {
     super();
-    this.VALIDATORS['lengthMinimum'] = [(k: string, v: any) => this.validateMinimum(v)];
-    this.VALIDATORS['lengthMaximum'] = [(k: string, v: any) => this.validateMaximum(v)];
     this.init(series, versionTemplate, loadRelated);
   }
 
@@ -62,40 +62,6 @@ export class AudioVersionTemplateModel extends BaseModel {
 
   saveNew(data: {}): Observable<HalDoc> {
     return this.parent.create('prx:audio-version-templates', {}, data);
-  }
-
-  validateMinimum(value: any, checkMax = true): string {
-    if (checkMax) {
-      this.invalidFields['lengthMaximum'] = this.validateMaximum(this.lengthMaximum, false);
-    }
-    if (this.lengthMaximum === null && value === null) {
-      return null; // allow unset
-    } else if (value === null) {
-      return 'Must set a minimum';
-    } else if (isNaN(parseInt(value, 10))) {
-      return 'Minimum is not a number';
-    } else if (value < 1) {
-      return 'Minimum must be greater than 0';
-    } else if (value >= this.lengthMaximum) {
-      return 'Minimum must be less than maximum';
-    }
-  }
-
-  validateMaximum(value: any, checkMin = true): string {
-    if (checkMin) {
-      this.invalidFields['lengthMinimum'] = this.validateMinimum(this.lengthMinimum, false);
-    }
-    if (this.lengthMinimum === null && value === null) {
-      return null; // allow unset
-    } else if (value === null) {
-      return 'Must set a maximum';
-    } else if (isNaN(parseInt(value, 10))) {
-      return 'Maximum is not a number';
-    } else if (value < 1) {
-      return 'Maximum must be greater than 0';
-    } else if (value <= this.lengthMinimum) {
-      return 'Maximum must be greater than minimum';
-    }
   }
 
   invalid(field?: string | string[]): string {

--- a/src/app/shared/model/audio-version-template.model.ts
+++ b/src/app/shared/model/audio-version-template.model.ts
@@ -1,0 +1,109 @@
+import { Observable} from 'rxjs';
+import { HalDoc } from '../../core';
+import { BaseModel } from './base.model';
+import { REQUIRED, LENGTH } from './invalid';
+import { AudioFileTemplateModel } from './audio-file-template.model';
+
+export class AudioVersionTemplateModel extends BaseModel {
+
+  public id: number;
+  public label: string;
+  public lengthMinimum: number;
+  public lengthMaximum: number;
+  public fileTemplates: AudioFileTemplateModel[];
+
+  SETABLE = ['label', 'lengthMinimum', 'lengthMaximum'];
+
+  VALIDATORS = {
+    label: [REQUIRED(), LENGTH(3)]
+  };
+
+  constructor(series: HalDoc, versionTemplate?: HalDoc, loadRelated = true) {
+    super();
+    this.VALIDATORS['lengthMinimum'] = [(k: string, v: any) => this.validateMinimum(v)];
+    this.VALIDATORS['lengthMaximum'] = [(k: string, v: any) => this.validateMaximum(v)];
+    this.init(series, versionTemplate, loadRelated);
+  }
+
+  key() {
+    if (this.doc) {
+      return `prx.audio-version-template.${this.doc.id}`;
+    } else {
+      return `prx.audio-version-template.new.${this.parent.id}`;
+    }
+  }
+
+  related() {
+    let files = Observable.of([]);
+    if (this.doc) {
+      files = this.doc.followList('prx:audio-file-templates').map(ftdocs => {
+        return ftdocs.map(ft => new AudioFileTemplateModel(this.doc, ft));
+      });
+    }
+    return {
+      fileTemplates: files
+    };
+  }
+
+  decode() {
+    this.id = this.doc['id'];
+    this.label = this.doc['label'] || '';
+    this.lengthMinimum = this.doc['lengthMinimum'] || null;
+    this.lengthMaximum = this.doc['lengthMaximum'] || null;
+  }
+
+  encode(): {} {
+    let data = <any> {};
+    data.label = this.label;
+    data.lengthMinimum = this.lengthMinimum || 0;
+    data.lengthMaximum = this.lengthMaximum || 0;
+    return data;
+  }
+
+  saveNew(data: {}): Observable<HalDoc> {
+    return this.parent.create('prx:audio-version-templates', {}, data);
+  }
+
+  validateMinimum(value: any, checkMax = true): string {
+    if (checkMax) {
+      this.invalidFields['lengthMaximum'] = this.validateMaximum(this.lengthMaximum, false);
+    }
+    if (this.lengthMaximum === null && value === null) {
+      return null; // allow unset
+    } else if (value === null) {
+      return 'Must set a minimum';
+    } else if (isNaN(parseInt(value, 10))) {
+      return 'Minimum is not a number';
+    } else if (value < 1) {
+      return 'Minimum must be greater than 0';
+    } else if (value >= this.lengthMaximum) {
+      return 'Minimum must be less than maximum';
+    }
+  }
+
+  validateMaximum(value: any, checkMin = true): string {
+    if (checkMin) {
+      this.invalidFields['lengthMinimum'] = this.validateMinimum(this.lengthMinimum, false);
+    }
+    if (this.lengthMinimum === null && value === null) {
+      return null; // allow unset
+    } else if (value === null) {
+      return 'Must set a maximum';
+    } else if (isNaN(parseInt(value, 10))) {
+      return 'Maximum is not a number';
+    } else if (value < 1) {
+      return 'Maximum must be greater than 0';
+    } else if (value <= this.lengthMinimum) {
+      return 'Maximum must be greater than minimum';
+    }
+  }
+
+  invalid(field?: string | string[]): string {
+    if (field === 'lengthAny') {
+      return this.invalid('lengthMinimum') || this.invalid('lengthMaximum');
+    } else {
+      return super.invalid(field);
+    }
+  }
+
+}

--- a/src/app/shared/model/audio-version-template.model.ts
+++ b/src/app/shared/model/audio-version-template.model.ts
@@ -7,9 +7,9 @@ import { AudioFileTemplateModel } from './audio-file-template.model';
 export class AudioVersionTemplateModel extends BaseModel {
 
   public id: number;
-  public label: string;
-  public lengthMinimum: number;
-  public lengthMaximum: number;
+  public label: string = null;
+  public lengthMinimum: number = null;
+  public lengthMaximum: number = null;
   public fileTemplates: AudioFileTemplateModel[];
 
   SETABLE = ['label', 'lengthMinimum', 'lengthMaximum'];
@@ -20,7 +20,7 @@ export class AudioVersionTemplateModel extends BaseModel {
     lengthMaximum: [VERSION_LENGTH(this)]
   };
 
-  constructor(series: HalDoc, versionTemplate?: HalDoc, loadRelated = true) {
+  constructor(series?: HalDoc, versionTemplate?: HalDoc, loadRelated = true) {
     super();
     this.init(series, versionTemplate, loadRelated);
   }
@@ -28,17 +28,23 @@ export class AudioVersionTemplateModel extends BaseModel {
   key() {
     if (this.doc) {
       return `prx.audio-version-template.${this.doc.id}`;
-    } else {
+    } else if (this.parent) {
       return `prx.audio-version-template.new.${this.parent.id}`;
+    } else {
+      return 'prx.audio-version-template.new.new';
     }
   }
 
   related() {
-    let files = Observable.of([]);
+    let files: Observable<AudioFileTemplateModel[]>;
     if (this.doc) {
       files = this.doc.followList('prx:audio-file-templates').map(ftdocs => {
-        return ftdocs.map(ft => new AudioFileTemplateModel(this.doc, ft));
+        let saved = ftdocs.map(ft => new AudioFileTemplateModel(this.parent, this.doc, ft));
+        let unsaved = this.findUnsavedFiles(saved.length + 1);
+        return saved.concat(unsaved);
       });
+    } else {
+      files = Observable.of(this.findUnsavedFiles(1));
     }
     return {
       fileTemplates: files
@@ -69,6 +75,16 @@ export class AudioVersionTemplateModel extends BaseModel {
       return this.invalid('lengthMinimum') || this.invalid('lengthMaximum');
     } else {
       return super.invalid(field);
+    }
+  }
+
+  findUnsavedFiles(position, found: AudioFileTemplateModel[] = []) {
+    let file = new AudioFileTemplateModel(this.parent, this.doc, position);
+    if (file.isStored() && !file.isDestroy) {
+      found.push(file);
+      return this.findUnsavedFiles(position + 1, found);
+    } else {
+      return found;
     }
   }
 

--- a/src/app/shared/model/base.model.ts
+++ b/src/app/shared/model/base.model.ts
@@ -39,10 +39,6 @@ export abstract class BaseModel {
     this.isNew = self ? false : true;
     if (self) {
       this.decode();
-    } else if (this.original) {
-      for (let key of Object.keys(this.original)) {
-        this[key] = this.original[key];
-      }
     }
 
     // get remote values, before overlaying localstorage
@@ -146,6 +142,11 @@ export abstract class BaseModel {
     this.unstore();
     this.lastStored = null;
     this.isDestroy = false;
+    if (!this.doc && this.original) {
+     for (let key of Object.keys(this.original)) {
+       this[key] = this.original[key];
+     }
+   }
     this.init(this.parent, this.doc, false);
     this.getRelated().forEach(model => {
       if (model.discard() !== false && model.isNew) {

--- a/src/app/shared/model/base.model.ts
+++ b/src/app/shared/model/base.model.ts
@@ -122,7 +122,12 @@ export abstract class BaseModel {
       } else {
         model.parent = this.doc;
       }
-      return model.save();
+      return model.save().map(saved => {
+        if (saved && model.isDestroy) {
+          this.removeRelated(model);
+        }
+        return saved;
+      });
     });
     return Observable.from(relatedSavers).concatAll().toArray();
   }

--- a/src/app/shared/model/base.model.ts
+++ b/src/app/shared/model/base.model.ts
@@ -39,6 +39,10 @@ export abstract class BaseModel {
     this.isNew = self ? false : true;
     if (self) {
       this.decode();
+    } else if (this.original) {
+      for (let key of Object.keys(this.original)) {
+        this[key] = this.original[key];
+      }
     }
 
     // get remote values, before overlaying localstorage
@@ -146,6 +150,9 @@ export abstract class BaseModel {
   }
 
   changed(field?: string | string[], includeRelations = true): boolean {
+    if (this.isDestroy) {
+      return true;
+    }
     return this.setableFields(field, includeRelations).some(f => {
       if (this.RELATIONS.indexOf(f) > -1) {
         return this.getRelated(f).some(m => m.changed());

--- a/src/app/shared/model/index.ts
+++ b/src/app/shared/model/index.ts
@@ -1,5 +1,7 @@
 export * from './audio-file.model';
+export * from './audio-file-template.model';
 export * from './audio-version.model';
+export * from './audio-version-template.model';
 export * from './image.model';
 export * from './series.model';
 export * from './story.model';

--- a/src/app/shared/model/invalid/audio.invalid.spec.ts
+++ b/src/app/shared/model/invalid/audio.invalid.spec.ts
@@ -4,6 +4,11 @@ describe('AudioInvalid', () => {
 
   describe('VERSION_TEMPLATED', () => {
 
+    const build = (data: any, count = null): any => {
+      data.count = () => count;
+      return data;
+    };
+
     it('defaults to at least one segment', () => {
       let invalid = VERSION_TEMPLATED();
       expect(invalid('', {files: []})).toMatch('upload at least 1 segment');
@@ -11,19 +16,32 @@ describe('AudioInvalid', () => {
     });
 
     it('checks segment count', () => {
-      let invalid = VERSION_TEMPLATED(<any> {segmentCount: 3});
+      let invalid = VERSION_TEMPLATED(build({}, 3));
       expect(invalid('', {files: [1, 2]})).toMatch('upload 3 segment');
       expect(invalid('', {files: [1, 2, 3]})).toBeNull();
     });
 
+    it('ignores destroyed segments', () => {
+      let invalid = VERSION_TEMPLATED(build({}, 3));
+      let f1: any = {}, f2: any = {}, f3: any = {};
+      expect(invalid('', {files: [f1, f2, f3]})).toBeNull();
+      f2.isDestroy = true;
+      expect(invalid('', {files: [f1, f2, f3]})).toMatch('upload 3 segment');
+    });
+
+    it('waits for uploads', () => {
+      let invalid = VERSION_TEMPLATED();
+      expect(invalid('', {files: [{}, {isUploading: true}]})).toMatch('wait for uploads');
+    });
+
     it('checks min duration', () => {
-      let invalid = VERSION_TEMPLATED(<any> {lengthMinimum: 10});
+      let invalid = VERSION_TEMPLATED(build({lengthMinimum: 10}));
       expect(invalid('', {files: [{duration: 3}, {duration: 2}]})).toMatch('must be greater than 0:00:10');
       expect(invalid('', {files: [{duration: 3}, {duration: 8}]})).toBeNull();
     });
 
     it('checks max duration', () => {
-      let invalid = VERSION_TEMPLATED(<any> {lengthMaximum: 10});
+      let invalid = VERSION_TEMPLATED(build({lengthMaximum: 10}));
       expect(invalid('', {files: [{duration: 3}, {duration: 8}]})).toMatch('must be less than 0:00:10');
       expect(invalid('', {files: [{duration: 3}, {duration: 2}]})).toBeNull();
     });

--- a/src/app/shared/model/invalid/audio.invalid.ts
+++ b/src/app/shared/model/invalid/audio.invalid.ts
@@ -15,8 +15,11 @@ export const VERSION_TEMPLATED = (template?: HalDoc): BaseInvalid => {
     let count = undeleted.length;
 
     // segment count
-    if (template && template['segmentCount'] && count !== template['segmentCount']) {
-      return `you must upload ${template['segmentCount']} segments (got ${count})`;
+    if (template && template.count('prx:audio-file-templates')) {
+      let segments = template.count('prx:audio-file-templates');
+      if (count !== segments) {
+        return `you must upload ${segments} segments (got ${count})`;
+      }
     } else if (count < 1) {
       return 'upload at least 1 segment';
     }

--- a/src/app/shared/model/invalid/index.ts
+++ b/src/app/shared/model/invalid/index.ts
@@ -1,2 +1,3 @@
 export * from './base.invalid';
 export * from './audio.invalid';
+export * from './template.invalid';

--- a/src/app/shared/model/invalid/template.invalid.spec.ts
+++ b/src/app/shared/model/invalid/template.invalid.spec.ts
@@ -1,0 +1,64 @@
+import { VERSION_LENGTH, FILE_LENGTH } from './template.invalid';
+
+describe('TemplateInvalid', () => {
+
+  let model: any;
+  const buildModel = (min, max) => {
+    model = {
+      lengthMinimum: min,
+      lengthMaximum: max,
+      invalidFields: {lengthMinimum: null, lengthMaximum: null}
+    };
+    return model;
+  };
+
+  describe('VERSION_LENGTH', () => {
+
+    const build = (min, max) => VERSION_LENGTH(buildModel(min, max));
+
+    it('allows both min and max to be null', () => {
+      let invalid = build(null, null);
+      expect(invalid('lengthMinimum', null)).toBeNull();
+      expect(invalid('lengthMaximum', null)).toBeNull();
+    });
+
+    it('requires both min and max', () => {
+      let invalid = build(null, 4);
+      expect(invalid('lengthMinimum', null)).toMatch('Must set');
+      invalid = build(4, null);
+      expect(invalid('lengthMaximum', null)).toMatch('Must set');
+    });
+
+    it('checks for positive numbers', () => {
+      let invalid = build(-1, 'b');
+      expect(invalid('lengthMinimum', null)).toMatch('greater than 0');
+      expect(invalid('lengthMaximum', null)).toMatch('is not a number');
+    });
+
+    it('compares the min and max', () => {
+      let invalid = build(6, 4);
+      expect(invalid('lengthMinimum', 6)).toMatch('less than maximum');
+      expect(invalid('lengthMaximum', 4)).toMatch('greater than minimum');
+    });
+
+    it('also validates the other column', () => {
+      let invalid = build(null, -1);
+      expect(invalid('lengthMinimum', null)).toMatch('Must set');
+      expect(model.invalidFields.lengthMaximum).toMatch('greater than 0');
+    });
+
+  });
+
+  describe('FILE_LENGTH', () => {
+
+    const build = (min, max) => FILE_LENGTH(buildModel(min, max));
+
+    it('compares the min and max', () => {
+      let invalid = build(6, 4);
+      expect(invalid('lengthMinimum', 6)).toMatch('less than maximum');
+      expect(invalid('lengthMaximum', 4)).toMatch('greater than minimum');
+    });
+
+  });
+
+});

--- a/src/app/shared/model/invalid/template.invalid.ts
+++ b/src/app/shared/model/invalid/template.invalid.ts
@@ -1,0 +1,66 @@
+import { AudioVersionTemplateModel } from '../audio-version-template.model';
+import { AudioFileTemplateModel } from '../audio-file-template.model';
+import { BaseInvalid } from './base.invalid';
+
+/**
+ * Audio version template length
+ */
+const checkMinimum = (min, max): string => {
+  if (min === null && max === null) {
+    return null; // allow unset
+  } else if (min === null) {
+    return `Must set a minimum`;
+  } else if (isNaN(parseInt(min, 10))) {
+    return `Minimum is not a number`;
+  } else if (min < 1) {
+    return `Minimum must be greater than 0`;
+  } else if (min >= max) {
+    return 'Minimum must be less than maximum';
+  } else {
+    return null;
+  }
+};
+
+const checkMaximum = (min, max): string => {
+  if (min === null && max === null) {
+    return null; // allow unset
+  } else if (max === null) {
+    return `Must set a maximum`;
+  } else if (isNaN(parseInt(max, 10))) {
+    return `Maximum is not a number`;
+  } else if (max < 1) {
+    return `Maximum must be greater than 0`;
+  } else if (max <= min) {
+    return 'Maximum must be greater than minimum';
+  } else {
+    return null;
+  }
+};
+
+export const VERSION_LENGTH = (version?: AudioVersionTemplateModel): BaseInvalid => {
+  return <BaseInvalid> (key: string, value: any) => {
+    let min = version.lengthMinimum;
+    let max = version.lengthMaximum;
+    if (key === 'lengthMinimum') {
+      version.invalidFields['lengthMaximum'] = checkMaximum(min, max);
+      return checkMinimum(min, max);
+    } else if (key === 'lengthMaximum') {
+      version.invalidFields['lengthMinimum'] = checkMinimum(min, max);
+      return checkMaximum(min, max);
+    }
+  };
+};
+
+export const FILE_LENGTH = (file?: AudioFileTemplateModel): BaseInvalid => {
+  return <BaseInvalid> (key: string, value: any) => {
+    let min = file.lengthMinimum;
+    let max = file.lengthMaximum;
+    if (key === 'lengthMinimum') {
+      file.invalidFields['lengthMaximum'] = checkMaximum(min, max);
+      return checkMinimum(min, max);
+    } else if (key === 'lengthMaximum') {
+      file.invalidFields['lengthMinimum'] = checkMinimum(min, max);
+      return checkMaximum(min, max);
+    }
+  };
+};

--- a/src/app/shared/model/series.model.ts
+++ b/src/app/shared/model/series.model.ts
@@ -8,9 +8,9 @@ import { REQUIRED, LENGTH } from './invalid';
 export class SeriesModel extends BaseModel {
 
   public id: number;
-  public title: string;
-  public description: string;
-  public shortDescription: string;
+  public title: string = '';
+  public description: string = '';
+  public shortDescription: string = '';
   public createdAt: Date;
   public updatedAt: Date;
   public images: ImageModel[] = [];
@@ -57,6 +57,8 @@ export class SeriesModel extends BaseModel {
       templates = this.doc.followItems('prx:audio-version-templates').map(tdocs => {
         return tdocs.map(t => new AudioVersionTemplateModel(this.doc, t));
       });
+    } else if (this.unsavedVersionTemplate) {
+      templates = Observable.of([this.unsavedVersionTemplate]);
     }
 
     return {
@@ -107,6 +109,11 @@ export class SeriesModel extends BaseModel {
   get unsavedImage(): ImageModel {
     let img = new ImageModel(this.parent, this.doc, null);
     return img.isStored() && !img.isDestroy ? img : null;
+  }
+
+  get unsavedVersionTemplate(): AudioVersionTemplateModel {
+    let tpl = new AudioVersionTemplateModel(this.doc, null);
+    return tpl.isStored() && !tpl.isDestroy ? tpl : null;
   }
 
   isV4(): boolean {

--- a/src/app/shared/model/series.model.ts
+++ b/src/app/shared/model/series.model.ts
@@ -2,6 +2,7 @@ import { Observable} from 'rxjs';
 import { HalDoc } from '../../core';
 import { BaseModel } from './base.model';
 import { ImageModel } from './image.model';
+import { AudioVersionTemplateModel } from './audio-version-template.model';
 import { REQUIRED, LENGTH } from './invalid';
 
 export class SeriesModel extends BaseModel {
@@ -13,6 +14,7 @@ export class SeriesModel extends BaseModel {
   public createdAt: Date;
   public updatedAt: Date;
   public images: ImageModel[] = [];
+  public versionTemplates: AudioVersionTemplateModel[] = [];
 
   SETABLE = ['title', 'description', 'shortDescription'];
 
@@ -37,6 +39,8 @@ export class SeriesModel extends BaseModel {
 
   related() {
     let images = Observable.of([]);
+    let templates = Observable.of([]);
+
     if (this.doc && this.doc.has('prx:image')) {
       images = this.doc.follow('prx:image').map(idoc => {
         let imageModels = [new ImageModel(this.parent, this.doc, idoc)];
@@ -48,8 +52,16 @@ export class SeriesModel extends BaseModel {
     } else if (this.unsavedImage) {
       images = Observable.of([this.unsavedImage]);
     }
+
+    if (this.doc && this.doc.count('prx:audio-version-templates')) {
+      templates = this.doc.followItems('prx:audio-version-templates').map(tdocs => {
+        return tdocs.map(t => new AudioVersionTemplateModel(this.doc, t));
+      });
+    }
+
     return {
-      images: images
+      images: images,
+      versionTemplates: templates
     };
   }
 

--- a/src/assets/styles/forms.css
+++ b/src/assets/styles/forms.css
@@ -159,13 +159,13 @@ button.btn-link {
   background: 0 0 transparent;
 }
 button.btn-link:hover, button.btn-link:focus {
-  color: #f59f51;
+  color: #2b7187;
 }
 button.btn-link[disabled] {
   color: #a3a3a3;
 }
 button.btn-link.active {
-  color: #f59f51;
+  color: #2b7187;
 }
 
 button.delete {

--- a/src/assets/styles/layout.css
+++ b/src/assets/styles/layout.css
@@ -44,6 +44,9 @@ a {
   color: #368aa2;
   text-decoration: none;
 }
+a:focus, a:hover {
+  color: #2b7187;
+}
 a:active {
   color: #2b7187;
 }


### PR DESCRIPTION
Ability to edit audio version/file templates on the series.

- [x] Add/remove audio-version-templates on the series
- [x] Allow a maximum of 1 per series for now (since we're only doing the podcast audio-version)
- [x] Add/remove audio-file-templates within the audio-version-template

Makes no attempt to warn the user about the "bad things" that might happen if you change the templates for a series with existing stories.  We'll probably lock that down more at some point in the future - but this PR at least gets all the functionality in place.