### PR TITLE
Fix wysiwyg Cancel add link expression changed error

### DIFF
--- a/src/app/shared/wysiwyg/prompt.component.ts
+++ b/src/app/shared/wysiwyg/prompt.component.ts
@@ -27,6 +27,6 @@ export class PromptComponent {
   }
 
   public hide(): void {
-    setTimeout(() => this.visible = false, 300);
+    this.visible = false;
   }
 }

--- a/src/app/shared/wysiwyg/prosemirror.markdown.editor.ts
+++ b/src/app/shared/wysiwyg/prosemirror.markdown.editor.ts
@@ -48,6 +48,10 @@ export class ProseMirrorMarkdownEditor {
     this.view.editor.destroy();
   }
 
+  isSelectionEmpty() {
+    return this.view.editor.state.selection.empty;
+  }
+
   viewProps(state: any) {
     return {
       state,

--- a/src/app/shared/wysiwyg/wysiwyg.component.ts
+++ b/src/app/shared/wysiwyg/wysiwyg.component.ts
@@ -10,7 +10,8 @@ import { PromptComponent } from './prompt.component';
   template: `
     <div #contentEditable [class.changed]="changed" [class.invalid]="invalid"></div>
     <p *ngIf="invalid" class="error">{{invalid | capitalize}}</p>
-    <publish-prompt #prompt>
+    
+    <publish-prompt #prompt *ngIf="!editor?.isSelectionEmpty()">
       <h1 class="modal-header">Link to</h1>
       <div class="modal-body">
         <label>URL<span class="error" [style.display]="isURLInvalid() ? 'inline' : 'none'">*</span></label>
@@ -22,6 +23,15 @@ import { PromptComponent } from './prompt.component';
       <div class="modal-footer">
         <button (click)="createLink()">Okay</button>
         <button (click)="prompt.hide()">Cancel</button>
+      </div>
+    </publish-prompt>
+    <publish-prompt #prompt *ngIf="editor?.isSelectionEmpty()">
+      <h1 class="modal-header">Warning</h1>
+      <div class="modal-body" *ngIf="editor?.isSelectionEmpty()">
+        <p class="error">Please select text to create link</p>
+      </div>
+      <div class="modal-footer">
+        <button (click)="prompt.hide()">Okay</button>
       </div>
     </publish-prompt>
   `,
@@ -93,7 +103,7 @@ export class WysiwygComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   isURLInvalid() {
-    return this.url.invalid && this.url.dirty;
+    return this.url && this.url.invalid && this.url.dirty;
   }
 
   promptForLink() {

--- a/src/app/shared/wysiwyg/wysiwyg.component.ts
+++ b/src/app/shared/wysiwyg/wysiwyg.component.ts
@@ -27,7 +27,7 @@ import { PromptComponent } from './prompt.component';
     </publish-prompt>
     <publish-prompt #prompt *ngIf="editor?.isSelectionEmpty()">
       <h1 class="modal-header">Warning</h1>
-      <div class="modal-body" *ngIf="editor?.isSelectionEmpty()">
+      <div class="modal-body">
         <p class="error">Please select text to create link</p>
       </div>
       <div class="modal-footer">


### PR DESCRIPTION
- [ ] fixes the Expression changed after checked error when the user opens the link prompt, doesn't fill in the fields, and clicks Cancel
- [ ] warns the user when they have clicked the link button if no text is selected