### PR TITLE
Fetch items instead of array for audio file templates

### DIFF
--- a/src/app/shared/model/audio-version-template.model.ts
+++ b/src/app/shared/model/audio-version-template.model.ts
@@ -38,7 +38,7 @@ export class AudioVersionTemplateModel extends BaseModel {
   related() {
     let files: Observable<AudioFileTemplateModel[]>;
     if (this.doc) {
-      files = this.doc.followList('prx:audio-file-templates').map(ftdocs => {
+      files = this.doc.followItems('prx:audio-file-templates').map(ftdocs => {
         let saved = ftdocs.map(ft => new AudioFileTemplateModel(this.parent, this.doc, ft));
         let unsaved = this.findUnsavedFiles(saved.length + 1);
         return saved.concat(unsaved);

--- a/src/app/shared/model/audio-version.model.spec.ts
+++ b/src/app/shared/model/audio-version.model.spec.ts
@@ -99,7 +99,7 @@ describe('AudioVersionModel', () => {
     });
 
     it('loads audio templates', () => {
-      templateMock.mockList('prx:audio-file-templates', ['one', 'two']);
+      templateMock.mockItems('prx:audio-file-templates', ['one', 'two']);
       let version = makeVersion(null);
       expect(version.template).toBeTruthy();
       expect(version.fileTemplates.length).toEqual(2);
@@ -107,7 +107,7 @@ describe('AudioVersionModel', () => {
     });
 
     it('assigns templates to files', () => {
-      templateMock.mockList('prx:audio-file-templates', [{position: 1}, {position: 3}, {position: 2}]);
+      templateMock.mockItems('prx:audio-file-templates', [{position: 1}, {position: 3}, {position: 2}]);
       let version = makeVersion({}, [{position: 2}, {position: 1, isDestroy: true}, {position: 4}]);
       expect(version.filesAndTemplates.length).toEqual(4);
       expect(version.filesAndTemplates[0].file).toBeNull();

--- a/src/app/shared/model/audio-version.model.ts
+++ b/src/app/shared/model/audio-version.model.ts
@@ -87,7 +87,7 @@ export class AudioVersionModel extends BaseModel {
 
     // optionally load-and-assign file templates
     if (this.hasFileTemplates) {
-      let tpls = this.template.followList('prx:audio-file-templates');
+      let tpls = this.template.followItems('prx:audio-file-templates');
       files = Observable.forkJoin(files, tpls).map(([models, tdocs]) => {
         this.fileTemplates = tdocs.sort(fileSort);
         return models;


### PR DESCRIPTION
PRX/cms.prx.org#202 now embeds most resources as paged `prx:items` instead of a flat array.

The only impact on Publish is the `prx:audio-file-templates` resource.  There's already a HalDoc method to fetch items, so this just switches to using that.