### PR TITLE
Allow user to override default author name for podcast

### DIFF
--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -28,6 +28,10 @@
       </div>
     </publish-fancy-field>
 
+    <publish-fancy-field label="Author Name" textinput [model]="podcast" name="authorName">
+      <div class="fancy-hint">By default, the podcast author name will be set to your account holder name. Override that here.</div>
+    </publish-fancy-field>
+
     <publish-fancy-field label="iTunes Categories" required=1>
       <div class="fancy-hint">Some description of what these are here and
         maybe also a link to the itunes docs.</div>

--- a/src/app/shared/model/feeder-podcast.model.spec.ts
+++ b/src/app/shared/model/feeder-podcast.model.spec.ts
@@ -5,6 +5,7 @@ describe('FeederPodcastModel', () => {
 
   let series = cms.mock('prx:series', {id: 'series1'});
   let dist = series.mock('prx:distributions', {id: 'dist1', kind: 'podcast'});
+  let authorDist = series.mock('prx:accounts', {name: 'Foo'});
 
   beforeEach(() => window.localStorage.clear());
 
@@ -50,6 +51,12 @@ describe('FeederPodcastModel', () => {
     expect(dest.id).not.toEqual(1234);
     expect(dest.category).toEqual('src-category');
     expect(src.unstore).toHaveBeenCalled();
+  });
+
+  it('allows user to override account name for podcast', () => {
+    let doc = authorDist.mock('some-feeder', {author: {name: 'Bar'}});
+    let podcast = new FeederPodcastModel(series, dist, doc);
+    expect(podcast.authorName).toEqual('Bar');
   });
 
 });

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -55,7 +55,7 @@ export class FeederPodcastModel extends BaseModel {
     }
     this.link = this.doc['link'] || '';
     this.newFeedUrl = this.doc['newFeedUrl'] || '';
-    if (this.doc['author']['name']) {
+    if (this.doc['author'] && this.doc['author']['name']) {
       this.authorName = this.doc['author']['name'];
     } else if (this.series.has('prx:account')) {
       this.series.follow('prx:account').subscribe(account => this.authorName = account['name']);

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -55,11 +55,12 @@ export class FeederPodcastModel extends BaseModel {
     }
     this.link = this.doc['link'] || '';
     this.newFeedUrl = this.doc['newFeedUrl'] || '';
-    if (this.series.has('prx:account')) {
-      this.series.follow('prx:account').subscribe(account => this.authorName = account['name']);
-    }
-    if (this.doc['author']) {
+    if (this.doc['author']['name']) {
       this.authorName = this.doc['author']['name'];
+    } else if (this.series.has('prx:account')) {
+      this.series.follow('prx:account').subscribe(account => this.authorName = account['name']);
+    } else {
+      this.authorName = '';
     }
     // pretend path was blank if it was just the podcast id
     this.path = this.doc['path'] || '';

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -55,8 +55,12 @@ export class FeederPodcastModel extends BaseModel {
     }
     this.link = this.doc['link'] || '';
     this.newFeedUrl = this.doc['newFeedUrl'] || '';
-    this.authorName = this.doc['author']['name'] || this.series['_embedded']['prx:account'].name;
-
+    if (this.series.has('prx:account')) {
+      this.series.follow('prx:account').subscribe(account => this.authorName = account['name']);
+    }
+    if (this.doc['author']) {
+      this.authorName = this.doc['author']['name'];
+    }
     // pretend path was blank if it was just the podcast id
     this.path = this.doc['path'] || '';
     if (`${this.path}` === `${this.id}`) {

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -11,13 +11,14 @@ export class FeederPodcastModel extends BaseModel {
   publishedUrl: string;
 
   // writeable
-  SETABLE = ['category', 'subCategory', 'explicit', 'path', 'link', 'newFeedUrl'];
+  SETABLE = ['category', 'subCategory', 'explicit', 'path', 'link', 'newFeedUrl', 'authorName'];
   category: string = '';
   subCategory: string = '';
   explicit: string = '';
   path: string = '';
   link: string = '';
   newFeedUrl: string = '';
+  authorName: string = '';
 
   VALIDATORS = {
     path: [TOKENY('Use letters, numbers and underscores only')],
@@ -54,6 +55,7 @@ export class FeederPodcastModel extends BaseModel {
     }
     this.link = this.doc['link'] || '';
     this.newFeedUrl = this.doc['newFeedUrl'] || '';
+    this.authorName = this.doc['author']['name'] || this.series['_embedded']['prx:account'].name;
 
     // pretend path was blank if it was just the podcast id
     this.path = this.doc['path'] || '';
@@ -86,7 +88,9 @@ export class FeederPodcastModel extends BaseModel {
     }
     data.link = this.link || null;
     data.newFeedUrl = this.newFeedUrl || null;
-
+    if (this.authorName) {
+      data.author = { name: this.authorName };
+    }
     // default path back to the id
     data.path = this.path || this.id;
 


### PR DESCRIPTION
By default, `author` will be set to account holder's name. This allows the user to override the author name that will be displayed with their podcast. (See #167)