### PR TITLE
Image removal change detection

### DIFF
--- a/src/app/shared/image/image-upload.component.spec.ts
+++ b/src/app/shared/image/image-upload.component.spec.ts
@@ -26,12 +26,6 @@ describe('ImageUploadComponent', () => {
     expect(comp.model.images.length).toEqual(1);
   });
 
-  cit('savagely removes new destroyed images', (fix, el, comp) => {
-    comp.model = {images: [{isDestroy: true, isNew: true}]};
-    expect(comp.noImages).toEqual(true);
-    expect(comp.model.images.length).toEqual(0);
-  });
-
   cit('adds an image', (fix, el, comp) => {
     comp.model = {images: []};
     comp.addUpload({});

--- a/src/app/shared/image/image-upload.component.ts
+++ b/src/app/shared/image/image-upload.component.ts
@@ -29,7 +29,6 @@ export class ImageUploadComponent {
 
   get noImages(): boolean {
     if (this.model && this.model.images) {
-      this.model.images = this.model.images.filter(img => !(img.isNew && img.isDestroy));
       if (this.model.images.length === 0) {
         return true;
       } else if (this.model.images.every(img => img.isDestroy)) {

--- a/src/app/shared/model/base.model.spec.ts
+++ b/src/app/shared/model/base.model.spec.ts
@@ -226,11 +226,19 @@ describe('BaseModel', () => {
       expect(base.changed(null, false)).toBeFalsy();
     });
 
-    it('counts destroys as changed', () => {
+    it('counts existing destroys as changed', () => {
       expect(base.changed()).toBeFalsy();
       base.isDestroy = true;
       expect(base.changed()).toBeTruthy();
       expect(base.changed('foo')).toBeTruthy();
+    });
+
+    it('counts new destroys as unchanged', () => {
+      expect(base.changed()).toBeFalsy();
+      base.isDestroy = true;
+      base.isNew = true;
+      expect(base.changed()).toBeFalsy();
+      expect(base.changed('foo')).toBeFalsy();
     });
 
   });

--- a/src/app/shared/model/base.model.ts
+++ b/src/app/shared/model/base.model.ts
@@ -158,7 +158,7 @@ export abstract class BaseModel {
 
   changed(field?: string | string[], includeRelations = true): boolean {
     if (this.isDestroy) {
-      return true;
+      return this.isNew ? false : true;
     }
     return this.setableFields(field, includeRelations).some(f => {
       if (this.RELATIONS.indexOf(f) > -1) {


### PR DESCRIPTION
It was a "Really Bad Idea of Ryan's" (™) to alter the `images` array during the call to `get noImages()`.  Because it occurs during change detection.  Which really shouldn't change things.  Sad.

And more generally, a call to `model.changed()` should return false if the model is deleted AND new.