### PR TITLE
Use feeder for embed player

### DIFF
--- a/src/app/shared/model/story.model.ts
+++ b/src/app/shared/model/story.model.ts
@@ -182,8 +182,12 @@ export class StoryModel extends BaseModel implements HasUpload {
     return !this.doc || this.doc['appVersion'] === 'v4';
   }
 
-  isPublished(): boolean {
-    return this.publishedAt && (new Date().valueOf() >= this.publishedAt.valueOf());
+  isPublished(bufferSeconds = 0): boolean {
+    if (this.publishedAt) {
+      return new Date().valueOf() >= this.publishedAt.valueOf() + (bufferSeconds * 1000);
+    } else {
+      return false;
+    }
   }
 
   getSeriesDistribution(kind: string): Observable<HalDoc> {

--- a/src/app/shared/model/story.model.ts
+++ b/src/app/shared/model/story.model.ts
@@ -182,6 +182,10 @@ export class StoryModel extends BaseModel implements HasUpload {
     return !this.doc || this.doc['appVersion'] === 'v4';
   }
 
+  isPublished(): boolean {
+    return this.publishedAt && (new Date().valueOf() >= this.publishedAt.valueOf());
+  }
+
   getSeriesDistribution(kind: string): Observable<HalDoc> {
     if (this.parent && this.parent.count('prx:distributions')) {
       return this.parent.followItems('prx:distributions').map(dists => {

--- a/src/app/story/directives/player.component.css
+++ b/src/app/story/directives/player.component.css
@@ -1,54 +1,31 @@
 p {
   margin: 10px 0;
 }
-
-.embed-code {
-  margin: 0;
-  border: 0;
-  display: flex;
-  flex-flow: row nowrap;
-  justify-content: center;
-  align-items: flex-start;
-  align-content: flex-start;
-  width: 100%;
-}
-
-.embed-code input {
-  margin: 0;
-  border: 0;
-  height: 20px;
-  font-family: monospace;
-  flex-grow: 1;
-  flex-basis: 300px;
+publish-spinner {
   display: block;
-  outline: none;
-  background: white;
+  position: relative;
+  top: 50px;
 }
-
-.embed-code button {
-  height: 20px;
-  width: 60px;
-  flex-grow: 0;
-  flex-shrink: 0;
-  display: block;
-  margin: 0;
-  border: 0;
-  padding: 0 8px;
-  background: #368AA2;
-  color: white;
-  border-radius: 0;
-  border-top-right-radius: 3px;
-  border-bottom-right-radius: 3px;
-  cursor: pointer;
-  text-transform: uppercase;
-  outline: none;
-  text-align: center;
+input {
+  min-width: 400px;
+  padding: 10px 8px;
+  color: #939393;
+  background: #fff;
+  margin-bottom: 4px;
 }
-.embed-code button:hover {
-  color: #368AA2;
-  background: white;
-  border-left: 1px solid #368AA2;
+button, .button {
+  padding-top: 9px;
+  padding-bottom: 8px;
 }
-.embed-code button:active {
-  background: #ddd;
+button {
+  background-color: #f59f51;
+}
+button:hover, button:focus {
+  background-color: #e28b42;
+}
+p.error {
+  color: #e32;
+}
+p.error b {
+  font-weight: 600;
 }

--- a/src/app/story/directives/player.component.html
+++ b/src/app/story/directives/player.component.html
@@ -11,9 +11,10 @@
 
     <div *ngIf="previewUrl">
       <p *ngIf="previewingUnpublished" class="error">
-        <b>WARNING:</b> It looks like your story is not yet published.  This may
-        cause the embeddable player to look broken.  But this link/iframe will
-        not change, so feel free to copy it and check back once your story is published.
+        <b>WARNING:</b> It looks like your episode is not yet published, or very recently
+        published. The player below is only a preview of how it will appear after
+        your feed is updated with the new episode. Your copyable link/iframe will begin
+        to function as expected within a few minutes of publishing.
       </p>
 
       <iframe [src]='previewSafe' frameborder="0" height="200" width ="100%"></iframe>

--- a/src/app/story/directives/player.component.html
+++ b/src/app/story/directives/player.component.html
@@ -1,0 +1,32 @@
+<div *ngIf="story">
+
+  <publish-fancy-field label="Embeddable Player">
+    <div class="fancy-hint">
+      You can include this embeddable player on your website to play the audio for this clip directly.
+    </div>
+
+    <publish-spinner *ngIf="!previewUrl && !loadError"></publish-spinner>
+
+    <p *ngIf="loadError" class="error">{{loadError}}</p>
+
+    <div *ngIf="previewUrl">
+      <p *ngIf="previewingUnpublished" class="error">
+        <b>WARNING:</b> It looks like your story is not yet published.  This may
+        cause the embeddable player to look broken.  But this link/iframe will
+        not change, so feel free to copy it and check back once your story is published.
+      </p>
+
+      <iframe [src]='previewSafe' frameborder="0" height="200" width ="100%"></iframe>
+
+      <p>The link to your embed player</p>
+      <input type="text" readonly [ngModel]="copyUrl" #urlInput/>
+      <button [publishCopyInput]="urlInput">Copy</button>
+      <a class="button" target="_blank" rel="noopener" [href]="copyUrl">Open Link</a>
+      <p class="embed-iframe">An embeddable iframe</p>
+      <input type="text" readonly [ngModel]="copyIframe" #iframeInput/>
+      <button [publishCopyInput]="iframeInput">Copy</button>
+    </div>
+
+  </publish-fancy-field>
+
+</div>

--- a/src/app/story/directives/player.component.spec.ts
+++ b/src/app/story/directives/player.component.spec.ts
@@ -27,6 +27,7 @@ describe('PlayerComponent', () => {
   });
 
   cit('loads data from cms', (fix, el, comp) => {
+    story['_links'] = {alternate: {href: 'http://the-alt-href'}};
     story.mockItems('prx:images', [{
       status: 'complete',
       _links: {enclosure: {href: 'http://the-image-href'}}
@@ -42,7 +43,7 @@ describe('PlayerComponent', () => {
     expect(comp.subtitle).toEqual('ExistingSeriesTitle');
     expect(comp.audioUrl).toEqual('http://the-audio-href');
     expect(comp.imageUrl).toEqual('http://the-image-href');
-    // expect(comp.subscriptionUrl).toEqual('TODO');
+    expect(comp.subscriptionUrl).toEqual('http://the-alt-href');
   });
 
   cit('has defaults for cms data', (fix, el, comp) => {
@@ -75,6 +76,14 @@ describe('PlayerComponent', () => {
     storyDists[0].mock('http://some-where/episode', {guid: 'the-guid'});
     comp.fromFeeder(new StoryModel(series, story), new DistributionModel(series, dist));
     expect(comp.loadError).toMatch(/unable to find the public URL/);
+  });
+
+  cit('warns when using defaults for cms data', (fix, el, comp) => {
+    tabModel.next(new StoryModel(series, story));
+    expect(comp.audioUrl).toMatch(/s3\.amazonaws\.com/);
+    expect(comp.imageUrl).toMatch(/s3\.amazonaws\.com/);
+    fix.detectChanges();
+    expect(el).toContainText('no audio or image');
   });
 
 });

--- a/src/app/story/directives/player.component.spec.ts
+++ b/src/app/story/directives/player.component.spec.ts
@@ -1,0 +1,80 @@
+import { cit, create, provide, cms } from '../../../testing';
+import { Subject } from 'rxjs';
+import { PlayerComponent } from './player.component';
+import { StoryModel, DistributionModel, TabService } from '../../shared';
+
+describe('PlayerComponent', () => {
+
+  create(PlayerComponent);
+
+  let tabModel = new Subject<StoryModel>();
+  provide(TabService, {model: tabModel});
+
+  let series, story;
+  beforeEach(() => {
+    series = cms.mock('prx:series', {title: 'ExistingSeriesTitle'});
+    story = series.mock('prx:story', {title: 'ExistingStoryTitle'});
+    story.mockItems('prx:images', []);
+    story.mockItems('prx:audio-versions', []);
+  });
+
+  cit('uses feeder for series with a podcast distribution', (fix, el, comp) => {
+    tabModel.next(new StoryModel(series, story));
+    expect(comp.shouldUseFeeder).toEqual(false);
+    series.mockItems('prx:distributions', [{kind: 'podcast'}]);
+    tabModel.next(new StoryModel(series, story));
+    expect(comp.shouldUseFeeder).toEqual(true);
+  });
+
+  cit('loads data from cms', (fix, el, comp) => {
+    story.mockItems('prx:images', [{
+      status: 'complete',
+      _links: {enclosure: {href: 'http://the-image-href'}}
+    }]);
+    let versions = story.mockItems('prx:audio-versions', [{}]);
+    versions[0].mockItems('prx:audio', [{
+      status: 'complete',
+      _links: {enclosure: {href: 'http://the-audio-href'}}
+    }]);
+
+    comp.fromStory(new StoryModel(series, story));
+    expect(comp.title).toEqual('ExistingStoryTitle');
+    expect(comp.subtitle).toEqual('ExistingSeriesTitle');
+    expect(comp.audioUrl).toEqual('http://the-audio-href');
+    expect(comp.imageUrl).toEqual('http://the-image-href');
+    // expect(comp.subscriptionUrl).toEqual('TODO');
+  });
+
+  cit('has defaults for cms data', (fix, el, comp) => {
+    comp.fromStory(new StoryModel(series, story));
+    expect(comp.audioUrl).toMatch(/s3\.amazonaws\.com/);
+    expect(comp.imageUrl).toMatch(/s3\.amazonaws\.com/);
+    expect(comp.subscriptionUrl).toMatch(/prx\.org/);
+  });
+
+  cit('loads data from feeder', (fix, el, comp) => {
+    let dist = series.mock('prx:distribution', {kind: 'podcast', url: 'http://some-where'});
+    dist.mock('http://some-where', {publishedUrl: 'http://published-url'});
+    let storyDists = story.mockItems('prx:distributions', [{kind: 'episode', url: 'http://some-where/episode'}]);
+    storyDists[0].mock('http://some-where/episode', {guid: 'episode1'});
+    comp.fromFeeder(new StoryModel(series, story), new DistributionModel(series, dist));
+    expect(comp.feedUrl).toEqual('http://published-url');
+    expect(comp.episodeGuid).toEqual('episode1');
+  });
+
+  cit('handles feeder load errors', (fix, el, comp) => {
+    let dist = series.mock('prx:distribution', {kind: 'foobar'});
+    comp.fromFeeder(new StoryModel(series, story), new DistributionModel(series, dist));
+    expect(comp.loadError).toMatch(/no podcast episode set/);
+
+    let storyDists = story.mockItems('prx:distributions', [{kind: 'episode', url: 'http://some-where/episode'}]);
+    storyDists[0].mock('http://some-where/episode', {guid: null});
+    comp.fromFeeder(new StoryModel(series, story), new DistributionModel(series, dist));
+    expect(comp.loadError).toMatch(/unable to find the guid/);
+
+    storyDists[0].mock('http://some-where/episode', {guid: 'the-guid'});
+    comp.fromFeeder(new StoryModel(series, story), new DistributionModel(series, dist));
+    expect(comp.loadError).toMatch(/unable to find the public URL/);
+  });
+
+});

--- a/src/app/story/directives/player.component.ts
+++ b/src/app/story/directives/player.component.ts
@@ -61,7 +61,7 @@ export class PlayerComponent implements OnDestroy, DoCheck {
       this.buildPlayer(false, false);
     }
     if (this.shouldUseFeeder === true && hasFeederParams) {
-      if (this.story.isPublished()) {
+      if (this.story.isPublished(60)) {
         this.previewingUnpublished = false;
         this.buildPlayer(true, true);
       } else {

--- a/src/app/story/story.component.spec.ts
+++ b/src/app/story/story.component.spec.ts
@@ -21,12 +21,12 @@ describe('StoryComponent', () => {
   });
   beforeEach(() => modalAlertTitle = null);
 
-  let auth;
+  let auth, series, story;
   beforeEach(() => {
     auth = cms.mock('prx:authorization', {});
     auth.mock('prx:default-account', {title: 'DefaultAccountTitle'});
-    auth.mock('prx:series', {title: 'ExistingSeriesTitle'});
-    let story = auth.mock('prx:story', {title: 'ExistingStoryTitle', appVersion: 'v4'});
+    series = auth.mock('prx:series', {title: 'ExistingSeriesTitle'});
+    story = auth.mock('prx:story', {title: 'ExistingStoryTitle', appVersion: 'v4'});
     story.mockItems('prx:audio-versions', []);
     story.mockItems('prx:images', []);
   });
@@ -84,7 +84,7 @@ describe('StoryComponent', () => {
   describe('with a v3 story', () => {
 
     beforeEach(() => {
-      let story = auth.mock('prx:story', {title: 'SomeV3Story', appVersion: 'v3'});
+      story = auth.mock('prx:story', {title: 'SomeV3Story', appVersion: 'v3'});
       story.mockItems('prx:audio-versions', []);
       story.mockItems('prx:images', []);
     });
@@ -95,6 +95,38 @@ describe('StoryComponent', () => {
       expect(modalAlertTitle).toMatch(/cannot edit story/i);
     });
 
+  });
+
+  cit('shows the player tab for existing stories', (fix, el, comp) => {
+    activatedRoute.testParams = {};
+    fix.detectChanges();
+    expect(el).not.toContainText('Embeddable Player');
+    comp.id = 1234;
+    comp.showDistributionTabs();
+    fix.detectChanges();
+    expect(el).toContainText('Embeddable Player');
+  });
+
+  cit('shows the podcast distribution tab for existing stories', (fix, el, comp) => {
+    activatedRoute.testParams = {id: 1234};
+    story.mockItems('prx:distributions', [{kind: 'foobar'}]);
+    fix.detectChanges();
+    expect(el).not.toContainText('Podcast Distribution');
+    story.mockItems('prx:distributions', [{kind: 'foobar'}, {kind: 'episode'}]);
+    comp.loadStory();
+    fix.detectChanges();
+    expect(el).toContainText('Podcast Distribution');
+  });
+
+  cit('shows the podcast distribution tab for new stories', (fix, el, comp) => {
+    activatedRoute.testParams = {seriesId: 5678};
+    series.mockItems('prx:distributions', [{kind: 'foobar'}]);
+    fix.detectChanges();
+    expect(el).not.toContainText('Podcast Distribution');
+    series.mockItems('prx:distributions', [{kind: 'foobar'}, {kind: 'podcast'}]);
+    comp.loadStory();
+    fix.detectChanges();
+    expect(el).toContainText('Podcast Distribution');
   });
 
 });

--- a/src/app/story/story.component.ts
+++ b/src/app/story/story.component.ts
@@ -49,6 +49,7 @@ export class StoryComponent implements OnInit {
         this.base += `/${this.seriesId}`;
       }
       this.loadStory();
+      this.showDistributionTabs();
     });
   }
 
@@ -87,12 +88,12 @@ export class StoryComponent implements OnInit {
   }
 
   showDistributionTabs() {
-    if (this.story.isNew) {
-      this.distPlayer = false;
+    this.distPlayer = this.id ? true : false;
+    if (this.story && this.story.isNew) {
       this.story.getSeriesDistribution('podcast').subscribe(dist => {
         this.distPodcast = dist ? true : false;
       });
-    } else {
+    } else if (this.story) {
       this.story.loadRelated('distributions').subscribe(() => {
         let hasEpisode = this.story.distributions.some(d => d.kind === 'episode');
         this.distPodcast = hasEpisode;

--- a/src/app/story/story.component.ts
+++ b/src/app/story/story.component.ts
@@ -95,9 +95,7 @@ export class StoryComponent implements OnInit {
       });
     } else if (this.story) {
       this.story.loadRelated('distributions').subscribe(() => {
-        let hasEpisode = this.story.distributions.some(d => d.kind === 'episode');
-        this.distPodcast = hasEpisode;
-        this.distPlayer = hasEpisode;
+        this.distPodcast = this.story.distributions.some(d => d.kind === 'episode');
       });
     }
   }

--- a/src/testing/mock.haldoc.ts
+++ b/src/testing/mock.haldoc.ts
@@ -89,6 +89,8 @@ export class MockHalDoc extends HalDoc {
   has(rel: string, mustBeList = false): boolean {
     if (this.MOCKS[rel]) {
       return mustBeList ? (this.MOCKS[rel] instanceof Array) : true;
+    } else if (this['_links'] && this['_links'][rel]) {
+      return mustBeList ? (this['_links'][rel] instanceof Array) : true;
     } else {
       return false;
     }


### PR DESCRIPTION
Load embed player from different sources:

- [x] For published stories in feeder, use the feed-url + guid for the player
- [x] For unpublished stories that will eventually be in feeder, preview the player via query params, but still use the url/guid for the copyable link/iframe.  Displays an angry warning about what you're doing.
- [x] For stories not in feeder, just keep using the query params
- [x] Handle various distribution/podcast/episode load errors

Note that any changes to CMS will take a few seconds to propagate to feeder.  So it's fairly easy to get a broken embed player, if say, you just clicked the Publish button.

There are a couple feeder issues that will make this look not-entirely convincing at the moment, including: PRX/feeder.prx.org#177 and PRX/feeder.prx.org#181.