### PR TITLE
Prompt before deleting audio files

### DIFF
--- a/src/app/upload/shared/audio-cancel.directive.spec.ts
+++ b/src/app/upload/shared/audio-cancel.directive.spec.ts
@@ -1,6 +1,6 @@
 import { cit, create, direct, provide, By } from '../../../testing';
 import { Component } from '@angular/core';
-import { ModalService } from '../../core'
+import { ModalService } from '../../core';
 import { AudioCancelDirective } from './audio-cancel.directive';
 
 @Component({

--- a/src/app/upload/shared/audio-cancel.directive.spec.ts
+++ b/src/app/upload/shared/audio-cancel.directive.spec.ts
@@ -1,5 +1,6 @@
-import { cit, create, direct, By } from '../../../testing';
+import { cit, create, direct, provide, By } from '../../../testing';
 import { Component } from '@angular/core';
+import { ModalService } from '../../core'
 import { AudioCancelDirective } from './audio-cancel.directive';
 
 @Component({
@@ -10,12 +11,34 @@ class MiniComponent {
   version: any;
   delay = 10;
 }
+const getDirective = (el): AudioCancelDirective => {
+  let cancelEl = el.query(By.directive(AudioCancelDirective));
+  expect(cancelEl).toBeDefined();
+  return cancelEl.injector.get(AudioCancelDirective);
+};
 
-describe('AudioCancelDirective', () => {
+fdescribe('AudioCancelDirective', () => {
 
   create(MiniComponent, false);
 
   direct(AudioCancelDirective);
+
+  let modalAlertTitle: any;
+  beforeEach(() => modalAlertTitle = null);
+  provide(ModalService, {
+    prompt: (p) => modalAlertTitle = p
+  });
+
+  cit('prompts before deleting audio', (fix, el, comp) => {
+    comp.file = {canceled: false, destroy: () => true};
+    comp.version = {removeUpload: () => true};
+    fix.detectChanges();
+
+    let cancel = getDirective(el);
+    spyOn(cancel, 'cancelAndDestroy').and.stub();
+    el.query(By.css('button')).nativeElement.click();
+    expect(modalAlertTitle).toMatch(/really delete/i);
+  });
 
   cit('cancels but delays deletion', (fix, el, comp, done) => {
     let destroyed = false;
@@ -23,7 +46,9 @@ describe('AudioCancelDirective', () => {
     comp.file = {canceled: false, destroy: () => destroyed = true};
     comp.version = {removeUpload: () => removed = true};
     fix.detectChanges();
-    el.query(By.css('button')).nativeElement.click();
+
+    let cancel = getDirective(el);
+    cancel.cancelAndDestroy();
     expect(comp.file.canceled).toEqual(true);
     expect(destroyed).toEqual(false);
     expect(removed).toEqual(false);

--- a/src/app/upload/shared/audio-cancel.directive.spec.ts
+++ b/src/app/upload/shared/audio-cancel.directive.spec.ts
@@ -17,7 +17,7 @@ const getDirective = (el): AudioCancelDirective => {
   return cancelEl.injector.get(AudioCancelDirective);
 };
 
-fdescribe('AudioCancelDirective', () => {
+describe('AudioCancelDirective', () => {
 
   create(MiniComponent, false);
 

--- a/src/app/upload/shared/audio-cancel.directive.ts
+++ b/src/app/upload/shared/audio-cancel.directive.ts
@@ -21,7 +21,7 @@ export class AudioCancelDirective {
     } else {
       this.modal.prompt(
         'Really delete audio file?',
-        'This operation cannot be undone',
+        'This action cannot be undone.',
         (okay: boolean) => okay && this.cancelAndDestroy()
       );
     }

--- a/src/app/upload/shared/audio-cancel.directive.ts
+++ b/src/app/upload/shared/audio-cancel.directive.ts
@@ -1,4 +1,5 @@
 import { Directive, Input, HostListener } from '@angular/core';
+import { ModalService } from '../../core';
 import { AudioFileModel, AudioVersionModel } from '../../shared';
 
 @Directive({
@@ -12,7 +13,21 @@ export class AudioCancelDirective {
 
   @Input() version: AudioVersionModel;
 
+  constructor(private modal: ModalService) {}
+
   @HostListener('click') onClick() {
+    if (this.publishAudioCancel.isUploading) {
+      this.cancelAndDestroy();
+    } else {
+      this.modal.prompt(
+        'Really delete audio file?',
+        'This operation cannot be undone',
+        (okay: boolean) => okay && this.cancelAndDestroy()
+      );
+    }
+  }
+
+  cancelAndDestroy() {
     this.publishAudioCancel.canceled = true;
     setTimeout(() => {
       this.publishAudioCancel.destroy();


### PR DESCRIPTION
See #97.

Not sure of the best wording here, so I made it up.

There are actually a couple different scenarios around deleting an audio file:

1. New unsaved audio - we really do need to prompt for this, as clicking the X will remove all traces forever.
2. Saved audio - also prompting for this, but not quite as catastrophic, since your deletion won't be sent to the server until you click "Save".  (And you can always "Discard" first).
3. In-progress upload - not prompting for this.  Just cancel the upload.
4. Failed upload - not prompting for this, as there's nothing to save.