### PR TITLE
fix missing draft info on dashboard

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -49,6 +49,9 @@ module.exports = function (config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     browsers: ['Chrome'],
-    singleRun: false
+    singleRun: false,
+    mime: {
+      'text/x-typescript': ['ts','tsx']
+    }
   });
 };

--- a/src/app/home/directives/home-series.component.ts
+++ b/src/app/home/directives/home-series.component.ts
@@ -91,9 +91,9 @@ export class HomeSeriesComponent implements OnInit {
       // parent result total is embedded in child total
       this.count = storyDocs.length ? storyDocs[0].total() : 0;
 
-      this.stories = [new StoryModel(accountDoc, null, false)];
+      this.stories = [new StoryModel(accountDoc, null, true)];
       for (let story of storyDocs) {
-        this.stories.push(new StoryModel(accountDoc, story, false));
+        this.stories.push(new StoryModel(accountDoc, story, true));
       }
       this.storyLoaders = null;
     });

--- a/src/app/home/directives/home-series.component.ts
+++ b/src/app/home/directives/home-series.component.ts
@@ -70,9 +70,9 @@ export class HomeSeriesComponent implements OnInit {
 
     this.series.followItems('prx:stories', {per: limit, filters: 'v4'}).subscribe((stories) => {
       this.storyLoaders = null;
-      this.stories = [new StoryModel(this.series, null, false)];
+      this.stories = [new StoryModel(this.series, null, true)];
       for (let story of stories) {
-        this.stories.push(new StoryModel(this.series, story, false));
+        this.stories.push(new StoryModel(this.series, story, true));
       }
     });
   }

--- a/src/app/home/directives/home-story.component.spec.ts
+++ b/src/app/home/directives/home-story.component.spec.ts
@@ -1,0 +1,23 @@
+import { cit, create, stubPipe } from '../../../testing';
+import { HomeStoryComponent } from './home-story.component';
+
+
+describe('HomeStoryComponent', () => {
+
+  create(HomeStoryComponent, false);
+
+  stubPipe('duration');
+
+  cit('renders new story as draft', (fix, el, comp) => {
+    comp.story = {isNew: true, changed: () => true};
+    fix.detectChanges();
+    expect(el).toContainText('Draft');
+  });
+
+  cit('renders add story button when no draft changes', (fix, el, comp) => {
+    comp.story = {isNew: true, changed: () => false};
+    fix.detectChanges();
+    expect(el).toQuery('.plus-sign');
+  });
+
+});

--- a/src/app/home/directives/home-story.component.ts
+++ b/src/app/home/directives/home-story.component.ts
@@ -74,7 +74,7 @@ export class HomeStoryComponent implements OnInit {
     let duration = 0;
     if (this.story.versions && this.story.versions.length > 0) {
       if (this.story.versions[0].files.length > 0) {
-        duration = this.story.versions[0].files.map((audio) => {
+        duration = this.story.versions[0].files.filter((audio) => !audio.isDestroy).map((audio) => {
           return audio['duration'] || 0;
         }).reduce((prevDuration, currDuration) => {
           return prevDuration + currDuration;

--- a/src/app/home/directives/home-story.component.ts
+++ b/src/app/home/directives/home-story.component.ts
@@ -1,6 +1,4 @@
 import { Component, Input, OnInit } from '@angular/core';
-
-import { HalDoc } from '../../core';
 import { StoryModel } from '../../shared';
 
 @Component({
@@ -15,7 +13,7 @@ import { StoryModel } from '../../shared';
     </template>
     <template [ngIf]="!isPlusSign">
       <a [routerLink]="editLink">
-        <publish-image [src]="storyImage" [imageDoc]="storyImageDoc"></publish-image>
+        <publish-image [src]="storyImage" ></publish-image>
       </a>
       <h2>
         <a *ngIf="storyTitle" [routerLink]="editLink">{{storyTitle}}</a>
@@ -35,8 +33,6 @@ export class HomeStoryComponent implements OnInit {
   editLink: any[];
 
   storyId: number;
-  storyImage: string;
-  storyImageDoc: HalDoc;
   storyTitle: string;
   storyUpdated: Date;
 
@@ -55,13 +51,6 @@ export class HomeStoryComponent implements OnInit {
       }
     } else {
       this.editLink = ['/story', this.story.id];
-    }
-
-    // TODO: draft audios - to be removed
-    if (this.story.isNew) {
-      this.storyImage = this.story.unsavedImage ? this.story.unsavedImage.enclosureHref : null;
-    } else {
-      this.storyImageDoc = this.story.doc;// TODO: loading related now, so do we want doc or href?
     }
 
     if (this.story.isNew) {
@@ -95,4 +84,11 @@ export class HomeStoryComponent implements OnInit {
     return duration;
   }
 
+  get storyImage(): string {
+    if (this.story.isNew) {
+      return this.story.unsavedImage ? this.story.unsavedImage.enclosureHref : null;
+    } else {
+      return this.story.images.length > 0 ? this.story.images[0].enclosureHref : '';
+    }
+  }
 }

--- a/src/app/home/directives/home-story.component.ts
+++ b/src/app/home/directives/home-story.component.ts
@@ -66,8 +66,7 @@ export class HomeStoryComponent implements OnInit {
   }
 
   get isPlusSign(): boolean {
-    return this.story.isNew && !this.story.isStored()
-      && !this.story.unsavedImage && this.story.versions.length === 0;
+    return this.story.isNew && !this.story.changed();
   }
 
   get storyDuration(): number {

--- a/src/app/home/directives/home-story.component.ts
+++ b/src/app/home/directives/home-story.component.ts
@@ -33,13 +33,11 @@ export class HomeStoryComponent implements OnInit {
   @Input() story: StoryModel;
 
   editLink: any[];
-  isPlusSign: boolean;
 
   storyId: number;
   storyImage: string;
   storyImageDoc: HalDoc;
   storyTitle: string;
-  storyDuration: number;
   storyUpdated: Date;
 
   statusClass: string;
@@ -47,7 +45,6 @@ export class HomeStoryComponent implements OnInit {
 
   ngOnInit() {
     this.storyId = this.story.id;
-    this.isPlusSign = this.story.isNew && !this.story.isStored();
     this.storyTitle = this.story.title;
     this.storyUpdated = this.story.lastStored || this.story.updatedAt;
 
@@ -60,27 +57,11 @@ export class HomeStoryComponent implements OnInit {
       this.editLink = ['/story', this.story.id];
     }
 
-    // TODO: draft audios
+    // TODO: draft audios - to be removed
     if (this.story.isNew) {
       this.storyImage = this.story.unsavedImage ? this.story.unsavedImage.enclosureHref : null;
-      this.storyDuration = 0;
     } else {
-      this.storyImageDoc = this.story.doc;
-      if (this.story.doc.has('prx:audio')) {
-        this.story.doc.followItems('prx:audio').subscribe((audios) => {
-          if (!audios || audios.length < 1) {
-            this.storyDuration = 0;
-          } else {
-            this.storyDuration = audios.map((audio) => {
-              return audio['duration'] || 0;
-            }).reduce((prevDuration, currDuration) => {
-              return prevDuration + currDuration;
-            });
-          }
-        });
-      } else {
-        this.storyDuration = 0;
-      }
+      this.storyImageDoc = this.story.doc;// TODO: loading related now, so do we want doc or href?
     }
 
     if (this.story.isNew) {
@@ -93,6 +74,25 @@ export class HomeStoryComponent implements OnInit {
       this.statusClass = 'status unpublished';
       this.statusText = 'Private';
     }
+  }
+
+  get isPlusSign(): boolean {
+    return this.story.isNew && !this.story.isStored()
+      && !this.story.unsavedImage && this.story.versions.length === 0;
+  }
+
+  get storyDuration(): number {
+    let duration = 0;
+    if (this.story.versions && this.story.versions.length > 0) {
+      if (this.story.versions[0].files.length > 0) {
+        duration = this.story.versions[0].files.map((audio) => {
+          return audio['duration'] || 0;
+        }).reduce((prevDuration, currDuration) => {
+          return prevDuration + currDuration;
+        });
+      }
+    }
+    return duration;
   }
 
 }

--- a/src/app/shared/model/audio-version.model.spec.ts
+++ b/src/app/shared/model/audio-version.model.spec.ts
@@ -120,9 +120,13 @@ describe('AudioVersionModel', () => {
 
   describe('encode', () => {
 
-    it('really only cares about the label', () => {
-      let version = makeVersion({label: 'foobar'});
+    it('sets label and translates explicit', () => {
+      let version = makeVersion({label: 'foobar', explicit: 'clean'});
       expect(version.encode()).toEqual({label: 'foobar', explicit: 'clean'});
+      version = makeVersion({label: 'foobar', explicit: 'yes'});
+      expect(version.encode()).toEqual({label: 'foobar', explicit: 'yes'});
+      version = makeVersion({label: 'foobar', explicit: ''});
+      expect(version.encode()).toEqual({label: 'foobar', explicit: ''});
     });
 
   });

--- a/src/app/shared/model/audio-version.model.ts
+++ b/src/app/shared/model/audio-version.model.ts
@@ -11,7 +11,7 @@ export class AudioVersionModel extends BaseModel {
   public id: number;
   public uploads: string = '';
   public label: string;
-  public explicit: string;
+  public explicit: string = '';
   public files: AudioFileModel[];
 
   // save in-progress uploads to localstorage
@@ -101,13 +101,33 @@ export class AudioVersionModel extends BaseModel {
     this.id = this.doc['id'];
     this.uploads = '';
     this.label = this.doc['label'];
-    this.explicit = (this.doc['explicit'] === 'yes') ? 'Explicit' : 'Clean';
+    switch (this.doc['explicit']) {
+      case 'yes':
+        this.explicit = 'Explicit';
+        break;
+      case 'clean':
+        this.explicit = 'Clean';
+        break;
+      default:
+        this.explicit = '';
+        break;
+    }
   }
 
   encode(): {} {
     let data = <any> {};
     data.label = this.label;
-    data.explicit = (this.explicit === 'Explicit') ? 'yes' : 'clean';
+    switch (this.explicit) {
+      case 'Explicit':
+        data.explicit = 'yes';
+        break;
+      case 'Clean':
+        data.explicit = 'clean';
+        break;
+      default:
+        data.explicit = '';
+        break;
+    }
     if (this.isNew && this.template) {
       data.set_audio_version_template_uri = this.template.expand('self');
     }
@@ -127,7 +147,7 @@ export class AudioVersionModel extends BaseModel {
   }
 
   changed(field?: string | string[], includeRelations = true): boolean {
-    if (this.isNew && this.files.length === 0 && this.explicit === undefined) {
+    if (this.isNew && this.files.length === 0 && !this.explicit) {
       return false;
     } else {
       return super.changed(field, includeRelations);

--- a/src/app/shared/model/audio-version.model.ts
+++ b/src/app/shared/model/audio-version.model.ts
@@ -127,7 +127,7 @@ export class AudioVersionModel extends BaseModel {
   }
 
   changed(field?: string | string[], includeRelations = true): boolean {
-    if (this.isNew && this.files.length === 0) {
+    if (this.isNew && this.files.length === 0 && this.explicit === undefined) {
       return false;
     } else {
       return super.changed(field, includeRelations);


### PR DESCRIPTION
Fixes #90 dashboard draft info.
 - [ ] Audio durations on the dashboard not including unsaved audio --> should compute duration for files !isDestroy(), including those that are only in local storage and not yet persisted to CMS
 - [ ] Make sure unsaved images are shown on the dashboard --> If only an image was set, the dashboard tile was showing as an add new story plus-sign button
 - [ ] Make sure you get a dashboard draft, even if you haven't added a title yet --> If only image, audio, and or clean/explicit was set, the dashboard tile was showing as an add new story plus-sign button