### PR TITLE
Fix 401s for publish/unpublish buttons

### DIFF
--- a/src/app/core/cms/halremote.ts
+++ b/src/app/core/cms/halremote.ts
@@ -65,7 +65,7 @@ export class HalRemote {
   private httpRequest(method: string, href: string, body?: string, allowRetry = true): Observable<Response> {
     return this.httpOptions(body ? true : false)
       .flatMap(opts => {
-        if (body) {
+        if (method === 'put' || method === 'post') {
           return this.http[method](href, body, opts);
         } else {
           return this.http[method](href, opts);


### PR DESCRIPTION
Fixes #114.  CMS was returning 401s for POST requests to publish/unpublish a story.

Turns out this was the only POST request Publish makes that doesn't include any data in the body.  And I was using the incorrect `http.post` signature as a result.

TMI: Which resulted in a non-json content type, and the browser sending the wrong `access-control-request-headers` header, and CMS returning that it doesn't allow the `authorization` header in the OPTIONS request, and then the browser didn't send `authorization` header with the POST, and thus a 401!