### PR TITLE
support invalid on datepicker

### DIFF
--- a/src/app/shared/date/datepicker.component.css
+++ b/src/app/shared/date/datepicker.component.css
@@ -17,6 +17,10 @@ input.changed {
   outline: 5px auto #f09b4c;
 }
 
+input.invalid {
+  outline: 5px auto #e32;
+}
+
 .input-group-addon i {
   height: 20px;
   width: 20px;

--- a/src/app/shared/date/datepicker.component.ts
+++ b/src/app/shared/date/datepicker.component.ts
@@ -6,7 +6,8 @@ import * as moment from 'moment';
   selector: 'publish-datepicker',
   template: `
     <span class="input-group">
-      <input type="text" #datepicker [value]="formattedDate" [class.changed]="changed">
+      <input type="text" #datepicker [value]="formattedDate" 
+        [class.changed]="changed" [class.invalid]="invalid" (input)="setWhenValid($event.target.value)">
       <span class="input-group-addon" (click)="datepicker.click()"><i class="icon-calendar"></i></span>
     </span>
   `,
@@ -28,6 +29,19 @@ export class DatepickerComponent implements AfterViewInit {
       return moment(this.date.valueOf()).format(DatepickerComponent.FORMAT);
     } else {
       return '';
+    }
+  }
+
+  get invalid(): boolean {
+    return this.input.nativeElement.value.length > 0 &&
+      !moment(this.input.nativeElement.value, DatepickerComponent.FORMAT, true).isValid();
+  }
+
+  setWhenValid(value: string) {
+    if (moment(value, DatepickerComponent.FORMAT, true).isValid()) {
+      let date = new Date(value);
+      this.picker.setDate(date);
+      this.onDateChange.emit(this.picker.getDate());
     }
   }
 


### PR DESCRIPTION
If the user types into the input field (if you tab to it or select the text, you can type over it), the datepicker will highlight red if the date entered is invalid. If the date is valid, an event will be emitted to update the model. Uses moment parsing to determine date, so if month and day is typed, auto sets to current year, if just month, auto sets to the 1st of that month in the current year.