### PR TITLE
Explicitly observable related models

### DIFF
--- a/src/app/shared/image/image-loader.component.spec.ts
+++ b/src/app/shared/image/image-loader.component.spec.ts
@@ -30,10 +30,10 @@ describe('ImageLoaderComponent', () => {
   describe('from src', () => {
 
     cit('renders the image src', (fix, el, comp, done) => {
-      comp.src = 'http://placehold.it/10x10';
+      comp.src = 'http://fillmurray.com/10/10';
       waitFor(comp, 'onLoad', () => {
-        expect(el).toQueryAttr('img', 'src', 'http://placehold.it/10x10');
-        expect(getBackground(el)).toEqual('http://placehold.it/10x10');
+        expect(el).toQueryAttr('img', 'src', 'http://fillmurray.com/10/10');
+        expect(getBackground(el)).toEqual('http://fillmurray.com/10/10');
         done();
       });
       fix.detectChanges();
@@ -58,10 +58,10 @@ describe('ImageLoaderComponent', () => {
   describe('from haldoc', () => {
 
     cit('follows the prx:image', (fix, el, comp, done) => {
-      comp.imageDoc = mockDoc('http://placehold.it/10x10');
+      comp.imageDoc = mockDoc('http://fillmurray.com/10/10');
       waitFor(comp, 'onLoad', () => {
-        expect(el).toQueryAttr('img', 'src', 'http://placehold.it/10x10');
-        expect(getBackground(el)).toEqual('http://placehold.it/10x10');
+        expect(el).toQueryAttr('img', 'src', 'http://fillmurray.com/10/10');
+        expect(getBackground(el)).toEqual('http://fillmurray.com/10/10');
         done();
       });
 

--- a/src/app/shared/model/base.model.spec.ts
+++ b/src/app/shared/model/base.model.spec.ts
@@ -67,12 +67,12 @@ describe('BaseModel', () => {
         return {foo: Observable.of('bar')};
       });
       base.init(null, null, false);
-      expect(base.related).not.toHaveBeenCalled();
+      expect(base.RELATIONS).toEqual(['foo']);
+      expect(base['foo']).toBeUndefined();
 
       base.init();
-      expect(base.related).toHaveBeenCalled();
-      expect(base['foo']).toEqual('bar');
       expect(base.RELATIONS).toEqual(['foo']);
+      expect(base['foo']).toEqual('bar');
     });
 
   });
@@ -334,7 +334,9 @@ describe('BaseModel', () => {
     });
 
     it('discards child models and removes new records', () => {
-      base.RELATIONS = ['foo'];
+      spyOn(base, 'related').and.callFake(() => {
+        return {foo: Observable.of('bar')};
+      });
       base['foo'] = [
         {id: 1, isNew: true, discard: () => true},
         {id: 2, isNew: true, discard: () => false},

--- a/src/app/shared/model/base.model.ts
+++ b/src/app/shared/model/base.model.ts
@@ -61,11 +61,16 @@ export abstract class BaseModel {
     }
   }
 
-  set(field: string, value: any) {
+  set(field: string, value: any, forceOriginal = false) {
     this[field] = value;
     if (this.SETABLE.indexOf(field) > -1) {
+      if (forceOriginal) {
+        this.original[field] = value;
+        this.changedFields[field] = false;
+      } else {
+        this.changedFields[field] = this.checkChanged(field, value);
+      }
       this.invalidFields[field] = this.invalidate(field, value);
-      this.changedFields[field] = this.checkChanged(field, value);
       this.store();
     }
   }
@@ -164,10 +169,10 @@ export abstract class BaseModel {
     this.lastStored = null;
     this.isDestroy = false;
     if (!this.doc && this.original) {
-     for (let key of Object.keys(this.original)) {
-       this[key] = this.original[key];
-     }
-   }
+      for (let key of Object.keys(this.original)) {
+        this[key] = this.original[key];
+      }
+    }
     this.init(this.parent, this.doc, false);
     this.getRelated().forEach(model => {
       if (model.discard() !== false && model.isNew) {

--- a/src/app/shared/wysiwyg/wysiwig.component.spec.ts
+++ b/src/app/shared/wysiwyg/wysiwig.component.spec.ts
@@ -1,7 +1,7 @@
 import { cit, create, By, stubPipe } from '../../../testing';
+import { MockHalDoc } from '../../../testing/mock.haldoc';
 import { WysiwygComponent } from './wysiwyg.component';
 import { StoryModel } from '../model/story.model';
-import { HalDoc } from '../../core/cms/haldoc';
 
 describe('WysiwygComponent', () => {
 
@@ -12,7 +12,7 @@ describe('WysiwygComponent', () => {
   cit('shows markdown formatted as html', (fix, el, comp) => {
     let initialState = {descriptionMd: '**bold text**'};
     comp.name = 'description';
-    comp.model = new StoryModel(undefined, new HalDoc(initialState, undefined), false);
+    comp.model = new StoryModel(undefined, new MockHalDoc(initialState, undefined), false);
     comp.content = comp.model[comp.name];
     comp.images = [];
     fix.detectChanges();
@@ -23,7 +23,7 @@ describe('WysiwygComponent', () => {
   cit('doesn\'t add empty links', (fix, el, comp) => {
     let initialState = {descriptionMd: 'initial state'};
     comp.name = 'description';
-    comp.model = new StoryModel(undefined, new HalDoc(initialState, undefined), false);
+    comp.model = new StoryModel(undefined, new MockHalDoc(initialState, undefined), false);
     comp.content = comp.model[comp.name];
     comp.images = [];
     fix.detectChanges();

--- a/src/testing/mock.haldoc.ts
+++ b/src/testing/mock.haldoc.ts
@@ -108,6 +108,7 @@ export class MockHalDoc extends HalDoc {
         sub.error(this.error(`Expected mocked object at ${rel} - got array`));
       } else if (this.MOCKS[rel]) {
         sub.next(this.MOCKS[rel]);
+        sub.complete();
       } else {
         sub.error(this.error(`Un-mocked request for rel ${rel}`));
       }
@@ -120,6 +121,7 @@ export class MockHalDoc extends HalDoc {
         sub.error(this.nonLoggingError(this.ERRORS[rel]));
       } else if (this.MOCKS[rel] && this.MOCKS[rel] instanceof Array) {
         sub.next(this.MOCKS[rel]);
+        sub.complete();
       } else if (this.MOCKS[rel]) {
         sub.error(this.error(`Expected mocked array at ${rel} - got object`));
       } else {

--- a/src/testing/mock.haldoc.ts
+++ b/src/testing/mock.haldoc.ts
@@ -101,33 +101,31 @@ export class MockHalDoc extends HalDoc {
   }
 
   follow(rel: string, params: {} = null): HalObservable<MockHalDoc> {
-    if (this.ERRORS[rel]) {
-      return <HalObservable<MockHalDoc>> this.nonLoggingError(this.ERRORS[rel]);
-    } else if (this.MOCKS[rel]) {
-      if (this.MOCKS[rel] instanceof Array) {
-        return <HalObservable<MockHalDoc>>
-          this.error(`Expected mocked object at ${rel} - got array`);
+    return Observable.create(sub => {
+      if (this.ERRORS[rel]) {
+        sub.error(this.nonLoggingError(this.ERRORS[rel]));
+      } else if (this.MOCKS[rel] && this.MOCKS[rel] instanceof Array) {
+        sub.error(this.error(`Expected mocked object at ${rel} - got array`));
+      } else if (this.MOCKS[rel]) {
+        sub.next(this.MOCKS[rel]);
       } else {
-        return <HalObservable<MockHalDoc>> Observable.of(this.MOCKS[rel]);
+        sub.error(this.error(`Un-mocked request for rel ${rel}`));
       }
-    } else {
-      return <HalObservable<MockHalDoc>> this.error(`Un-mocked request for rel ${rel}`);
-    }
+    });
   }
 
   followList(rel: string, params: {} = null): HalObservable<MockHalDoc[]> {
-    if (this.ERRORS[rel]) {
-      return <HalObservable<MockHalDoc[]>> this.nonLoggingError(this.ERRORS[rel]);
-    } else if (this.MOCKS[rel]) {
-      if (!(this.MOCKS[rel] instanceof Array)) {
-        return <HalObservable<MockHalDoc[]>>
-          this.error(`Expected mocked array at ${rel} - got object`);
+    return Observable.create(sub => {
+      if (this.ERRORS[rel]) {
+        sub.error(this.nonLoggingError(this.ERRORS[rel]));
+      } else if (this.MOCKS[rel] && this.MOCKS[rel] instanceof Array) {
+        sub.next(this.MOCKS[rel]);
+      } else if (this.MOCKS[rel]) {
+        sub.error(this.error(`Expected mocked array at ${rel} - got object`));
       } else {
-        return <HalObservable<MockHalDoc[]>> Observable.of(this.MOCKS[rel]);
+        sub.error(this.error(`Un-mocked request for rel ${rel}`));
       }
-    } else {
-      return <HalObservable<MockHalDoc[]>> this.error(`Un-mocked request for rel ${rel}`);
-    }
+    });
   }
 
   followLink(linkObj: any, params: any = {}): HalObservable<HalDoc> {


### PR DESCRIPTION
Use replay subjects to make a model's related arrays observable, so you can tell when they've loaded.  Also allows loading single relations, if you pass `loadRelated = false` in the constructor.

```
# to wait for all related models to load
story.loadRelated().subscribe(() => ...);

# to wait for a specific relation to load
story.loadRelated('versions').subscribe(() => ...);

# to force reloading a relation
story.loadRelated('versions', true).subscribe(() => ...);
```

Also allows force-setting a field, which will update the original value:

```
version.set('label', 'This will be original looking', true);
version.changed('label'); #false
```