### PR TITLE
Allow 200 from PUT

### DIFF
--- a/src/app/core/cms/halremote.ts
+++ b/src/app/core/cms/halremote.ts
@@ -83,7 +83,7 @@ export class HalRemote {
       })
       .catch(res => Observable.of(res)) // don't throw http errors
       .flatMap(res => {
-        if (method === 'get' && res.status === 200) {
+        if ((method === 'get' || method === 'put') && res.status === 200) {
           return Observable.of(res.json());
         } else if (method === 'put' && res.status === 204) {
           return Observable.of(true);


### PR DESCRIPTION
CMS and Feeder may now return 200 (and a response body) from a PUT request.