### PR TITLE
Recover from token expiration

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,7 +13,13 @@ export class AppComponent {
   constructor(authService: AuthService, cmsService: CmsService) {
     authService.token.subscribe((token) => {
       if (token) {
-        cmsService.setToken(token);
+        let refresher: any;
+        cmsService.setToken(token, cb => {
+          if (!refresher) {
+            refresher = authService.refreshToken();
+          }
+          return refresher;
+        });
       }
       this.loggedIn = token ? true : false;
     });

--- a/src/app/core/auth/auth.component.ts
+++ b/src/app/core/auth/auth.component.ts
@@ -1,5 +1,6 @@
-import { Component, ElementRef } from '@angular/core';
+import { Component, ElementRef, OnDestroy } from '@angular/core';
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
+import { Subscription } from 'rxjs';
 
 import { AuthService } from './auth.service';
 import { AuthUrls } from './auth.urls';
@@ -10,17 +11,29 @@ import { AuthUrls } from './auth.urls';
   template: `<iframe [src]="authUrl" (load)="checkAuth()"></iframe>`
 })
 
-export class AuthComponent {
+export class AuthComponent implements OnDestroy {
 
   private authUrl: SafeResourceUrl;
+  private sub: Subscription;
 
   constructor(
     private element: ElementRef,
     private authService: AuthService,
     private sanitizer: DomSanitizer
   ) {
+    this.sub = authService.refresh.subscribe(() => this.generateAuthUrl());
+    this.generateAuthUrl();
+  }
+
+  ngOnDestroy() {
+    if (this.sub) {
+      this.sub.unsubscribe();
+    }
+  }
+
+  generateAuthUrl() {
     let url = AuthUrls.buildUrl('none');
-    this.authUrl = sanitizer.bypassSecurityTrustResourceUrl(url);
+    this.authUrl = this.sanitizer.bypassSecurityTrustResourceUrl(url);
   }
 
   checkAuth() {

--- a/src/app/core/auth/auth.service.spec.ts
+++ b/src/app/core/auth/auth.service.spec.ts
@@ -1,6 +1,6 @@
 import { AuthService } from './auth.service';
 
-describe('AuthService', () => {
+fdescribe('AuthService', () => {
 
   let auth = new AuthService();
 
@@ -19,6 +19,21 @@ describe('AuthService', () => {
     let currentToken = 'nothing';
     auth.token.subscribe((token) => { currentToken = token; });
     expect(currentToken).toEqual('something');
+  });
+
+  it('refreshes and waits for a new token', () => {
+    auth.setToken('something');
+
+    let currentToken = 'nothing';
+    let refreshToken = 'nothing';
+    auth.token.subscribe(token => currentToken = token);
+    auth.refreshToken().subscribe(token => refreshToken = token);
+    expect(currentToken).toEqual('something');
+    expect(refreshToken).toEqual('nothing');
+
+    auth.setToken('somethingelse');
+    expect(currentToken).toEqual('somethingelse');
+    expect(refreshToken).toEqual('somethingelse');
   });
 
 });

--- a/src/app/core/auth/auth.service.spec.ts
+++ b/src/app/core/auth/auth.service.spec.ts
@@ -1,6 +1,6 @@
 import { AuthService } from './auth.service';
 
-fdescribe('AuthService', () => {
+describe('AuthService', () => {
 
   let auth = new AuthService();
 

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@angular/core';
-import { ReplaySubject } from 'rxjs';
+import { Observable, ReplaySubject } from 'rxjs';
 
 @Injectable()
 export class AuthService {
 
   token = new ReplaySubject<string>(1);
+  refresh = new ReplaySubject<boolean>(1);
 
   setToken(authToken: string) {
     if (authToken) {
@@ -12,6 +13,12 @@ export class AuthService {
     } else {
       this.token.next(null);
     }
+  }
+
+  // refresh and wait for a new auth token
+  refreshToken(): Observable<string> {
+    this.refresh.next(true);
+    return this.token.skip(1);
   }
 
 }

--- a/src/app/core/cms/haldoc.spec.ts
+++ b/src/app/core/cms/haldoc.spec.ts
@@ -4,7 +4,7 @@ import { HalRemote } from './halremote';
 
 class MockRemote extends HalRemote {
   constructor(private getData = {}) {
-    super(null, 'http://thehost', 'thetoken');
+    super(null, 'http://thehost', Observable.of('thetoken'));
   }
   get(link: any, params: {} = null): Observable<{}> {
     let key = link['href'];

--- a/src/app/core/cms/halremote.ts
+++ b/src/app/core/cms/halremote.ts
@@ -1,4 +1,4 @@
-import { Http, Headers, RequestOptionsArgs } from '@angular/http';
+import { Http, Headers, RequestOptionsArgs, Response } from '@angular/http';
 import { Observable } from 'rxjs';
 import * as TemplateParser from 'url-template';
 import { HalRemoteCache } from './halremote.cache';
@@ -12,7 +12,8 @@ export class HalRemote {
   constructor(
     private http: Http,
     private host: string,
-    private token: string
+    private token?: Observable<string>,
+    private refreshToken?: () => Observable<string>
   ) {}
 
   expand(link: HalLink, params: {} = null): string {
@@ -34,18 +35,7 @@ export class HalRemote {
       if (cachedResponse) {
         return cachedResponse;
       } else {
-        return HalRemoteCache.set(href, this.http.get(href, this.httpOptions())
-          .catch((res) => {
-            return Observable.of(res);
-          })
-          .flatMap((res) => {
-            if (res.status === 200) {
-              return Observable.of(res.json());
-            } else {
-              return Observable.throw(new Error(`Got ${res.status} from GET ${href}`));
-            }
-          })
-        );
+        return HalRemoteCache.set(href, this.httpRequest('get', href));
       }
     } else {
       return Observable.throw(new Error('No link object specified!'));
@@ -56,45 +46,63 @@ export class HalRemote {
     let href = this.expand(link, params);
     let body = data ? JSON.stringify(data) : null;
     HalRemoteCache.del(href);
-    return this.http.put(href, body, this.httpOptions(true)).map((res) => {
-      if (res.status === 204) {
-        return Observable.of(true);
-      } else {
-        return Observable.throw(new Error(`Got ${res.status} from PUT ${href}`));
-      }
-    });
+    return this.httpRequest('put', href, body);
   }
 
   post(link: HalLink, params: {} = null, data: {}): Observable<{}> {
     let href = this.expand(link, params);
     let body = data ? JSON.stringify(data) : null;
-    return this.http.post(href, body, this.httpOptions(true)).map((res) => {
-      return res.json();
-    });
+    HalRemoteCache.del(href);
+    return this.httpRequest('post', href, body);
   }
 
   delete(link: HalLink, params: {} = null): Observable<{}> {
     let href = this.expand(link, params);
     HalRemoteCache.del(href);
-    return this.http.delete(href, this.httpOptions()).map((res) => {
-      if (res.status === 204) {
-        return Observable.of(true);
-      } else {
-        return Observable.throw(new Error(`Got ${res.status} from DELETE ${href}`));
-      }
-    });
+    return this.httpRequest('delete', href);
   }
 
-  private httpOptions(hasContent = false): RequestOptionsArgs {
+  private httpRequest(method: string, href: string, body?: string, allowRetry = true): Observable<Response> {
+    return this.httpOptions(body ? true : false)
+      .flatMap(opts => {
+        if (body) {
+          return this.http[method](href, body, opts);
+        } else {
+          return this.http[method](href, opts);
+        }
+      })
+      .catch(res => Observable.of(res)) // don't throw http errors
+      .flatMap(res => {
+        if (method === 'get' && res.status === 200) {
+          return Observable.of(res.json());
+        } else if (method === 'put' && res.status === 204) {
+          return Observable.of(true);
+        } else if (method === 'post' && res.status === 201) {
+          return Observable.of(res.json());
+        } else if (method === 'delete' && res.status === 204) {
+          return Observable.of(true);
+        } else if (res.status === 401 && allowRetry && this.refreshToken) {
+          return this.refreshToken().flatMap(() => this.httpRequest(method, href, body, false));
+        } else {
+          return Observable.throw(new Error(`Got ${res.status} from ${method.toUpperCase()} ${href}`));
+        }
+      });
+  }
+
+  private httpOptions(hasContent = false): Observable<RequestOptionsArgs> {
     let headers = new Headers();
     headers.append('Accept', 'application/hal+json');
-    if (this.token) {
-      headers.append('Authorization', `Bearer ${this.token}`);
-    }
     if (hasContent) {
       headers.append('Content-Type', 'application/hal+json');
     }
-    return {headers: headers};
+    if (this.token) {
+      return this.token.first().map(tokenString => {
+        headers.append('Authorization', `Bearer ${tokenString}`);
+        return {headers: headers};
+      });
+    } else {
+      return Observable.of({headers: headers});
+    }
   }
 
 }

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -20,7 +20,7 @@ export class HomeComponent implements OnInit {
 
   ngOnInit() {
     this.isLoaded = false;
-    this.cms.follow('prx:authorization').subscribe(auth => {
+    this.cms.auth.subscribe(auth => {
       this.auth = auth;
 
       // only load v4 series

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -44,7 +44,7 @@ export class SearchComponent implements OnInit {
               private route: ActivatedRoute) {}
 
   ngOnInit() {
-    this.cms.follow('prx:authorization').subscribe((auth) => {
+    this.cms.auth.subscribe((auth) => {
       this.auth = auth;
 
       this.allSeriesIds = [-1];

--- a/src/app/series/series.component.ts
+++ b/src/app/series/series.component.ts
@@ -34,11 +34,10 @@ export class SeriesComponent implements OnInit {
   }
 
   loadSeries() {
-    let auth = this.cms.follow('prx:authorization');
     if (this.id) {
-      auth.follow('prx:series', {id: this.id}).subscribe(s => this.setSeries(null, s));
+      this.cms.auth.follow('prx:series', {id: this.id}).subscribe(s => this.setSeries(null, s));
     } else {
-      auth.follow('prx:default-account').subscribe(a => this.setSeries(a, null));
+      this.cms.account.subscribe(a => this.setSeries(a, null));
     }
   }
 

--- a/src/app/story/story.component.ts
+++ b/src/app/story/story.component.ts
@@ -49,13 +49,12 @@ export class StoryComponent implements OnInit {
   }
 
   loadStory() {
-    let auth = this.cms.follow('prx:authorization');
     if (this.id) {
-      auth.follow('prx:story', {id: this.id}).subscribe(s => this.setStory(null, s));
+      this.cms.auth.follow('prx:story', {id: this.id}).subscribe(s => this.setStory(null, s));
     } else if (this.seriesId) {
-      auth.follow('prx:series', {id: this.seriesId}).subscribe(s => this.setStory(s, null));
+      this.cms.auth.follow('prx:series', {id: this.seriesId}).subscribe(s => this.setStory(s, null));
     } else {
-      auth.follow('prx:default-account').subscribe(a => this.setStory(a, null));
+      this.cms.account.subscribe(a => this.setStory(a, null));
     }
   }
 

--- a/src/testing/mock.cms.service.ts
+++ b/src/testing/mock.cms.service.ts
@@ -35,8 +35,12 @@ export class MockCmsService {
     return <HalObservable<MockHalDoc>> Observable.of(this.mockRoot);
   }
 
+  get auth(): HalObservable<MockHalDoc> {
+    return this.follow('prx:authorization');
+  }
+
   get account(): HalObservable<MockHalDoc> {
-    return this.follow('prx:authorization').follow('prx:default-account');
+    return this.auth.follow('prx:default-account');
   }
 
   follow(rel: string, params: {} = null): HalObservable<MockHalDoc> {


### PR DESCRIPTION
See #85.

This requires PRX/cms.prx.org#190 and PRX/id.prx.org#34 to run CMS and ID locally.

- [x] Rework how tokens are tied to the HTTP `halremote` layer, in order to refresh an expired token and seamlessly retry the request.
- [x] Fixed some bugs in how the `halremote` caching/memoization worked.
- [x] More tests!