### PR TITLE
Read-only custom podcast path

### DIFF
--- a/src/app/series/directives/series-podcast.component.css
+++ b/src/app/series/directives/series-podcast.component.css
@@ -3,24 +3,20 @@
   width: 250px;
   margin-right: 40px;
 }
-.feed-urls input {
+.feed-url input {
   min-width: 400px;
   padding: 10px 8px;
   color: #939393;
   background: #fff;
   margin-bottom: 4px;
 }
-.feed-urls button, .feed-urls .button {
+.feed-url button, .feed-url .button {
   padding-top: 9px;
   padding-bottom: 8px;
 }
-.feed-urls button {
+.feed-url button {
   background-color: #f59f51;
 }
-.feed-urls button:hover, .feed-urls button:focus {
+.feed-url button:hover, .feed-url button:focus {
   background-color: #e28b42;
-}
-
-.custom-path >>> input {
-  width: 160px;
 }

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -12,22 +12,11 @@
 
   <div *ngSwitchCase="'editing'">
 
-    <publish-fancy-field label="PRX Feeds" *ngIf="podcast?.id">
-      <div class="fancy-hint">There should really be some text here describing
-        exactly what these are and what you might do with them.</div>
-      <div class="feed-urls">
-        <publish-fancy-field label="Published Feed" small=1>
-          <input type="text" readonly [ngModel]="podcast?.publishedUrl" name="publishedUrl" #pubFeed/>
-          <button [publishCopyInput]="pubFeed">Copy</button>
-          <a class="button" target="_blank" rel="noopener" [href]="podcast?.publishedUrl">Open Link</a>
-        </publish-fancy-field>
-
-        <publish-fancy-field class="custom-path" label="Custom Path" textinput [model]="podcast" name="path" small=1>
-          <div class="fancy-hint">An optional custom folder name to use in your PRX published feed url.</div>
-          <span class="prefix">{{urlStart}}</span>
-          <span class="suffix">{{urlEnd}}</span>
-        </publish-fancy-field>
-      </div>
+    <publish-fancy-field label="PRX Feed" class="feed-url" *ngIf="podcast?.id">
+      <div class="fancy-hint">The public URL of your PRX podcast feed.</div>
+      <input type="text" readonly [ngModel]="podcast?.publishedUrl" name="publishedUrl" #pubFeed/>
+      <button [publishCopyInput]="pubFeed">Copy</button>
+      <a class="button" target="_blank" rel="noopener" [href]="podcast?.publishedUrl">Open Link</a>
     </publish-fancy-field>
 
     <publish-fancy-field label="Author Name" textinput [model]="podcast" name="authorName">

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -19,7 +19,6 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
   series: SeriesModel;
   distribution: DistributionModel;
   podcast: FeederPodcastModel;
-  previewUrl: string;
 
   constructor(tab: TabService) {
     this.tabSub = tab.model.subscribe(s => this.series = <SeriesModel> s);
@@ -64,7 +63,6 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
   setPodcast() {
     this.podcast = this.distribution.podcast;
     this.setSubCategories();
-    this.previewUrl = this.podcast.previewUrl;
   }
 
   createDistribution() {

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -86,22 +86,4 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
     }
   }
 
-  get urlStart() {
-    if (this.podcast) {
-      let parts = this.podcast.publishedUrl.split('/');
-      if (parts.length > 2) {
-        return parts.slice(0, parts.length - 2).join('/') + '/';
-      }
-    }
-  }
-
-  get urlEnd() {
-    if (this.podcast) {
-      let parts = this.podcast.publishedUrl.split('/');
-      if (parts.length > 2) {
-        return '/' + parts.slice(parts.length - 1).join('/');
-      }
-    }
-  }
-
 }

--- a/src/app/shared/model/feeder-podcast.model.spec.ts
+++ b/src/app/shared/model/feeder-podcast.model.spec.ts
@@ -53,14 +53,6 @@ describe('FeederPodcastModel', () => {
     expect(src.unstore).toHaveBeenCalled();
   });
 
-  it('updates the publishedUrl with changes to the custom path', () => {
-    let src = new FeederPodcastModel(series, dist);
-    src.publishedUrl = 'http://staging-f.prxu.org/doesnotsaythebestpodcast/feed-rss.xml';
-    src.set('path', 'the_best_podcast');
-    src.save();
-    expect(src.publishedUrl).toEqual('http://staging-f.prxu.org/the_best_podcast/feed-rss.xml');
-  });
-
   it('allows user to override account name for podcast', () => {
     let doc = authorDist.mock('some-feeder', {author: {name: 'Bar'}});
     let podcast = new FeederPodcastModel(series, dist, doc);

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -7,21 +7,18 @@ export class FeederPodcastModel extends BaseModel {
 
   // read-only
   id: number;
-  previewUrl: string;
   publishedUrl: string;
 
   // writeable
-  SETABLE = ['category', 'subCategory', 'explicit', 'path', 'link', 'newFeedUrl', 'authorName', 'publishedUrl'];
+  SETABLE = ['category', 'subCategory', 'explicit', 'link', 'newFeedUrl', 'authorName'];
   category: string = '';
   subCategory: string = '';
   explicit: string = '';
-  path: string = '';
   link: string = '';
   newFeedUrl: string = '';
   authorName: string = '';
 
   VALIDATORS = {
-    path: [TOKENY('Use letters, numbers and underscores only')],
     link: [REQUIRED(), URL('Not a valid URL')],
     newFeedUrl: [URL('Not a valid URL')]
   };
@@ -47,8 +44,7 @@ export class FeederPodcastModel extends BaseModel {
 
   decode() {
     this.id = this.doc['id'];
-    this.previewUrl = (this.doc.expand('self') || '').replace(/api\/v1\//, '');
-    this.publishedUrl = this.doc['publishedUrl'];
+    this.publishedUrl = this.doc['publishedUrl'] || '';
     this.explicit = this.doc['explicit'] || '';
     if (this.explicit) {
       this.explicit = this.explicit.charAt(0).toUpperCase() + this.explicit.slice(1);
@@ -61,11 +57,6 @@ export class FeederPodcastModel extends BaseModel {
       this.series.follow('prx:account').subscribe(account => this.authorName = account['name']);
     } else {
       this.authorName = '';
-    }
-    // pretend path was blank if it was just the podcast id
-    this.path = this.doc['path'] || '';
-    if (`${this.path}` === `${this.id}`) {
-      this.path = '';
     }
 
     // just ignore all but first category/subcategory
@@ -98,8 +89,6 @@ export class FeederPodcastModel extends BaseModel {
     if (this.authorName) {
       data.author = { name: this.authorName };
     }
-    // default path back to the id
-    data.path = this.path || this.id;
 
     // we can always send a categories array
     data.itunesCategories = [];
@@ -124,18 +113,6 @@ export class FeederPodcastModel extends BaseModel {
         model.set(fld, this[fld]);
       }
       this.unstore();
-    }
-  }
-
-  set(field: string, value: any) {
-    super.set(field, value);
-    if (field === 'path' && this.publishedUrl) {
-      let parts = this.publishedUrl.split('/');
-      if (parts.length > 2) {
-        parts[parts.length - 2] = this.path;
-      }
-      this.publishedUrl = parts.join('/');
-      this.set('publishedUrl', this.publishedUrl);
     }
   }
 


### PR DESCRIPTION
Per slack discussions... a podcast's custom/vanity path is no longer writeable.  If we want/need to change them from the ID to something more human-readable, we'll do it manually.

Also nukes `previewUrl` which is no longer used.