### PR TITLE
Podcast Distribution custom path

### DIFF
--- a/src/app/series/directives/series-podcast.component.css
+++ b/src/app/series/directives/series-podcast.component.css
@@ -20,3 +20,7 @@
 .feed-urls button:hover, .feed-urls button:focus {
   background-color: #e28b42;
 }
+
+.custom-path >>> input {
+  width: 160px;
+}

--- a/src/app/series/directives/series-podcast.component.css
+++ b/src/app/series/directives/series-podcast.component.css
@@ -6,7 +6,7 @@
 .feed-urls input {
   min-width: 400px;
   padding: 10px 8px;
-  color: #ccc;
+  color: #939393;
   background: #fff;
   margin-bottom: 4px;
 }

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -22,8 +22,10 @@
           <a class="button" target="_blank" rel="noopener" [href]="podcast?.publishedUrl">Open Link</a>
         </publish-fancy-field>
 
-        <publish-fancy-field label="Custom Path" textinput [model]="podcast" name="path">
+        <publish-fancy-field class="custom-path" label="Custom Path" textinput [model]="podcast" name="path" small=1>
           <div class="fancy-hint">An optional custom folder name to use in your PRX published feed url.</div>
+          <span class="prefix">{{urlStart}}</span>
+          <span class="suffix">{{urlEnd}}</span>
         </publish-fancy-field>
       </div>
     </publish-fancy-field>

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -21,10 +21,6 @@
           <button [publishCopyInput]="pubFeed">Copy</button>
           <a class="button" target="_blank" rel="noopener" [href]="podcast?.publishedUrl">Open Link</a>
         </publish-fancy-field>
-        <publish-fancy-field label="Preview Feed" small=1>
-          <input type="text" readonly [ngModel]="podcast?.previewUrl" name="previewUrl"/>
-          <a class="button" target="_blank" rel="noopener" [href]="podcast?.previewUrl">Open Link</a>
-        </publish-fancy-field>
       </div>
     </publish-fancy-field>
 

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -21,6 +21,10 @@
           <button [publishCopyInput]="pubFeed">Copy</button>
           <a class="button" target="_blank" rel="noopener" [href]="podcast?.publishedUrl">Open Link</a>
         </publish-fancy-field>
+
+        <publish-fancy-field label="Custom Path" textinput [model]="podcast" name="path">
+          <div class="fancy-hint">An optional custom folder name to use in your PRX published feed url.</div>
+        </publish-fancy-field>
       </div>
     </publish-fancy-field>
 
@@ -46,10 +50,6 @@
 
     <publish-fancy-field label="Homepage Link" required textinput [model]="podcast" name="link">
       <div class="fancy-hint">A link to the homepage for your podcast.</div>
-    </publish-fancy-field>
-
-    <publish-fancy-field label="Vanity Path" textinput [model]="podcast" name="path">
-      <div class="fancy-hint">An optional vanity folder name to use in your PRX published feed url.</div>
     </publish-fancy-field>
 
     <publish-fancy-field label="New Feed Url" textinput [model]="podcast" name="newFeedUrl">

--- a/src/app/series/directives/series-podcast.component.spec.ts
+++ b/src/app/series/directives/series-podcast.component.spec.ts
@@ -27,18 +27,6 @@ describe('SeriesPodcastComponent', () => {
     expect(comp.loadPodcast).toHaveBeenCalled();
   });
 
-  cit('displays feed urls for existing podcasts', (fix, el, comp) => {
-    comp.distribution = {kind: 'podcast'};
-    fix.detectChanges();
-    expect(el).not.toQuery('[label="PRX Feeds"]');
-    comp.podcast = {id: null};
-    fix.detectChanges();
-    expect(el).not.toQuery('[label="PRX Feeds"]');
-    comp.podcast.id = 1234;
-    fix.detectChanges();
-    expect(el).toQuery('[label="PRX Feeds"]');
-  });
-
   cit('sets itunes subcategories', (fix, el, comp) => {
     comp.podcast = {set: () => null};
     comp.setSubCategories();

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -88,4 +88,22 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
     }
   }
 
+  get urlStart() {
+    if (this.podcast) {
+      let parts = this.podcast.publishedUrl.split('/');
+      if (parts.length > 2) {
+        return parts.slice(0, parts.length - 2).join('/') + '/';
+      }
+    }
+  }
+
+  get urlEnd() {
+    if (this.podcast) {
+      let parts = this.podcast.publishedUrl.split('/');
+      if (parts.length > 2) {
+        return '/' + parts.slice(parts.length - 1).join('/');
+      }
+    }
+  }
+
 }

--- a/src/app/shared/form/fancy-field.component.html
+++ b/src/app/shared/form/fancy-field.component.html
@@ -16,6 +16,7 @@
   </div>
 
   <template [ngIf]="model">
+    <ng-content select=".prefix"></ng-content>
     <input *ngIf="type == 'textinput'" [id]="name" type="text"
       [ngModel]="model[name]" (ngModelChange)="onChange($event)"/>
     <input *ngIf="type == 'number'" [id]="name" type="number"
@@ -26,6 +27,7 @@
       [(ngModel)]="model[name]" (ngModelChange)="onChange($event)">
       <option *ngFor="let opt of select" [value]="opt">{{opt}}</option>
     </select>
+    <ng-content select=".suffix"></ng-content>
   </template>
 
   <template [ngIf]="!model">

--- a/src/app/shared/model/feeder-podcast.model.spec.ts
+++ b/src/app/shared/model/feeder-podcast.model.spec.ts
@@ -56,6 +56,7 @@ describe('FeederPodcastModel', () => {
     let src = new FeederPodcastModel(series, dist);
     src.publishedUrl = 'http://staging-f.prxu.org/doesnotsaythebestpodcast/feed-rss.xml';
     src.set('path', 'the_best_podcast');
+    src.save();
     expect(src.publishedUrl).toEqual('http://staging-f.prxu.org/the_best_podcast/feed-rss.xml');
   });
 

--- a/src/app/shared/model/feeder-podcast.model.spec.ts
+++ b/src/app/shared/model/feeder-podcast.model.spec.ts
@@ -52,4 +52,11 @@ describe('FeederPodcastModel', () => {
     expect(src.unstore).toHaveBeenCalled();
   });
 
+  it('updates the publishedUrl with changes to the custom path', () => {
+    let src = new FeederPodcastModel(series, dist);
+    src.publishedUrl = 'http://staging-f.prxu.org/doesnotsaythebestpodcast/feed-rss.xml';
+    src.set('path', 'the_best_podcast');
+    expect(src.publishedUrl).toEqual('http://staging-f.prxu.org/the_best_podcast/feed-rss.xml');
+  });
+
 });

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -11,7 +11,7 @@ export class FeederPodcastModel extends BaseModel {
   publishedUrl: string;
 
   // writeable
-  SETABLE = ['category', 'subCategory', 'explicit', 'path', 'link', 'newFeedUrl'];
+  SETABLE = ['category', 'subCategory', 'explicit', 'path', 'link', 'newFeedUrl', 'publishedUrl'];
   category: string = '';
   subCategory: string = '';
   explicit: string = '';
@@ -86,6 +86,7 @@ export class FeederPodcastModel extends BaseModel {
     }
     data.link = this.link || null;
     data.newFeedUrl = this.newFeedUrl || null;
+    data.publishedUrl = this.publishedUrl || null;
 
     // default path back to the id
     data.path = this.path || this.id;
@@ -124,6 +125,7 @@ export class FeederPodcastModel extends BaseModel {
         parts[parts.length - 2] = this.path;
       }
       this.publishedUrl = parts.join('/');
+      this.set('publishedUrl', this.publishedUrl);
     }
   }
 

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -116,4 +116,15 @@ export class FeederPodcastModel extends BaseModel {
     }
   }
 
+  set(field: string, value: any) {
+    super.set(field, value);
+    if (field === 'path') {
+      let parts = this.publishedUrl.split('/');
+      if (parts.length > 2) {
+        parts[parts.length - 2] = this.path;
+      }
+      this.publishedUrl = parts.join('/');
+    }
+  }
+
 }

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -118,7 +118,7 @@ export class FeederPodcastModel extends BaseModel {
 
   set(field: string, value: any) {
     super.set(field, value);
-    if (field === 'path') {
+    if (field === 'path' && this.publishedUrl) {
       let parts = this.publishedUrl.split('/');
       if (parts.length > 2) {
         parts[parts.length - 2] = this.path;


### PR DESCRIPTION
#163, #165, #170, #176 

The one thing not covered here is explaining to the user that the custom path is used in the URL instead of the podcast id. I'm just still not clear on if users understand what the podcast id # is and what this hint should actually say. I think putting it in the context of the url prefix and suffix does help though (and fixing that bug where it wasn't actually showing up when set until requested from the API again.)