### PR TITLE
fix error caused by story duration map reduce on empty array

### DIFF
--- a/src/app/home/directives/home-story.component.ts
+++ b/src/app/home/directives/home-story.component.ts
@@ -73,11 +73,14 @@ export class HomeStoryComponent implements OnInit {
     let duration = 0;
     if (this.story.versions && this.story.versions.length > 0) {
       if (this.story.versions[0].files.length > 0) {
-        duration = this.story.versions[0].files.filter((audio) => !audio.isDestroy).map((audio) => {
-          return audio['duration'] || 0;
-        }).reduce((prevDuration, currDuration) => {
-          return prevDuration + currDuration;
-        });
+        let nonDestroyedAudio = this.story.versions[0].files.filter((audio) => !audio.isDestroy);
+        if (nonDestroyedAudio && nonDestroyedAudio.length > 0) {
+          duration = nonDestroyedAudio.map((audio) => {
+            return audio['duration'] || 0;
+          }).reduce((prevDuration, currDuration) => {
+            return prevDuration + currDuration;
+          });
+        }
       }
     }
     return duration;


### PR DESCRIPTION
If you remove the audio from a piece without saving, the error `Reduce of empty array with no initial value` is thrown from the story duration calculation on the dashboard. I created this bug last week with the changes to show draft info on the dashboard.