### PR TITLE
Show podcast feed story order

### DIFF
--- a/src/app/series/directives/series-basic.component.css
+++ b/src/app/series/directives/series-basic.component.css
@@ -5,6 +5,20 @@ h3 {
   margin-bottom: 6px;
   width: 100%;
 }
+h4 {
+  font-size: 18px;
+  line-height: 22px;
+  font-weight: 400;
+  margin-bottom: 6px;
+  color: #343434;
+}
+h5 {
+  font-size: 16px;
+  line-height: 22px;
+  font-weight: 400;
+  margin-bottom: 6px;
+  color: #343434;
+}
 .hint {
   margin-bottom: 6px;
   width: 100%;

--- a/src/app/series/directives/series-basic.component.css
+++ b/src/app/series/directives/series-basic.component.css
@@ -5,20 +5,6 @@ h3 {
   margin-bottom: 6px;
   width: 100%;
 }
-h4 {
-  font-size: 18px;
-  line-height: 22px;
-  font-weight: 400;
-  margin-bottom: 6px;
-  color: #343434;
-}
-h5 {
-  font-size: 16px;
-  line-height: 22px;
-  font-weight: 400;
-  margin-bottom: 6px;
-  color: #343434;
-}
 .hint {
   margin-bottom: 6px;
   width: 100%;

--- a/src/app/series/directives/series-feed.component.css
+++ b/src/app/series/directives/series-feed.component.css
@@ -1,12 +1,25 @@
+h4 {
+  font-size: 18px;
+  line-height: 22px;
+  font-weight: 400;
+  margin: 6px 0;
+  color: #343434;
+}
+
+li {
+  display: flex;
+  justify-content: space-between;
+  margin: 5px 0;
+}
+
 .public {
-  background-color: blue;
+  color: #000000;
 }
 
 .futurePublic {
-  background-color: yellow;
-
+  color: #ffa500;
 }
 
 .private {
-  background-color: red;
+  color: #ee4d3e;
 }

--- a/src/app/series/directives/series-feed.component.css
+++ b/src/app/series/directives/series-feed.component.css
@@ -23,3 +23,9 @@ li {
 .private {
   color: #ee4d3e;
 }
+
+.extra {
+  text-align: center;
+  margin-top: 30px;
+  font-weight: 400;
+}

--- a/src/app/series/directives/series-feed.component.css
+++ b/src/app/series/directives/series-feed.component.css
@@ -1,0 +1,12 @@
+.public {
+  background-color: blue;
+}
+
+.futurePublic {
+  background-color: yellow;
+
+}
+
+.private {
+  background-color: red;
+}

--- a/src/app/series/directives/series-feed.component.spec.ts
+++ b/src/app/series/directives/series-feed.component.spec.ts
@@ -8,17 +8,25 @@ describe('SeriesFeedComponent', () => {
 
   provide(TabService);
 
-  cit('does not render until the series and podcast are loaded', (fix, el, comp) => {
-    expect(el).not.toContainText('Published Feed');
-    comp.series = comp.podcast = {};
+  cit('shows a loading spinner', (fix, el, comp) => {
+    comp.isLoaded = false;
+    fix.detectChanges();
+    expect(el).toQuery('publish-spinner');
+  });
+
+  cit('does not render until the series and list are loaded', (fix, el, comp) => {
+    expect(el).not.toContainText('stories');
+    comp.series = comp.list = {};
     comp.noStories = true;
+    comp.isLoaded = true;
     fix.detectChanges();
 
     expect(el).toContainText('You have no published stories');
   });
 
   cit('displays story titles and publication status', (fix, el, comp) => {
-    comp.series = comp.podcast = {};
+    comp.series = comp.list = {};
+    comp.isLoaded = true;
     comp.publicStories = [
       {title: 'First Public Story', pubDate: new Date()},
       {title: 'Second Public Story', pubDate: new Date()},
@@ -36,7 +44,7 @@ describe('SeriesFeedComponent', () => {
     expect(el).toContainText('Set for future publication');
     expect(el).toContainText('First Public Story');
     expect(el).toContainText('Second Public Story');
-    expect(el).toContainText('Public feed');
+    expect(el).toContainText('Public');
   });
 
 });

--- a/src/app/series/directives/series-feed.component.spec.ts
+++ b/src/app/series/directives/series-feed.component.spec.ts
@@ -14,9 +14,9 @@ describe('SeriesFeedComponent', () => {
     expect(el).toQuery('publish-spinner');
   });
 
-  cit('does not render until the series and list are loaded', (fix, el, comp) => {
+  cit('does not render until the series is loaded', (fix, el, comp) => {
     expect(el).not.toContainText('stories');
-    comp.series = comp.list = {};
+    comp.series = {};
     comp.noStories = true;
     comp.isLoaded = true;
     fix.detectChanges();
@@ -25,7 +25,7 @@ describe('SeriesFeedComponent', () => {
   });
 
   cit('displays story titles and publication status', (fix, el, comp) => {
-    comp.series = comp.list = {};
+    comp.series = {};
     comp.isLoaded = true;
     comp.publicStories = [
       {title: 'First Public Story', pubDate: new Date()},

--- a/src/app/series/directives/series-feed.component.spec.ts
+++ b/src/app/series/directives/series-feed.component.spec.ts
@@ -1,0 +1,32 @@
+import { cit, create, provide } from '../../../testing';
+import { SeriesFeedComponent } from './series-feed.component';
+import { TabService } from '../../shared';
+
+describe('SeriesFeedComponent', () => {
+
+  create(SeriesFeedComponent);
+
+  provide(TabService);
+
+  cit('does not render until the series and podcast are loaded', (fix, el, comp) => {
+    expect(el).not.toContainText('Published Feed');
+    comp.series = comp.podcast = {};
+    fix.detectChanges();
+
+    expect(el).toContainText('Published Feed');
+    expect(el).toContainText('published stories as they appear');
+  });
+
+  cit('displays story titles and pub dates', (fix, el, comp) => {
+    comp.series = comp.podcast = {};
+    comp.stories = [
+      {title: 'First Story', pubDate: new Date()},
+      {title: 'Second Story', pubDate: new Date()},
+    ];
+    fix.detectChanges();
+    expect(el).toContainText('First Story');
+    expect(el).toContainText('Second Story');
+    expect(el).toContainText('Published ');
+  });
+
+});

--- a/src/app/series/directives/series-feed.component.spec.ts
+++ b/src/app/series/directives/series-feed.component.spec.ts
@@ -11,22 +11,32 @@ describe('SeriesFeedComponent', () => {
   cit('does not render until the series and podcast are loaded', (fix, el, comp) => {
     expect(el).not.toContainText('Published Feed');
     comp.series = comp.podcast = {};
+    comp.noStories = true;
     fix.detectChanges();
 
-    expect(el).toContainText('Published Feed');
-    expect(el).toContainText('published stories as they appear');
+    expect(el).toContainText('You have no published stories');
   });
 
-  cit('displays story titles and pub dates', (fix, el, comp) => {
+  cit('displays story titles and publication status', (fix, el, comp) => {
     comp.series = comp.podcast = {};
-    comp.stories = [
-      {title: 'First Story', pubDate: new Date()},
-      {title: 'Second Story', pubDate: new Date()},
+    comp.publicStories = [
+      {title: 'First Public Story', pubDate: new Date()},
+      {title: 'Second Public Story', pubDate: new Date()},
+    ];
+    comp.futurePublicStories = [
+      {title: 'Future Story', pubDate: new Date('01/01/2020')}
+    ];
+    comp.privateStories = [
+      {title: 'Private Story'}
     ];
     fix.detectChanges();
-    expect(el).toContainText('First Story');
-    expect(el).toContainText('Second Story');
-    expect(el).toContainText('Published ');
+    expect(el).toContainText('Private Story');
+    expect(el).toContainText('No publication date set');
+    expect(el).toContainText('Future Story');
+    expect(el).toContainText('Set for future publication');
+    expect(el).toContainText('First Public Story');
+    expect(el).toContainText('Second Public Story');
+    expect(el).toContainText('Public feed');
   });
 
 });

--- a/src/app/series/directives/series-feed.component.ts
+++ b/src/app/series/directives/series-feed.component.ts
@@ -82,7 +82,7 @@ export class SeriesFeedComponent implements OnDestroy {
           .subscribe((docs) => {
             this.isLoaded = true;
             docs.forEach((doc) => {
-                let story = new StoryModel(this.list.parent, doc, false);
+                let story = new StoryModel(this.series.doc, doc, false);
                 if (!story.publishedAt) {
                   this.privateStories.push(story);
                   return;

--- a/src/app/series/directives/series-feed.component.ts
+++ b/src/app/series/directives/series-feed.component.ts
@@ -1,12 +1,12 @@
 import { Component, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { DistributionModel, SeriesModel, StoryModel, TabService } from '../../shared';
+import { SeriesModel, StoryModel, TabService } from '../../shared';
 
 @Component({
   template: `
   <div>
     <publish-spinner *ngIf="!isLoaded"></publish-spinner>
-    <section *ngIf="series && list">
+    <section *ngIf="series">
       <div class="hint" *ngIf="noStories">
         You have no published stories in this series.
       </div>
@@ -56,17 +56,13 @@ export class SeriesFeedComponent implements OnDestroy {
   publicStories: StoryModel[] = [];
   futurePublicStories: StoryModel[] = [];
   privateStories: StoryModel[] = [];
-  list: DistributionModel;
   tabSub: Subscription;
 
   constructor(tab: TabService) {
     this.noStories = false;
     this.tabSub = tab.model.subscribe((s: SeriesModel) => {
       this.series = s;
-      s.loadRelated('distributions').subscribe((dists) => {
-        this.list = dists[0];
-        this.sortStories();
-      });
+      this.sortStories();
     });
   }
 

--- a/src/app/series/directives/series-feed.component.ts
+++ b/src/app/series/directives/series-feed.component.ts
@@ -4,28 +4,37 @@ import { DistributionModel, SeriesModel, StoryModel, TabService } from '../../sh
 
 @Component({
   template: `
-    <form *ngIf="series && podcast">
+    <section *ngIf="series && podcast">
       <h3>Published Feed</h3>
-      <h4 class="hint">Here are your published stories as they appear in your podcast feed.</h4>
-      <ul>
-        <li *ngFor="let s of stories">
-          <h5><a [routerLink]="['/story', s.id]">{{s.title}}</a></h5>
-          <p class="hint">Published {{s.pubDate}}.</p>
-        </li>
-      </ul>
-    </form>
+
+      <div class="hint" *ngIf="noStories">
+        You have no published stories in this podcast.
+      </div>
+
+      <section *ngIf="!noStories">
+        <h4>Here are your published stories as they appear in your podcast feed.</h4>
+        <ul>
+          <li *ngFor="let s of stories">
+            <h5><a [routerLink]="['/story', s.id]">{{s.title}}</a></h5>
+            <p class="hint">Published {{s.pubDate}}.</p>
+          </li>
+        </ul>
+      </section>
+    </section>
   `,
   styleUrls: ['./series-basic.component.css']
 })
 
 export class SeriesFeedComponent implements OnDestroy {
 
+  noStories: boolean;
   series: SeriesModel;
   stories: StoryModel[];
   podcast: DistributionModel;
   tabSub: Subscription;
 
   constructor(tab: TabService) {
+    this.noStories = false;
     this.tabSub = tab.model.subscribe((s: SeriesModel) => {
       this.series = s;
       this.podcast = s.distributions.filter(dist => dist.kind === 'podcast')[0];
@@ -44,7 +53,10 @@ export class SeriesFeedComponent implements OnDestroy {
               let story = new StoryModel(this.podcast.parent, doc, false);
               story['pubDate'] = story.publishedAt.toLocaleDateString();
               return story;
-            })
+            });
+          if (this.stories.length === 0) {
+            this.noStories = true;
+          }
         });
   }
 

--- a/src/app/series/directives/series-feed.component.ts
+++ b/src/app/series/directives/series-feed.component.ts
@@ -71,8 +71,8 @@ export class SeriesFeedComponent implements OnDestroy {
   }
 
   sortStories() {
-    this.list
-        .parent
+    this.series
+        .doc
         .followItems('prx:stories', { sorts: 'updated_at:desc' })
         .subscribe((docs) => {
           this.isLoaded = true;

--- a/src/app/series/directives/series-feed.component.ts
+++ b/src/app/series/directives/series-feed.component.ts
@@ -1,0 +1,56 @@
+import { Component, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { DistributionModel, SeriesModel, StoryModel, TabService } from '../../shared';
+
+@Component({
+  template: `
+    <form *ngIf="series && podcast">
+      <h3>Published Feed</h3>
+      <h4 class="hint">Here are your published stories as they appear in your podcast feed.</h4>
+      <ul>
+        <li *ngFor="let s of stories">
+          <h5><a [routerLink]="['/story', s.id]">{{s.title}}</a></h5>
+          <p class="hint">Published {{s.pubDate}}.</p>
+        </li>
+      </ul>
+    </form>
+  `,
+  styleUrls: ['./series-basic.component.css']
+})
+
+export class SeriesFeedComponent implements OnDestroy {
+
+  series: SeriesModel;
+  stories: StoryModel[];
+  podcast: DistributionModel;
+  tabSub: Subscription;
+
+  constructor(tab: TabService) {
+    this.tabSub = tab.model.subscribe((s: SeriesModel) => {
+      this.series = s;
+      this.podcast = s.distributions.filter(dist => dist.kind === 'podcast')[0];
+      this.setStories();
+    });
+  }
+
+  setStories() {
+    this.podcast
+        .parent
+        .followItems('prx:stories', { sorts: 'updated_at:desc' })
+        .subscribe((docs) => {
+          this.stories = docs
+            .filter(doc => doc['publishedAt'])
+            .map((doc) => {
+              let story = new StoryModel(this.podcast.parent, doc, false);
+              story['pubDate'] = story.publishedAt.toLocaleDateString();
+              return story;
+            })
+        });
+  }
+
+
+  ngOnDestroy(): any {
+    this.tabSub.unsubscribe();
+  }
+
+}

--- a/src/app/series/directives/series-feed.component.ts
+++ b/src/app/series/directives/series-feed.component.ts
@@ -1,37 +1,36 @@
 import { Component, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { DistributionModel, SeriesModel, StoryModel, TabService } from '../../shared';
-import { HalDoc } from '../../core';
 
 @Component({
   template: `
     <section *ngIf="series && podcast">
-      <h3>Published Feed</h3>
-
       <div class="hint" *ngIf="noStories">
         You have no published stories in this podcast.
       </div>
 
       <section *ngIf="!noStories">
-        <h4>Here are your private stories. They do not appear in your podcast feed.</h4>
-        <ul class="private">
+        <ul *ngIf="privateStories.length">
+          <h4>Private</h4>
           <li *ngFor="let s of privateStories">
             <h5><a [routerLink]="['/story', s.id]">{{s.title}}</a></h5>
-            <p class="hint">Private.</p>
+            <p class="private">No publication date set.</p>
           </li>
         </ul>
-        <h4>Here are your stories set to be published in the future. </h4>
-        <ul class="futurePublic">
+
+        <ul *ngIf="futurePublicStories.length">
+          <h4>Set for future publication</h4>
           <li *ngFor="let s of futurePublicStories">
             <h5><a [routerLink]="['/story', s.id]">{{s.title}}</a></h5>
-            <p class="hint">To be published {{s.pubDate}}.</p>
+            <p class="futurePublic">Will be published {{s.pubDate}}.</p>
           </li>
         </ul>
-        <h4>Here are your published stories as they currently appear in your podcast feed.</h4>
-        <ul class="public">
+
+        <ul *ngIf="publicStories.length">
+          <h4>Public feed</h4>
           <li *ngFor="let s of publicStories">
             <h5><a [routerLink]="['/story', s.id]">{{s.title}}</a></h5>
-            <p class="hint">Published {{s.pubDate}}.</p>
+            <p class="public">Published {{s.pubDate}}.</p>
           </li>
         </ul>
       </section>
@@ -44,9 +43,9 @@ export class SeriesFeedComponent implements OnDestroy {
 
   noStories: boolean;
   series: SeriesModel;
-  publicStories: StoryModel[];
-  futurePublicStories: StoryModel[];
-  privateStories: StoryModel[];
+  publicStories: StoryModel[] = [];
+  futurePublicStories: StoryModel[] = [];
+  privateStories: StoryModel[] = [];
   podcast: DistributionModel;
   tabSub: Subscription;
 
@@ -55,11 +54,11 @@ export class SeriesFeedComponent implements OnDestroy {
     this.tabSub = tab.model.subscribe((s: SeriesModel) => {
       this.series = s;
       this.podcast = s.distributions.filter(dist => dist.kind === 'podcast')[0];
-      this.setStories();
+      this.sortStories();
     });
   }
 
-  setStories() {
+  sortStories() {
     this.podcast
         .parent
         .followItems('prx:stories', { sorts: 'updated_at:desc' })
@@ -68,42 +67,23 @@ export class SeriesFeedComponent implements OnDestroy {
             this.noStories = true;
             return;
           }
-          this.publicStories = docs
-            .filter(doc => this.publicStoryDoc(doc))
-            .map((doc) => {
+          docs.forEach((doc) => {
               let story = new StoryModel(this.podcast.parent, doc, false);
+              if (!story.publishedAt) {
+                this.privateStories.push(story);
+                return;
+              }
               story['pubDate'] = story.publishedAt.toLocaleDateString();
-              return story;
+              if (new Date(story.publishedAt) <= new Date()) {
+                this.publicStories.push(story);
+              } else {
+                this.futurePublicStories.push(story);
+              }
             });
-          this.futurePublicStories = docs
-            .filter(doc => this.futurePublicStoryDoc(doc))
-            .map((doc) => {
-              let story = new StoryModel(this.podcast.parent, doc, false);
-              story['pubDate'] = story.publishedAt.toLocaleDateString();
-              return story;
-            });
-          this.privateStories = docs
-            .filter(doc => this.privateStoryDoc(doc))
-            .map((doc) => {
-               return new StoryModel(this.podcast.parent, doc, false);
-            });
-        });
+          });
   }
 
   ngOnDestroy(): any {
     this.tabSub.unsubscribe();
   }
-
-  publicStoryDoc(doc: HalDoc): boolean {
-    return doc['publishedAt'] && new Date(doc['publishedAt']) <= new Date();
-  }
-
-  futurePublicStoryDoc(doc: HalDoc): boolean {
-    return doc['publishedAt'] && new Date(doc['publishedAt']) > new Date();
-  }
-
-  privateStoryDoc(doc: HalDoc): boolean {
-    return !doc['publishedAt'];
-  }
-
 }

--- a/src/app/series/directives/series-feed.component.ts
+++ b/src/app/series/directives/series-feed.component.ts
@@ -4,6 +4,8 @@ import { DistributionModel, SeriesModel, StoryModel, TabService } from '../../sh
 
 @Component({
   template: `
+  <div>
+    <publish-spinner *ngIf="!isLoaded"></publish-spinner>
     <section *ngIf="series && podcast">
       <div class="hint" *ngIf="noStories">
         You have no published stories in this podcast.
@@ -35,12 +37,14 @@ import { DistributionModel, SeriesModel, StoryModel, TabService } from '../../sh
         </ul>
       </section>
     </section>
+    </div>
   `,
   styleUrls: ['./series-feed.component.css']
 })
 
 export class SeriesFeedComponent implements OnDestroy {
 
+  isLoaded: boolean = false;
   noStories: boolean;
   series: SeriesModel;
   publicStories: StoryModel[] = [];
@@ -63,6 +67,7 @@ export class SeriesFeedComponent implements OnDestroy {
         .parent
         .followItems('prx:stories', { sorts: 'updated_at:desc' })
         .subscribe((docs) => {
+          this.isLoaded = true;
           if (docs.length === 0) {
             this.noStories = true;
             return;

--- a/src/app/series/directives/series-feed.component.ts
+++ b/src/app/series/directives/series-feed.component.ts
@@ -35,6 +35,12 @@ import { DistributionModel, SeriesModel, StoryModel, TabService } from '../../sh
             <p class="public">Published {{s.pubDate}}.</p>
           </li>
         </ul>
+
+        <div class="extra" *ngIf="isLoaded">
+          <a [routerLink]="['/search', { tab: 'stories', seriesId: series.id }]">
+            Search among these stories.
+          </a>
+        </div>
       </section>
     </section>
     </div>

--- a/src/app/series/directives/series-feed.component.ts
+++ b/src/app/series/directives/series-feed.component.ts
@@ -71,29 +71,31 @@ export class SeriesFeedComponent implements OnDestroy {
   }
 
   sortStories() {
-    this.series
-        .doc
-        .followItems('prx:stories', { sorts: 'updated_at:desc' })
-        .subscribe((docs) => {
-          this.isLoaded = true;
-          if (docs.length === 0) {
-            this.noStories = true;
-            return;
-          }
-          docs.forEach((doc) => {
-              let story = new StoryModel(this.list.parent, doc, false);
-              if (!story.publishedAt) {
-                this.privateStories.push(story);
-                return;
-              }
-              story['pubDate'] = story.publishedAt.toLocaleDateString();
-              if (new Date(story.publishedAt) <= new Date()) {
-                this.publicStories.push(story);
-              } else {
-                this.futurePublicStories.push(story);
-              }
+    let total = this.series.doc.count('prx:stories');
+    if (total === 0) {
+      this.noStories = true;
+      this.isLoaded = true;
+    } else {
+      this.series
+          .doc
+          .followItems('prx:stories', { per: total })
+          .subscribe((docs) => {
+            this.isLoaded = true;
+            docs.forEach((doc) => {
+                let story = new StoryModel(this.list.parent, doc, false);
+                if (!story.publishedAt) {
+                  this.privateStories.push(story);
+                  return;
+                }
+                story['pubDate'] = story.publishedAt.toLocaleDateString();
+                if (new Date(story.publishedAt) <= new Date()) {
+                  this.publicStories.push(story);
+                } else {
+                  this.futurePublicStories.push(story);
+                }
+              });
             });
-          });
+    }
   }
 
   ngOnDestroy(): any {

--- a/src/app/series/series.component.html
+++ b/src/app/series/series.component.html
@@ -31,7 +31,7 @@
     <a routerLinkActive="active" [routerLinkActiveOptions]="{exact:true}" [routerLink]="base">Basic Info</a>
     <a routerLinkActive="active" [routerLink]="[base, 'templates']">Audio Templates</a>
     <a routerLinkActive="active" [routerLink]="[base, 'podcast']">Podcast Distribution</a>
-    <a *ngIf="!series?.isNew" routerLinkActive="active" [routerLink]="[base, 'list']">{{storyCount}} {{storyNoun}} in Series</a>
+    <a *ngIf="series && !series?.isNew" routerLinkActive="active" [routerLink]="[base, 'list']">{{storyCount}} {{storyNoun}} in Series</a>
   </nav>
   <div class="extras">
     <button *ngIf="id && storyCount == 0" class="delete" (click)="confirmDelete()">Delete</button>

--- a/src/app/series/series.component.html
+++ b/src/app/series/series.component.html
@@ -31,7 +31,7 @@
     <a routerLinkActive="active" [routerLinkActiveOptions]="{exact:true}" [routerLink]="base">Basic Info</a>
     <a routerLinkActive="active" [routerLink]="[base, 'templates']">Audio Templates</a>
     <a routerLinkActive="active" [routerLink]="[base, 'podcast']">Podcast Distribution</a>
-    <a routerLinkActive="active" [routerLink]="[base, 'feed']">Stories in Feed</a>
+    <a *ngIf="!series?.isNew" routerLinkActive="active" [routerLink]="[base, 'list']">Stories in Series</a>
   </nav>
   <div class="extras">
     <a *ngIf="storyCount > 0" [routerLink]="['/search', { tab: 'stories', seriesId: id }]">{{storyCount}} {{storyNoun}} &raquo;</a>

--- a/src/app/series/series.component.html
+++ b/src/app/series/series.component.html
@@ -31,6 +31,7 @@
     <a routerLinkActive="active" [routerLinkActiveOptions]="{exact:true}" [routerLink]="base">Basic Info</a>
     <a routerLinkActive="active" [routerLink]="[base, 'templates']">Audio Templates</a>
     <a routerLinkActive="active" [routerLink]="[base, 'podcast']">Podcast Distribution</a>
+    <a routerLinkActive="active" [routerLink]="[base, 'feed']">Stories in Feed</a>
   </nav>
   <div class="extras">
     <a *ngIf="storyCount > 0" [routerLink]="['/search', { tab: 'stories', seriesId: id }]">{{storyCount}} {{storyNoun}} &raquo;</a>

--- a/src/app/series/series.component.html
+++ b/src/app/series/series.component.html
@@ -31,10 +31,9 @@
     <a routerLinkActive="active" [routerLinkActiveOptions]="{exact:true}" [routerLink]="base">Basic Info</a>
     <a routerLinkActive="active" [routerLink]="[base, 'templates']">Audio Templates</a>
     <a routerLinkActive="active" [routerLink]="[base, 'podcast']">Podcast Distribution</a>
-    <a *ngIf="!series?.isNew" routerLinkActive="active" [routerLink]="[base, 'list']">Stories in Series</a>
+    <a *ngIf="!series?.isNew" routerLinkActive="active" [routerLink]="[base, 'list']">{{storyCount}} {{storyNoun}} in Series</a>
   </nav>
   <div class="extras">
-    <a *ngIf="storyCount > 0" [routerLink]="['/search', { tab: 'stories', seriesId: id }]">{{storyCount}} {{storyNoun}} &raquo;</a>
     <button *ngIf="id && storyCount == 0" class="delete" (click)="confirmDelete()">Delete</button>
   </div>
 </publish-tabs>

--- a/src/app/series/series.component.spec.ts
+++ b/src/app/series/series.component.spec.ts
@@ -41,14 +41,6 @@ describe('SeriesComponent', () => {
     expect(comp.series.parent.id).toEqual(88);
   });
 
-  cit('shows the story count', (fix, el, comp) => {
-    activatedRoute.testParams = {id: '99'};
-    auth.mock('prx:series', {}).mockItems('prx:stories', [{}, {}, {}]);
-    fix.detectChanges();
-    expect(el).toContainText('3 Stories');
-    expect(el).toQueryAttr('div.extras a', 'href', '/search;tab=stories;seriesId=99');
-  });
-
   cit('refuses to edit v3 series', (fix, el, comp) => {
     activatedRoute.testParams = {id: '99'};
     auth.mock('prx:series', {appVersion: 'v3'});

--- a/src/app/series/series.routing.ts
+++ b/src/app/series/series.routing.ts
@@ -6,12 +6,14 @@ import { SeriesComponent } from './series.component';
 import { SeriesBasicComponent } from './directives/series-basic.component';
 import { SeriesTemplatesComponent } from './directives/series-templates.component';
 import { SeriesPodcastComponent } from './directives/series-podcast.component';
+import { SeriesFeedComponent } from './directives/series-feed.component';
 import { FileTemplateComponent } from './directives/file-template.component';
 
 const seriesChildRoutes = [
   { path: '',          component: SeriesBasicComponent },
   { path: 'templates', component: SeriesTemplatesComponent },
-  { path: 'podcast',   component: SeriesPodcastComponent }
+  { path: 'podcast',   component: SeriesPodcastComponent },
+  { path: 'feed',   component: SeriesFeedComponent }
 ];
 
 export const seriesRoutes: Routes = [
@@ -34,6 +36,7 @@ export const seriesComponents: any[] = [
   SeriesBasicComponent,
   SeriesTemplatesComponent,
   SeriesPodcastComponent,
+  SeriesFeedComponent,
   FileTemplateComponent
 ];
 

--- a/src/app/series/series.routing.ts
+++ b/src/app/series/series.routing.ts
@@ -13,7 +13,7 @@ const seriesChildRoutes = [
   { path: '',          component: SeriesBasicComponent },
   { path: 'templates', component: SeriesTemplatesComponent },
   { path: 'podcast',   component: SeriesPodcastComponent },
-  { path: 'feed',   component: SeriesFeedComponent }
+  { path: 'list',   component: SeriesFeedComponent }
 ];
 
 export const seriesRoutes: Routes = [


### PR DESCRIPTION
Added a tab on Series edit that shows the stories for a podcast in the order they'll show up in the feed (#124), and will sort based on public / to-be-public / private status. 