### PR TITLE
advanced field confirmation for new feed url

### DIFF
--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -65,12 +65,15 @@
       <div class="fancy-hint">A link to the homepage for your podcast.</div>
     </publish-fancy-field>
 
-    <publish-fancy-field label="New Feed Url" textinput [model]="podcast" name="newFeedUrl">
-      <div class="fancy-hint">Use this to manually change the URL where your podcast is located.</div>
-    </publish-fancy-field>
-
     <publish-fancy-field label="Podcast Audio" [select]="audioVersionOptions" [model]="distribution" name="versionTemplateUrl" required>
       <div class="fancy-hint">Select which audio version template should be used with your podcast.</div>
+    </publish-fancy-field>
+
+    <publish-fancy-field label="New Feed Url" textinput [model]="podcast" name="newFeedUrl" [advanced]="newFeedUrlConfirm">
+      <div class="fancy-hint">
+        If your podcast feed is moving, use this field to point to the new URL where your podcast is located.
+        The current feed should be maintained until all of your subscribers have migrated.
+      </div>
     </publish-fancy-field>
 
   </div>

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -69,7 +69,7 @@
       <div class="fancy-hint">Select which audio version template should be used with your podcast.</div>
     </publish-fancy-field>
 
-    <publish-fancy-field label="New Feed Url" textinput [model]="podcast" name="newFeedUrl" [advanced]="newFeedUrlConfirm">
+    <publish-fancy-field label="New Feed Url" textinput [model]="podcast" name="newFeedUrl" [advancedConfirm]="newFeedUrlConfirm">
       <div class="fancy-hint">
         If your podcast feed is moving, use this field to point to the new URL where your podcast is located.
         The current feed should be maintained until all of your subscribers have migrated.

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, DoCheck } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { SeriesModel, DistributionModel, FeederPodcastModel,
-         TabService, CATEGORIES, SUBCATEGORIES, AdvancedConfirmText } from '../../shared';
+         TabService, CATEGORIES, SUBCATEGORIES } from '../../shared';
 
 @Component({
   styleUrls: ['series-podcast.component.css'],
@@ -101,20 +101,18 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
     }
   }
 
-  resetNewFeedUrlOnCancel(confirm) {
-    if (!confirm) {
-      this.podcast.set('newFeedUrl', this.podcast.original['newFeedUrl']);
-    }
-  }
-
-  get newFeedUrlConfirm() {
+  get newFeedUrlConfirm(): string {
     if (this.podcast) {
-      return {
-        confirm: AdvancedConfirmText.newFeedUrl(
-          !this.podcast.isNew && !this.podcast.invalid('newFeedUrl') && this.podcast.changed('newFeedUrl'),
-          this.podcast.original['newFeedUrl'], this.podcast.newFeedUrl),
-        callback: this.resetNewFeedUrlOnCancel.bind(this)
-      };
+      let prompt = 'Are you sure you want to change New Feed URL';
+      if (this.podcast.original['newFeedUrl']) {
+        prompt += ` from "${this.podcast.original['newFeedUrl']}"`;
+      }
+      if (this.podcast.newFeedUrl) {
+        prompt += ` to "${this.podcast.newFeedUrl}"? This will point your subscribers to a new feed location.`;
+      } else {
+        prompt += '?';
+      }
+      return prompt;
     }
   }
 

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -110,7 +110,7 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
   get newFeedUrlConfirm() {
     if (this.podcast) {
       return {
-        confirm: AdvancedConfirmText.NEW_FEED_URL(
+        confirm: AdvancedConfirmText.newFeedUrl(
           !this.podcast.isNew && !this.podcast.invalid('newFeedUrl') && this.podcast.changed('newFeedUrl'),
           this.podcast.original['newFeedUrl'], this.podcast.newFeedUrl),
         callback: this.resetNewFeedUrlOnCancel.bind(this)

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnDestroy, DoCheck } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { SeriesModel, DistributionModel, FeederPodcastModel,
-         TabService, CATEGORIES, SUBCATEGORIES } from '../../shared';
+         TabService, CATEGORIES, SUBCATEGORIES, AdvancedConfirmText } from '../../shared';
 
 @Component({
   styleUrls: ['series-podcast.component.css'],
@@ -98,6 +98,23 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
     }
     if (this.podcast && this.subCategories.indexOf(this.podcast.subCategory) < 0) {
       this.podcast.set('subCategory', '');
+    }
+  }
+
+  resetNewFeedUrlOnCancel(confirm) {
+    if (!confirm) {
+      this.podcast.set('newFeedUrl', this.podcast.original['newFeedUrl']);
+    }
+  }
+
+  get newFeedUrlConfirm() {
+    if (this.podcast) {
+      return {
+        confirm: AdvancedConfirmText.NEW_FEED_URL(
+          !this.podcast.isNew && !this.podcast.invalid('newFeedUrl') && this.podcast.changed('newFeedUrl'),
+          this.podcast.original['newFeedUrl'], this.podcast.newFeedUrl),
+        callback: this.resetNewFeedUrlOnCancel.bind(this)
+      };
     }
   }
 

--- a/src/app/shared/form/advanced-confirm.directive.spec.ts
+++ b/src/app/shared/form/advanced-confirm.directive.spec.ts
@@ -4,7 +4,7 @@ import { ModalService } from '../../core';
 import { AdvancedConfirmDirective } from './advanced-confirm.directive';
 
 @Component({
-  template: '<input [publishAdvancedConfirm]="confirmText" [model]="model" [fieldName]="name"/>'
+  template: '<input [publishAdvancedConfirm]="confirmText" [advancedModel]="model" [advancedFieldName]="name"/>'
 })
 class MyComponent {
   confirmText: string;

--- a/src/app/shared/form/advanced-confirm.directive.spec.ts
+++ b/src/app/shared/form/advanced-confirm.directive.spec.ts
@@ -1,0 +1,47 @@
+import { cit, create, direct, provide, By } from '../../../testing';
+import { Component } from '@angular/core';
+import { ModalService } from '../../core';
+import { AdvancedConfirmDirective } from './advanced-confirm.directive';
+
+@Component({
+  template: '<input [publishAdvancedConfirm]="confirmText" [model]="model" [fieldName]="name"/>'
+})
+class MyComponent {
+  confirmText: string;
+  model: any;
+  fieldName: string;
+}
+const getDirective = (el): AdvancedConfirmDirective => {
+  let inputEl = el.query(By.directive(AdvancedConfirmDirective));
+  expect(inputEl).toBeDefined();
+  return inputEl.injector.get(AdvancedConfirmDirective);
+};
+
+describe('AdvancedConfirmDirective', () => {
+
+  create(MyComponent, false);
+
+  direct(AdvancedConfirmDirective);
+
+  let modalAlertMessage: any;
+  beforeEach(() => modalAlertMessage = null);
+  provide(ModalService, {
+    prompt: (title, message, callback) => modalAlertMessage = message
+  });
+
+  cit('forces user to confirm changes to advanced fields', (fix, el, comp) => {
+    comp.confirmText = 'some warning';
+    comp.model = {
+      isNew: false,
+      changed: () => true,
+      invalid: () => false
+    };
+    comp.fieldName = 'fieldName';
+    fix.detectChanges();
+
+    let advancedConfirm = getDirective(el);
+    advancedConfirm.onBlur();
+    expect(modalAlertMessage).toEqual(comp.confirmText);
+  });
+
+});

--- a/src/app/shared/form/advanced-confirm.directive.ts
+++ b/src/app/shared/form/advanced-confirm.directive.ts
@@ -17,7 +17,7 @@ export const AdvancedConfirmText = {
   }
 };
 
-interface AdvancedConfirm {
+export interface AdvancedConfirm {
   confirm: string;
   callback: Function;
 }

--- a/src/app/shared/form/advanced-confirm.directive.ts
+++ b/src/app/shared/form/advanced-confirm.directive.ts
@@ -1,40 +1,27 @@
-import { Directive, Input, HostListener, ElementRef } from '@angular/core';
+import { Directive, Input, HostListener } from '@angular/core';
 import { ModalService } from '../../core';
-
-export const AdvancedConfirmText = {
-  newFeedUrl: function (changed, originalValue, changedValue) {
-    if (changed) {
-      let prompt = "Are you sure you want to change New Feed URL";
-      if (originalValue) {
-        prompt += ` from "${originalValue}"`;
-      }
-      if (changedValue) {
-        prompt += ` to "${changedValue}"`;
-      }
-      prompt += '? This will point your subscribers to a new feed location.';
-      return prompt;
-    }
-  }
-};
-
-export interface AdvancedConfirm {
-  confirm: string;
-  callback: Function;
-}
+import { BaseModel } from '../model/base.model';
 
 @Directive({
   selector: '[publishAdvancedConfirm]'
 })
 
 export class AdvancedConfirmDirective implements Directive {
-  @Input() publishAdvancedConfirm: AdvancedConfirm;
+  @Input() fieldName: string;
+  @Input() model: BaseModel;
+  @Input('publishAdvancedConfirm') confirmText: string;
 
-  @HostListener('blur') onMouseEnter() {
-    if (this.publishAdvancedConfirm && this.publishAdvancedConfirm.confirm) {
-      this.modal.prompt('', this.publishAdvancedConfirm.confirm, this.publishAdvancedConfirm.callback);
+  @HostListener('blur') onBlur() {
+    if (this.confirmText && !this.model.isNew && !this.model.invalid(this.fieldName) && this.model.changed(this.fieldName)) {
+      this.modal.prompt('', this.confirmText, this.resetFieldOnCancel.bind(this));
     }
   }
 
-  constructor(private el: ElementRef,
-              private modal: ModalService) {}
+  constructor(private modal: ModalService) {}
+
+  resetFieldOnCancel(confirm) {
+    if (!confirm) {
+      this.model.set(this.fieldName, this.model.original[this.fieldName]);
+    }
+  }
 }

--- a/src/app/shared/form/advanced-confirm.directive.ts
+++ b/src/app/shared/form/advanced-confirm.directive.ts
@@ -1,0 +1,40 @@
+import { Directive, Input, HostListener, ElementRef } from '@angular/core';
+import { ModalService } from '../../core';
+
+export const AdvancedConfirmText = {
+  NEW_FEED_URL: function (changed, originalValue, changedValue) {
+    if (changed) {
+      let prompt = "Are you sure you want to change New Feed URL";
+      if (originalValue) {
+        prompt += ` from "${originalValue}"`;
+      }
+      if (changedValue) {
+        prompt += ` to "${changedValue}"`;
+      }
+      prompt += '? This will point your subscribers to a new feed location.';
+      return prompt;
+    }
+  }
+};
+
+interface AdvancedConfirm {
+  confirm: string;
+  callback: Function;
+}
+
+@Directive({
+  selector: '[publishAdvancedConfirm]'
+})
+
+export class AdvancedConfirmDirective implements Directive {
+  @Input() publishAdvancedConfirm: AdvancedConfirm;
+
+  @HostListener('blur') onMouseEnter() {
+    if (this.publishAdvancedConfirm && this.publishAdvancedConfirm.confirm) {
+      this.modal.prompt('', this.publishAdvancedConfirm.confirm, this.publishAdvancedConfirm.callback);
+    }
+  }
+
+  constructor(private el: ElementRef,
+              private modal: ModalService) {}
+}

--- a/src/app/shared/form/advanced-confirm.directive.ts
+++ b/src/app/shared/form/advanced-confirm.directive.ts
@@ -2,7 +2,7 @@ import { Directive, Input, HostListener, ElementRef } from '@angular/core';
 import { ModalService } from '../../core';
 
 export const AdvancedConfirmText = {
-  NEW_FEED_URL: function (changed, originalValue, changedValue) {
+  newFeedUrl: function (changed, originalValue, changedValue) {
     if (changed) {
       let prompt = "Are you sure you want to change New Feed URL";
       if (originalValue) {

--- a/src/app/shared/form/advanced-confirm.directive.ts
+++ b/src/app/shared/form/advanced-confirm.directive.ts
@@ -7,8 +7,8 @@ import { BaseModel } from '../model/base.model';
 })
 
 export class AdvancedConfirmDirective implements Directive {
-  @Input() fieldName: string;
-  @Input() model: BaseModel;
+  @Input('advancedFieldName') fieldName: string;
+  @Input('advancedModel') model: BaseModel;
   @Input('publishAdvancedConfirm') confirmText: string;
 
   @HostListener('blur') onBlur() {

--- a/src/app/shared/form/fancy-field.component.html
+++ b/src/app/shared/form/fancy-field.component.html
@@ -15,14 +15,18 @@
 
   <template [ngIf]="model">
     <ng-content select=".prefix"></ng-content>
-    <input *ngIf="type == 'textinput'" [id]="name" type="text" [publishAdvancedConfirm]="advanced"
-      [ngModel]="model[name]" (ngModelChange)="onChange($event)"/>
-    <input *ngIf="type == 'number'" [id]="name" type="number" [publishAdvancedConfirm]="advanced"
-      [ngModel]="model[name]" (ngModelChange)="onChange($event)"/>
-    <textarea *ngIf="type == 'textarea'" [id]="name" [publishAdvancedConfirm]="advanced"
+    <input *ngIf="type == 'textinput'" [id]="name" type="text"
+      [ngModel]="model[name]" (ngModelChange)="onChange($event)"
+      [publishAdvancedConfirm]="advancedConfirm" [fieldName]="name" [model]="model"/>
+    <input *ngIf="type == 'number'" [id]="name" type="number"
+      [ngModel]="model[name]" (ngModelChange)="onChange($event)"
+      [publishAdvancedConfirm]="advancedConfirm" [fieldName]="name" [model]="model"/>
+    <textarea *ngIf="type == 'textarea'" [id]="name"
+      [publishAdvancedConfirm]="advancedConfirm" [fieldName]="name" [model]="model"
       [(ngModel)]="model[name]" (ngModelChange)="onChange($event)"></textarea>
-    <select *ngIf="type == 'select'" [id]="name" [publishAdvancedConfirm]="advanced"
-      [(ngModel)]="model[name]" (ngModelChange)="onChange($event)">
+    <select *ngIf="type == 'select'" [id]="name"
+      [(ngModel)]="model[name]" (ngModelChange)="onChange($event)"
+      [publishAdvancedConfirm]="advancedConfirm" [fieldName]="name" [model]="model">
       <option *ngFor="let opt of select" [value]="opt[1]">{{opt[0]}}</option>
     </select>
     <ng-content select=".suffix"></ng-content>

--- a/src/app/shared/form/fancy-field.component.html
+++ b/src/app/shared/form/fancy-field.component.html
@@ -15,13 +15,13 @@
 
   <template [ngIf]="model">
     <ng-content select=".prefix"></ng-content>
-    <input *ngIf="type == 'textinput'" [id]="name" type="text"
+    <input *ngIf="type == 'textinput'" [id]="name" type="text" [publishAdvancedConfirm]="advanced"
       [ngModel]="model[name]" (ngModelChange)="onChange($event)"/>
-    <input *ngIf="type == 'number'" [id]="name" type="number"
+    <input *ngIf="type == 'number'" [id]="name" type="number" [publishAdvancedConfirm]="advanced"
       [ngModel]="model[name]" (ngModelChange)="onChange($event)"/>
-    <textarea *ngIf="type == 'textarea'" [id]="name"
+    <textarea *ngIf="type == 'textarea'" [id]="name" [publishAdvancedConfirm]="advanced"
       [(ngModel)]="model[name]" (ngModelChange)="onChange($event)"></textarea>
-    <select *ngIf="type == 'select'" [id]="name"
+    <select *ngIf="type == 'select'" [id]="name" [publishAdvancedConfirm]="advanced"
       [(ngModel)]="model[name]" (ngModelChange)="onChange($event)">
       <option *ngFor="let opt of select" [value]="opt[1]">{{opt[0]}}</option>
     </select>

--- a/src/app/shared/form/fancy-field.component.html
+++ b/src/app/shared/form/fancy-field.component.html
@@ -17,16 +17,16 @@
     <ng-content select=".prefix"></ng-content>
     <input *ngIf="type == 'textinput'" [id]="name" type="text"
       [ngModel]="model[name]" (ngModelChange)="onChange($event)"
-      [publishAdvancedConfirm]="advancedConfirm" [fieldName]="name" [model]="model"/>
+      [publishAdvancedConfirm]="advancedConfirm" [advancedFieldName]="name" [advancedModel]="model"/>
     <input *ngIf="type == 'number'" [id]="name" type="number"
       [ngModel]="model[name]" (ngModelChange)="onChange($event)"
-      [publishAdvancedConfirm]="advancedConfirm" [fieldName]="name" [model]="model"/>
+      [publishAdvancedConfirm]="advancedConfirm" [advancedFieldName]="name" [advancedModel]="model"/>
     <textarea *ngIf="type == 'textarea'" [id]="name"
-      [publishAdvancedConfirm]="advancedConfirm" [fieldName]="name" [model]="model"
+      [publishAdvancedConfirm]="advancedConfirm" [advancedFieldName]="name" [advancedModel]="model"
       [(ngModel)]="model[name]" (ngModelChange)="onChange($event)"></textarea>
     <select *ngIf="type == 'select'" [id]="name"
       [(ngModel)]="model[name]" (ngModelChange)="onChange($event)"
-      [publishAdvancedConfirm]="advancedConfirm" [fieldName]="name" [model]="model">
+      [publishAdvancedConfirm]="advancedConfirm" [advancedFieldName]="name" [advancedModel]="model">
       <option *ngFor="let opt of select" [value]="opt[1]">{{opt[0]}}</option>
     </select>
     <ng-content select=".suffix"></ng-content>

--- a/src/app/shared/form/fancy-field.component.ts
+++ b/src/app/shared/form/fancy-field.component.ts
@@ -21,6 +21,7 @@ export class FancyFieldComponent {
   @Input() label: string;
   @Input() invalidlabel: string;
   @Input() hideinvalid: boolean;
+  @Input() advanced: string;
 
   // Form field types (intercepted with defaults)
   type: string;

--- a/src/app/shared/form/fancy-field.component.ts
+++ b/src/app/shared/form/fancy-field.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { BaseModel } from '../model/base.model';
+import { AdvancedConfirm } from './advanced-confirm.directive';
 
 const isset = (val: any): boolean => val !== false && val !== undefined;
 
@@ -21,7 +22,7 @@ export class FancyFieldComponent {
   @Input() label: string;
   @Input() invalidlabel: string;
   @Input() hideinvalid: boolean;
-  @Input() advanced: string;
+  @Input() advanced: AdvancedConfirm;
 
   // Form field types (intercepted with defaults)
   type: string;

--- a/src/app/shared/form/fancy-field.component.ts
+++ b/src/app/shared/form/fancy-field.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { BaseModel } from '../model/base.model';
-import { AdvancedConfirm } from './advanced-confirm.directive';
 
 const isset = (val: any): boolean => val !== false && val !== undefined;
 
@@ -22,7 +21,7 @@ export class FancyFieldComponent {
   @Input() label: string;
   @Input() invalidlabel: string;
   @Input() hideinvalid: boolean;
-  @Input() advanced: AdvancedConfirm;
+  @Input() advancedConfirm: string;
 
   // Form field types (intercepted with defaults)
   type: string;

--- a/src/app/shared/form/index.ts
+++ b/src/app/shared/form/index.ts
@@ -1,3 +1,4 @@
+export * from './advanced-confirm.directive';
 export * from './button.component';
 export * from './capitalize.pipe';
 export * from './copy-input.directive';

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -5,7 +5,7 @@ import { RouterModule } from '@angular/router';
 
 import { DatepickerComponent, TimeAgoPipe, TimepickerComponent } from './date';
 import { DurationPipe, FileSelectDirective, FileSizePipe } from './file';
-import { ButtonComponent, CapitalizePipe, CopyInputDirective, FancyFieldComponent } from './form';
+import { AdvancedConfirmDirective, ButtonComponent, CapitalizePipe, CopyInputDirective, FancyFieldComponent } from './form';
 import { AuthGuard, DeactivateGuard, UnauthGuard } from './guard';
 import { HeroComponent } from './hero';
 import { ImageFileComponent, ImageLoaderComponent, ImageUploadComponent } from './image';
@@ -16,6 +16,7 @@ import { FocusDirective, WysiwygComponent } from './wysiwyg';
 
 @NgModule({
   declarations: [
+    AdvancedConfirmDirective,
     ButtonComponent,
     CapitalizePipe,
     CopyInputDirective,
@@ -39,6 +40,7 @@ import { FocusDirective, WysiwygComponent } from './wysiwyg';
     WysiwygComponent
   ],
   exports: [
+    AdvancedConfirmDirective,
     CommonModule,
     FormsModule,
     ButtonComponent,


### PR DESCRIPTION
#256 and #240 
If the new feed url is changed to a value that passes validation on a not new podcast, the user will be prompted to confirm the change. If the user clicks Cancel, the change is reverted.