### PR TITLE
defaults podcast homepage link to beta url

### DIFF
--- a/src/app/shared/model/distribution.model.spec.ts
+++ b/src/app/shared/model/distribution.model.spec.ts
@@ -6,6 +6,7 @@ describe('DistributionModel', () => {
   let podcastUrl = 'http://some.where/your/podcast/1234';
   let series = cms.mock('prx:series', {id: 'series1'});
   let account = series.mock('prx:account', {name: 'my account name'});
+  let alternate = series.mock('alternate', {href: 'http://linkto.beta'});
   let fooDist = series.mock('prx:distributions', {id: 'dist1', kind: 'foo'});
   let podDist = series.mock('prx:distributions', {id: 'dist2', kind: 'podcast', url: podcastUrl});
   let podcast = podDist.mock(podcastUrl, {id: 'pod1'});
@@ -35,6 +36,13 @@ describe('DistributionModel', () => {
     expect(dist.podcast).not.toBeNull();
     expect(dist.podcast.category).toEqual('');
     expect(dist.podcast.authorName).toEqual(account['name']);
+  });
+
+  it('defaults author and link for new podcasts', () => {
+    let dist = new DistributionModel(series, null, true);
+    expect(dist.podcast).not.toBeNull();
+    expect(dist.podcast.authorName).toEqual(account['name']);
+    expect(dist.podcast.link).toEqual(alternate['href']);
   });
 
   it('loads the feeder podcast on-demand only', () => {

--- a/src/app/shared/model/distribution.model.ts
+++ b/src/app/shared/model/distribution.model.ts
@@ -49,6 +49,9 @@ export class DistributionModel extends BaseModel {
         if (account && account['name']) {
           podmodel.set('authorName', account['name'], true);
         }
+        if (!podmodel.link) {
+          podmodel.set('link', this.parent.expand('alternate'), true);
+        }
         return podmodel;
       });
     }

--- a/src/testing/mock.haldoc.ts
+++ b/src/testing/mock.haldoc.ts
@@ -142,4 +142,18 @@ export class MockHalDoc extends HalDoc {
     return Observable.throw(new Error(msg));
   }
 
+  expand(rel: string, params: any = {}): string {
+    let link;
+    if (this.MOCKS) {
+      link = this.MOCKS[rel];
+    }
+    if (this['_links']) {
+      link = this['_links'][rel];
+    }
+    if (link && link instanceof Array) {
+      link = link[0];
+    }
+    return this.remote.expand(link, params);
+  }
+
 }


### PR DESCRIPTION
#239 To answer Genevieve's question, yes Homepage Link must be required because `<link>` is a required element for `<channel>` in the RSS feed. To ease the burden on users, when a new Podcast Distribution is created, the Homepage Link is defaulted to the series alternate link, which is a link to the series on beta. This default can be overridden by entering any valid URL.