### PR TITLE
Allow saving invalid unpublished stories

### DIFF
--- a/src/app/home/directives/home-series.component.ts
+++ b/src/app/home/directives/home-series.component.ts
@@ -14,7 +14,7 @@ import { StoryModel } from '../../shared';
     </header>
     <header *ngIf="!noseries">
       <a [routerLink]="['series', id]">
-        <publish-image [imageDoc]="logoDoc"></publish-image>
+        <publish-image [imageDoc]="series"></publish-image>
       </a>
       <p class="count">
         <span *ngIf="count === 0">0 Episodes</span>
@@ -39,7 +39,6 @@ export class HomeSeriesComponent implements OnInit {
   @Input() noseries: boolean;
   @Input() rows: number = 1;
 
-  logoDoc: HalDoc;
   count: number = -1;
   id: number;
   title: string;
@@ -63,7 +62,6 @@ export class HomeSeriesComponent implements OnInit {
     this.title = this.series['title'];
     this.count = this.series.count('prx:stories');
     this.updated = new Date(this.series['updatedAt']);
-    this.logoDoc = this.series;
 
     // how many stories to display? (plus 1 new/draft story)
     let total = this.series.count('prx:stories');
@@ -73,9 +71,9 @@ export class HomeSeriesComponent implements OnInit {
 
     this.series.followItems('prx:stories', {per: limit, filters: 'v4'}).subscribe((stories) => {
       this.storyLoaders = null;
-      this.stories = [new StoryModel(this.series, null, true)];
+      this.stories = [this.getDraftStory(this.series)];
       for (let story of stories) {
-        this.stories.push(new StoryModel(this.series, story, true));
+        this.stories.push(new StoryModel(this.series, story, false));
       }
     });
   }
@@ -94,12 +92,16 @@ export class HomeSeriesComponent implements OnInit {
       // parent result total is embedded in child total
       this.count = storyDocs.length ? storyDocs[0].total() : 0;
 
-      this.stories = [new StoryModel(accountDoc, null, true)];
+      this.stories = [this.getDraftStory()];
       for (let story of storyDocs) {
-        this.stories.push(new StoryModel(accountDoc, story, true));
+        this.stories.push(new StoryModel(accountDoc, story, false));
       }
       this.storyLoaders = null;
     });
+  }
+
+  private getDraftStory(series?: HalDoc) {
+    return new StoryModel(series, null, false);
   }
 
 }

--- a/src/app/home/directives/home-story.component.css
+++ b/src/app/home/directives/home-story.component.css
@@ -113,12 +113,12 @@ publish-image {
   text-transform: uppercase;
   line-height: 18px;
 }
+.status.new {
+  background-color: #61A85D;
+}
 .status.draft {
   background-color: #ffa500;
 }
-.status.unsaved {
+.status.scheduled {
   background-color: #368aa2;
-}
-.status.unpublished {
-  background-color: #ee4d3e;
 }

--- a/src/app/home/directives/home-story.component.spec.ts
+++ b/src/app/home/directives/home-story.component.spec.ts
@@ -8,10 +8,22 @@ describe('HomeStoryComponent', () => {
 
   stubPipe('duration');
 
-  cit('renders new story as draft', (fix, el, comp) => {
+  cit('renders new stories as new', (fix, el, comp) => {
     comp.story = {isNew: true, changed: () => true, images: []};
     fix.detectChanges();
+    expect(el).toContainText('New');
+  });
+
+  cit('renders unpublished stories as draft', (fix, el, comp) => {
+    comp.story = {isNew: false, publishedAt: null, changed: () => true, images: []};
+    fix.detectChanges();
     expect(el).toContainText('Draft');
+  });
+
+  cit('renders future published stories as scheduled', (fix, el, comp) => {
+    comp.story = {isNew: false, publishedAt: new Date(), isPublished: () => false, changed: () => true, images: []};
+    fix.detectChanges();
+    expect(el).toContainText('Scheduled');
   });
 
   cit('renders add story button when no draft changes', (fix, el, comp) => {

--- a/src/app/home/directives/home-story.component.spec.ts
+++ b/src/app/home/directives/home-story.component.spec.ts
@@ -8,6 +8,8 @@ describe('HomeStoryComponent', () => {
 
   stubPipe('duration');
 
+  stubPipe('date');
+
   cit('renders new stories as new', (fix, el, comp) => {
     comp.story = {isNew: true, changed: () => true, images: []};
     fix.detectChanges();

--- a/src/app/home/directives/home-story.component.ts
+++ b/src/app/home/directives/home-story.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { HalDoc } from '../../core';
 import { StoryModel } from '../../shared';
 
 @Component({
@@ -13,7 +14,7 @@ import { StoryModel } from '../../shared';
     </template>
     <template [ngIf]="!isPlusSign">
       <a [routerLink]="editLink">
-        <publish-image [src]="storyImage" ></publish-image>
+        <publish-image [imageDoc]="storyImage" ></publish-image>
       </a>
       <h2>
         <a *ngIf="storyTitle" [routerLink]="editLink">{{storyTitle}}</a>
@@ -30,20 +31,25 @@ export class HomeStoryComponent implements OnInit {
 
   @Input() story: StoryModel;
 
+  isPlusSign: boolean;
   editLink: any[];
 
-  storyId: number;
   storyTitle: string;
-  storyUpdated: Date;
+  storyDate: Date;
+  storyDuration: number;
+  storyImage: HalDoc;
 
   statusClass: string;
   statusText: string;
 
   ngOnInit() {
-    this.storyId = this.story.id;
-    this.storyTitle = this.story.title;
-    this.storyUpdated = this.story.lastStored || this.story.updatedAt;
+    this.isPlusSign = this.story.isNew && !this.story.changed();
+    this.setLink();
+    this.setStatus();
+    this.loadData();
+  }
 
+  setLink() {
     if (this.story.isNew) {
       this.editLink = ['story/new'];
       if (this.story.parent) {
@@ -52,41 +58,28 @@ export class HomeStoryComponent implements OnInit {
     } else {
       this.editLink = ['/story', this.story.id];
     }
+  }
 
+  setStatus() {
     if (this.story.isNew) {
+      this.statusClass = 'status new';
+      this.statusText = 'New';
+    } else if (!this.story.publishedAt) {
       this.statusClass = 'status draft';
       this.statusText = 'Draft';
-    } else if (this.story.changed()) {
-      this.statusClass = 'status unsaved';
-      this.statusText = 'Unsaved Changes';
-    } else if (!this.story.publishedAt) {
-      this.statusClass = 'status unpublished';
-      this.statusText = 'Private';
+    } else if (!this.story.isPublished()) {
+      this.statusClass = 'status scheduled';
+      this.statusText = 'Scheduled';
     }
   }
 
-  get isPlusSign(): boolean {
-    return this.story.isNew && !this.story.changed();
-  }
-
-  get storyDuration(): number {
-    let duration = 0;
-    if (this.story.versions && this.story.versions.length > 0) {
-      if (this.story.versions[0].files.length > 0) {
-        let nonDestroyedAudio = this.story.versions[0].files.filter((audio) => !audio.isDestroy);
-        if (nonDestroyedAudio && nonDestroyedAudio.length > 0) {
-          duration = nonDestroyedAudio.map((audio) => {
-            return audio['duration'] || 0;
-          }).reduce((prevDuration, currDuration) => {
-            return prevDuration + currDuration;
-          });
-        }
-      }
+  loadData() {
+    this.storyTitle = this.story.title;
+    this.storyDate = this.story.publishedAt || this.story.updatedAt || this.story.lastStored;
+    if (this.story.doc) {
+      this.storyDuration = this.story.doc['duration'] || 0;
+      this.storyImage = this.story.doc;
     }
-    return duration;
   }
 
-  get storyImage(): string {
-    return this.story.images.length > 0 ? this.story.images[0].enclosureHref : '';
-  }
 }

--- a/src/app/home/directives/home-story.component.ts
+++ b/src/app/home/directives/home-story.component.ts
@@ -21,7 +21,7 @@ import { StoryModel } from '../../shared';
         <a *ngIf="!storyTitle" [routerLink]="editLink">(Untitled)</a>
       </h2>
       <p class="duration">{{storyDuration | duration}}</p>
-      <p class="modified">{{storyUpdated | date:"MM/dd/yy"}}</p>
+      <p class="modified">{{storyDate | date:"MM/dd/yy"}}</p>
       <p *ngIf="statusClass" [class]="statusClass">{{statusText}}</p>
     </template>
   `
@@ -36,7 +36,7 @@ export class HomeStoryComponent implements OnInit {
 
   storyTitle: string;
   storyDate: Date;
-  storyDuration: number;
+  storyDuration: number = 0;
   storyImage: HalDoc;
 
   statusClass: string;

--- a/src/app/search/directives/story-card.component.css
+++ b/src/app/search/directives/story-card.component.css
@@ -33,8 +33,11 @@ publish-image  {
   text-transform: uppercase;
   line-height: 18px;
 }
-.status.unpublished {
-  background-color: #ee4d3e;
+.status.draft {
+  background-color: #ffa500;
+}
+.status.scheduled {
+  background-color: #368aa2;
 }
 
 .story-detail {
@@ -112,4 +115,3 @@ publish-text-overflow-fade >>> div:before {
   margin-top: 5px;
   margin-bottom: 10px;
 }
-

--- a/src/app/search/directives/story-card.component.ts
+++ b/src/app/search/directives/story-card.component.ts
@@ -18,7 +18,7 @@ import { StoryModel } from '../../shared';
       <section class="story-info">
         <span class="duration">{{storyDuration | duration}}</span>
         <span class="play-count"><i></i></span>
-        <span class="modified">{{storyUpdated | date:"MM/dd/yy"}}</span>
+        <span class="modified">{{storyDate | date:"MM/dd/yy"}}</span>
       </section>
     </section>
     <section class="story-tags">
@@ -41,7 +41,7 @@ export class StoryCardComponent implements OnInit {
   storyId: number;
   storyTitle: string;
   storyDuration: number;
-  storyUpdated: Date;
+  storyDate: Date;
   storyDescription: string;
   storyTags: string[];
   seriesTitle: string;
@@ -52,27 +52,11 @@ export class StoryCardComponent implements OnInit {
   ngOnInit() {
     this.storyId = this.story.id;
     this.storyTitle = this.story.title;
-    this.storyUpdated = this.story.lastStored || this.story.updatedAt;
+    this.storyDate = this.story.publishedAt || this.story.updatedAt || this.story.lastStored;
     this.storyDescription = this.story.shortDescription;
     this.storyTags = this.story.splitTags();
-
+    this.storyDuration = this.story.doc['duration'] || 0;
     this.editStoryLink = ['/story', this.story.id];
-
-    if (this.story.doc.has('prx:audio')) {
-      this.story.doc.followItems('prx:audio').subscribe((audios) => {
-        if (!audios || audios.length < 1) {
-          this.storyDuration = 0;
-        } else {
-          this.storyDuration = audios.map((audio) => {
-            return audio['duration'] || 0;
-          }).reduce((prevDuration, currDuration) => {
-            return prevDuration + currDuration;
-          });
-        }
-      });
-    } else {
-      this.storyDuration = 0;
-    }
 
     if (this.story.parent) {
       this.seriesTitle = this.story.parent['title'];
@@ -81,8 +65,11 @@ export class StoryCardComponent implements OnInit {
     }
 
     if (!this.story.publishedAt) {
-      this.statusClass = 'status unpublished';
-      this.statusText = 'Private';
+      this.statusClass = 'status draft';
+      this.statusText = 'Draft';
+    } else if (!this.story.isPublished()) {
+      this.statusClass = 'status scheduled';
+      this.statusText = 'Scheduled';
     }
   }
 

--- a/src/app/shared/form/fancy-field.component.ts
+++ b/src/app/shared/form/fancy-field.component.ts
@@ -22,6 +22,7 @@ export class FancyFieldComponent {
   @Input() invalidlabel: string;
   @Input() hideinvalid: boolean;
   @Input() advancedConfirm: string;
+  @Input() strict: boolean;
 
   // Form field types (intercepted with defaults)
   type: string;
@@ -64,7 +65,7 @@ export class FancyFieldComponent {
 
   get formattedInvalid(): string {
     if (this.invalidFieldName && this.model && this.hideinvalid === undefined) {
-      let msg = this.model.invalid(this.invalidFieldName);
+      let msg = this.model.invalid(this.invalidFieldName, this.strict);
       if (msg) {
         if (this.invalidFieldLabel) {
           msg = msg.replace(this.invalidFieldName, this.invalidFieldLabel);
@@ -82,7 +83,7 @@ export class FancyFieldComponent {
 
     // explicit changed/invalid inputs get different classes
     let changed = this.changedFieldName && this.model.changed(this.changedFieldName);
-    let invalid = this.invalidFieldName && this.model.invalid(this.invalidFieldName);
+    let invalid = this.invalidFieldName && this.model.invalid(this.invalidFieldName, this.strict);
     if (changed) {
       classes.push(this.name ? 'changed' : 'changed-explicit');
     }

--- a/src/app/shared/hero/hero.component.css
+++ b/src/app/shared/hero/hero.component.css
@@ -110,6 +110,14 @@
   border-color: rgba(97, 168, 93, 0);
   border-bottom-color: #61A85D;
 }
+.toolbar >>> .invalid-tip.publish {
+  color: #f59f51;
+  border-color: #f59f51;
+}
+.toolbar >>> .invalid-tip.publish:before {
+  border-color: rgba(97, 168, 93, 0);
+  border-bottom-color: #f59f51;
+}
 
 /**
  * Affixing

--- a/src/app/shared/image/image-upload.component.ts
+++ b/src/app/shared/image/image-upload.component.ts
@@ -35,6 +35,9 @@ export class ImageUploadComponent implements DoCheck {
   @Input() minHeight = 144;
   @Input() suggestSize: string;
 
+  // TODO: move size validations to model, to prevent saving an invalid image
+  @Input() strict: boolean;
+
   thumbnailHeight = '220px';
   imgError: string;
   reader: FileReader = new FileReader();

--- a/src/app/shared/model/base.model.ts
+++ b/src/app/shared/model/base.model.ts
@@ -144,7 +144,7 @@ export abstract class BaseModel {
 
   saveRelated(): Observable<boolean[]> {
     let relatedSavers: Observable<boolean>[] = this.getRelated().filter(model => {
-      return model.changed();
+      return model.isNew || model.changed();
     }).map(model => {
       if (model.isNew) {
         model.unstore(); // delete old storage key
@@ -213,7 +213,7 @@ export abstract class BaseModel {
     });
   }
 
-  invalid(field?: string | string[], strict = false): string {
+  invalid(field?: string | string[], strict = true): string {
     if (this.isDestroy) {
       return null; // don't care if it's invalid
     }

--- a/src/app/shared/model/base.model.ts
+++ b/src/app/shared/model/base.model.ts
@@ -5,8 +5,6 @@ import { BaseInvalid } from './invalid';
 interface ValidatorMap  { [key: string]: BaseInvalid[]; }
 interface RelatedMap    { [key: string]: Observable<any>; }
 interface RelatedLoader { [key: string]: Observable<BaseModel | BaseModel[]>; }
-interface InvalidMap    { [key: string]: string; }
-interface ChangedMap    { [key: string]: boolean; }
 
 /**
  * Base class for modeling/validating haldocs
@@ -24,8 +22,6 @@ export abstract class BaseModel {
 
   public SETABLE: string[] = [];
   public VALIDATORS: ValidatorMap = {};
-  public invalidFields: InvalidMap = {};
-  public changedFields: ChangedMap = {};
 
   public RELATIONS: string[] = [];
   private relatedReplays: RelatedLoader = {};
@@ -51,7 +47,6 @@ export abstract class BaseModel {
       this.original[f] = this[f];
     }
     this.restore();
-    this.revalidate();
 
     // setup cold observables for related models, and optionally preload them
     this.relatedLoaders = this.related();
@@ -64,13 +59,7 @@ export abstract class BaseModel {
   set(field: string, value: any, forceOriginal = false) {
     this[field] = value;
     if (this.SETABLE.indexOf(field) > -1) {
-      if (forceOriginal) {
-        this.original[field] = value;
-        this.changedFields[field] = false;
-      } else {
-        this.changedFields[field] = this.checkChanged(field, value);
-      }
-      this.invalidFields[field] = this.invalidate(field, value);
+      if (forceOriginal) { this.original[field] = value; }
       this.store();
     }
   }
@@ -97,10 +86,7 @@ export abstract class BaseModel {
     return saveMe.flatMap((doc?) => {
       this.unstore();
       this.lastStored = null;
-
-      // update haldoc reference (and mock the timestamp)
       if (doc) {
-        if (doc['updatedAt']) { doc['updatedAt'] = new Date(); }
         this.init(this.parent, doc, false);
       }
 
@@ -222,12 +208,12 @@ export abstract class BaseModel {
       if (this.RELATIONS.indexOf(f) > -1) {
         return this.getRelated(f).some(m => m.changed());
       } else {
-        return this.changedFields[f];
+        return this.original[f] !== this[f];
       }
     });
   }
 
-  invalid(field?: string | string[]): string {
+  invalid(field?: string | string[], strict = false): string {
     if (this.isDestroy) {
       return null; // don't care if it's invalid
     }
@@ -235,24 +221,29 @@ export abstract class BaseModel {
     let invalids: string[] = [];
     for (let f of fields) {
       if (f === 'self') {
-        invalids.push(this.invalidate('self', this));
-      } else if (this.RELATIONS.indexOf(f) < 0) {
-        invalids.push(this.invalidFields[f]);
+        invalids.push(this.invalidate('self', this, strict));
+      } else if (this.RELATIONS.indexOf(f) > -1) {
+        invalids.push(this.invalidate(f, this.getRelated(f), strict));
       } else {
-        invalids.push(this.invalidRelated(f));
+        invalids.push(this.invalidate(f, this[f], strict));
       }
     }
     return invalids.filter(i => i).join(', ') || null;
   }
 
-  invalidRelated(rel: string): string {
-    let models = this.getRelated(rel);
-    let invalidMsg = this.invalidate(rel, models);
-    if (invalidMsg) {
-      return invalidMsg; // fast-return first error
-    } else {
-      return models.map(m => m.invalid()).filter(i => i).join(', ') || null;
+  invalidate(field: string, value: any, strict: boolean): string {
+    let validators = this.VALIDATORS[field] || [];
+    for (let validator of validators) {
+      let invalidMsg = validator(field, value, strict, this);
+      if (invalidMsg) {
+        return invalidMsg;
+      }
     }
+    if (this.RELATIONS.indexOf(field) > -1) {
+      let models = <BaseModel[]> value;
+      return models.map(m => m.invalid(null, strict)).filter(i => i).join(', ') || null;
+    }
+    return null;
   }
 
   setableFields(only?: string | string[], includeRelations = true): string[] {
@@ -271,7 +262,7 @@ export abstract class BaseModel {
     this.lastStored = new Date();
     if (window && window.localStorage && this.key()) {
       let changed = {};
-      this.SETABLE.filter(f => this.changedFields[f]).forEach(f => changed[f] = this[f]);
+      this.SETABLE.filter(f => this.changed(f)).forEach(f => changed[f] = this[f]);
       if (Object.keys(changed).length > 0) {
         changed['lastStored'] = this.lastStored;
         window.localStorage.setItem(this.key(), JSON.stringify(changed));
@@ -310,28 +301,6 @@ export abstract class BaseModel {
     } else {
       return false;
     }
-  }
-
-  revalidate() {
-    for (let f of this.SETABLE) {
-      this.invalidFields[f] = this.invalidate(f, this[f]);
-      this.changedFields[f] = this.checkChanged(f, this[f]);
-    }
-  }
-
-  invalidate(field: string, value: any): string {
-    let validators = this.VALIDATORS[field] || [];
-    for (let validator of validators) {
-      let invalidMsg = validator(field, value);
-      if (invalidMsg) {
-        return invalidMsg;
-      }
-    }
-    return null;
-  }
-
-  checkChanged(field: string, value: any): boolean {
-    return this.original[field] !== value;
   }
 
   getRelated(rel?: string): BaseModel[] {

--- a/src/app/shared/model/feeder-episode.model.spec.ts
+++ b/src/app/shared/model/feeder-episode.model.spec.ts
@@ -28,12 +28,14 @@ describe('FeederEpisodeModel', () => {
   it('only validates guids for existing models', () => {
     let newEpisode = new FeederEpisodeModel(series, dist);
     expect(newEpisode.guid).toEqual('');
-    expect(newEpisode.invalid('guid')).toBeFalsy();
+    expect(newEpisode.invalid('guid', false)).toBeFalsy();
+    expect(newEpisode.invalid('guid', true)).toBeFalsy();
 
     let doc = cms.mock('some-episode', {id: 1234});
     let oldEpisode = new FeederEpisodeModel(series, dist, doc);
     expect(oldEpisode.guid).toEqual('');
-    expect(oldEpisode.invalid('guid')).toMatch(/guid is a required field/);
+    expect(oldEpisode.invalid('guid', false)).toBeFalsy();
+    expect(oldEpisode.invalid('guid', true)).toMatch(/guid is a required field/);
     oldEpisode.set('guid', '1234');
     expect(oldEpisode.invalid('guid')).toBeFalsy();
   });

--- a/src/app/shared/model/feeder-episode.model.ts
+++ b/src/app/shared/model/feeder-episode.model.ts
@@ -1,7 +1,7 @@
 import { Observable} from 'rxjs';
 import { HalDoc } from '../../core';
 import { BaseModel } from './base.model';
-import { REQUIRED } from './invalid';
+import { REQUIRED, UNLESS_NEW } from './invalid';
 
 export class FeederEpisodeModel extends BaseModel {
 
@@ -16,16 +16,11 @@ export class FeederEpisodeModel extends BaseModel {
   authorEmail: string = '';
 
   VALIDATORS = {
-    guid: [REQUIRED()]
+    guid: [UNLESS_NEW(REQUIRED())]
   };
 
   constructor(private series: HalDoc, distrib: HalDoc, episode?: HalDoc, loadRelated = true) {
     super();
-    this.VALIDATORS.guid = this.VALIDATORS.guid.map(validator => {
-      return (key: string, value: any) => {
-        return this.isNew ? null : validator(key, value);
-      };
-    });
     this.init(distrib, episode, loadRelated);
   }
 

--- a/src/app/shared/model/invalid/audio.invalid.spec.ts
+++ b/src/app/shared/model/invalid/audio.invalid.spec.ts
@@ -9,41 +9,46 @@ describe('AudioInvalid', () => {
       return data;
     };
 
-    it('defaults to at least one segment', () => {
+    it('strictly defaults to at least one segment', () => {
       let invalid = VERSION_TEMPLATED();
-      expect(invalid('', {files: []})).toMatch('upload at least 1 segment');
-      expect(invalid('', {files: [1]})).toBeNull();
+      expect(invalid('', {files: []}, false)).toBeNull();
+      expect(invalid('', {files: []}, true)).toMatch('upload at least 1 segment');
+      expect(invalid('', {files: [1]}, true)).toBeNull();
     });
 
-    it('checks segment count', () => {
+    it('strictly checks segment count', () => {
       let invalid = VERSION_TEMPLATED(build({}, 3));
-      expect(invalid('', {files: [1, 2]})).toMatch('upload 3 segment');
-      expect(invalid('', {files: [1, 2, 3]})).toBeNull();
+      expect(invalid('', {files: [1, 2]}, false)).toBeNull();
+      expect(invalid('', {files: [1, 2]}, true)).toMatch('upload 3 segment');
+      expect(invalid('', {files: [1, 2, 3]}, true)).toBeNull();
     });
 
     it('ignores destroyed segments', () => {
       let invalid = VERSION_TEMPLATED(build({}, 3));
       let f1: any = {}, f2: any = {}, f3: any = {};
-      expect(invalid('', {files: [f1, f2, f3]})).toBeNull();
+      expect(invalid('', {files: [f1, f2, f3]}, true)).toBeNull();
       f2.isDestroy = true;
-      expect(invalid('', {files: [f1, f2, f3]})).toMatch('upload 3 segment');
+      expect(invalid('', {files: [f1, f2, f3]}, true)).toMatch('upload 3 segment');
     });
 
-    it('waits for uploads', () => {
+    it('always waits for uploads', () => {
       let invalid = VERSION_TEMPLATED();
-      expect(invalid('', {files: [{}, {isUploading: true}]})).toMatch('wait for uploads');
+      expect(invalid('', {files: [{}, {isUploading: true}]}, true)).toMatch('wait for uploads');
+      expect(invalid('', {files: [{}, {isUploading: true}]}, false)).toMatch('wait for uploads');
     });
 
-    it('checks min duration', () => {
+    it('strictly checks min duration', () => {
       let invalid = VERSION_TEMPLATED(build({lengthMinimum: 10}));
-      expect(invalid('', {files: [{duration: 3}, {duration: 2}]})).toMatch('must be greater than 0:00:10');
-      expect(invalid('', {files: [{duration: 3}, {duration: 8}]})).toBeNull();
+      expect(invalid('', {files: [{duration: 3}, {duration: 2}]}, false)).toBeNull();
+      expect(invalid('', {files: [{duration: 3}, {duration: 2}]}, true)).toMatch('must be greater than 0:00:10');
+      expect(invalid('', {files: [{duration: 3}, {duration: 8}]}, true)).toBeNull();
     });
 
-    it('checks max duration', () => {
+    it('strictly checks max duration', () => {
       let invalid = VERSION_TEMPLATED(build({lengthMaximum: 10}));
-      expect(invalid('', {files: [{duration: 3}, {duration: 8}]})).toMatch('must be less than 0:00:10');
-      expect(invalid('', {files: [{duration: 3}, {duration: 2}]})).toBeNull();
+      expect(invalid('', {files: [{duration: 3}, {duration: 8}]}, false)).toBeNull();
+      expect(invalid('', {files: [{duration: 3}, {duration: 8}]}, true)).toMatch('must be less than 0:00:10');
+      expect(invalid('', {files: [{duration: 3}, {duration: 2}]}, true)).toBeNull();
     });
 
   });

--- a/src/app/shared/model/invalid/base.invalid.spec.ts
+++ b/src/app/shared/model/invalid/base.invalid.spec.ts
@@ -5,15 +5,20 @@ describe('BaseInvalid', () => {
   describe('REQUIRED', () => {
 
     it('checks for existence', () => {
-      expect(REQUIRED()('fldname', null)).toMatch('is a required field');
-      expect(REQUIRED()('fldname', false)).toMatch('is a required field');
-      expect(REQUIRED()('fldname', true)).toBeNull();
+      expect(REQUIRED()('fldname', null, true)).toMatch('is a required field');
+      expect(REQUIRED()('fldname', false, true)).toMatch('is a required field');
+      expect(REQUIRED()('fldname', true, true)).toBeNull();
     });
 
     it('checks for length', () => {
-      expect(REQUIRED()('fldname', [])).toMatch('is a required field');
-      expect(REQUIRED()('fldname', '')).toMatch('is a required field');
-      expect(REQUIRED()('fldname', [true])).toBeNull();
+      expect(REQUIRED()('fldname', [], true)).toMatch('is a required field');
+      expect(REQUIRED()('fldname', '', true)).toMatch('is a required field');
+      expect(REQUIRED()('fldname', [true], true)).toBeNull();
+    });
+
+    it('only runs when strict', () => {
+      expect(REQUIRED()('fldname', null, false)).toBeNull();
+      expect(REQUIRED()('fldname', null, true)).toMatch('is a required field');
     });
 
   });

--- a/src/app/shared/model/invalid/base.invalid.ts
+++ b/src/app/shared/model/invalid/base.invalid.ts
@@ -2,12 +2,22 @@
  * Model validations
  */
 export interface BaseInvalid {
-  (key: string, value: any): string;
+  (key: string, value: any, strict?: boolean, model?: any): string;
 }
 
-export const REQUIRED = (): BaseInvalid => {
-  return <BaseInvalid> (key: string, value: any) => {
-    if (!value || value.length < 1) {
+export const UNLESS_NEW = (validator: BaseInvalid) => {
+  return (key: string, value: any, strict?: boolean, model?: any) => {
+    if (model && model.isNew) {
+      return null;
+    } else {
+      return validator(key, value, strict, model);
+    }
+  };
+};
+
+export const REQUIRED = (beVeryStrict = false): BaseInvalid => {
+  return (key: string, value: any, strict: boolean) => {
+    if ((strict || beVeryStrict) && (!value || value.length < 1)) {
       return `${key} is a required field`;
     } else {
       return null;
@@ -16,7 +26,7 @@ export const REQUIRED = (): BaseInvalid => {
 };
 
 export const LENGTH = (minLength: number, maxLength?: number): BaseInvalid => {
-  return <BaseInvalid> (key: string, value: any) => {
+  return (key: string, value: any) => {
     if (minLength && value && (value.length < minLength)) {
       return `${key} is too short`;
     } else if (maxLength && value && (value.length > maxLength)) {
@@ -28,7 +38,7 @@ export const LENGTH = (minLength: number, maxLength?: number): BaseInvalid => {
 };
 
 export const IN = (list: any[]): BaseInvalid => {
-  return <BaseInvalid> (key: string, value: any) => {
+  return (key: string, value: any) => {
     if (list.indexOf(value) < 0) {
       return `${key} is not a valid value`;
     } else {
@@ -38,13 +48,13 @@ export const IN = (list: any[]): BaseInvalid => {
 };
 
 export const FALSEY = (msg: string): BaseInvalid => {
-  return <BaseInvalid> (key: string, value: any) => {
+  return (key: string, value: any) => {
     return value ? msg : null;
   };
 };
 
 export const TOKENY = (msg?: string): BaseInvalid => {
-  return <BaseInvalid> (key: string, value: any) => {
+  return (key: string, value: any) => {
     if (value && !value.match(/^[a-zA-Z0-9_]+$/)) {
       return msg || `${key} is not a valid token - use letters, numbers and underscores only`;
     } else {
@@ -56,7 +66,7 @@ export const TOKENY = (msg?: string): BaseInvalid => {
 // basic url matching ... not entirely accurate, but hopefully good enough
 const urlPattern = /(http|https):\/\/[\w-]+(\.[\w-]+)+([\w.,@?^=%&amp;:\/~+#-]*[\w@?^=%&amp;\/~+#-])?/;
 export const URL = (msg?: string): BaseInvalid => {
-  return <BaseInvalid> (key: string, value: any) => {
+  return (key: string, value: any) => {
     if (value && !value.match(urlPattern)) {
       return msg || `${key} is not a valid URL`;
     } else {

--- a/src/app/shared/model/invalid/template.invalid.spec.ts
+++ b/src/app/shared/model/invalid/template.invalid.spec.ts
@@ -6,8 +6,7 @@ describe('TemplateInvalid', () => {
   const buildModel = (min, max) => {
     model = {
       lengthMinimum: min,
-      lengthMaximum: max,
-      invalidFields: {lengthMinimum: null, lengthMaximum: null}
+      lengthMaximum: max
     };
     return model;
   };
@@ -44,7 +43,7 @@ describe('TemplateInvalid', () => {
     it('also validates the other column', () => {
       let invalid = build(null, -1);
       expect(invalid('lengthMinimum', null)).toMatch('Must set');
-      expect(model.invalidFields.lengthMaximum).toMatch('greater than 0');
+      expect(invalid('lengthMaximum', null)).toMatch('greater than 0');
     });
 
   });

--- a/src/app/shared/model/invalid/template.invalid.ts
+++ b/src/app/shared/model/invalid/template.invalid.ts
@@ -42,10 +42,10 @@ export const VERSION_LENGTH = (version?: AudioVersionTemplateModel): BaseInvalid
     let min = version.lengthMinimum;
     let max = version.lengthMaximum;
     if (key === 'lengthMinimum') {
-      version.invalidFields['lengthMaximum'] = checkMaximum(min, max);
+      // version.invalidFields['lengthMaximum'] = checkMaximum(min, max);
       return checkMinimum(min, max);
     } else if (key === 'lengthMaximum') {
-      version.invalidFields['lengthMinimum'] = checkMinimum(min, max);
+      // version.invalidFields['lengthMinimum'] = checkMinimum(min, max);
       return checkMaximum(min, max);
     }
   };
@@ -56,10 +56,10 @@ export const FILE_LENGTH = (file?: AudioFileTemplateModel): BaseInvalid => {
     let min = file.lengthMinimum;
     let max = file.lengthMaximum;
     if (key === 'lengthMinimum') {
-      file.invalidFields['lengthMaximum'] = checkMaximum(min, max);
+      // file.invalidFields['lengthMaximum'] = checkMaximum(min, max);
       return checkMinimum(min, max);
     } else if (key === 'lengthMaximum') {
-      file.invalidFields['lengthMinimum'] = checkMinimum(min, max);
+      // file.invalidFields['lengthMinimum'] = checkMinimum(min, max);
       return checkMaximum(min, max);
     }
   };

--- a/src/app/shared/model/invalid/template.invalid.ts
+++ b/src/app/shared/model/invalid/template.invalid.ts
@@ -42,10 +42,8 @@ export const VERSION_LENGTH = (version?: AudioVersionTemplateModel): BaseInvalid
     let min = version.lengthMinimum;
     let max = version.lengthMaximum;
     if (key === 'lengthMinimum') {
-      // version.invalidFields['lengthMaximum'] = checkMaximum(min, max);
       return checkMinimum(min, max);
     } else if (key === 'lengthMaximum') {
-      // version.invalidFields['lengthMinimum'] = checkMinimum(min, max);
       return checkMaximum(min, max);
     }
   };
@@ -56,10 +54,8 @@ export const FILE_LENGTH = (file?: AudioFileTemplateModel): BaseInvalid => {
     let min = file.lengthMinimum;
     let max = file.lengthMaximum;
     if (key === 'lengthMinimum') {
-      // file.invalidFields['lengthMaximum'] = checkMaximum(min, max);
       return checkMinimum(min, max);
     } else if (key === 'lengthMaximum') {
-      // file.invalidFields['lengthMinimum'] = checkMinimum(min, max);
       return checkMaximum(min, max);
     }
   };

--- a/src/app/shared/model/story.model.ts
+++ b/src/app/shared/model/story.model.ts
@@ -10,23 +10,22 @@ import { HasUpload, applyMixins } from './upload';
 export class StoryModel extends BaseModel implements HasUpload {
 
   public id: number;
-  public title: string;
-  public shortDescription: string;
-  public description: string;
-  public tags: string;
+  public title: string; // show changes
+  public shortDescription = '';
+  public description = '';
+  public tags = '';
   public updatedAt: Date;
   public publishedAt: Date;
   public releasedAt: Date;
   public versions: AudioVersionModel[] = [];
   public images: ImageModel[] = [];
-  public isPublishing: boolean;
   public account: HalDoc;
   public distributions: StoryDistributionModel[] = [];
 
   SETABLE = ['title', 'shortDescription', 'description', 'tags', 'hasUploadMap', 'releasedAt'];
 
   VALIDATORS = {
-    title:            [REQUIRED()],
+    title:            [REQUIRED(true)],
     shortDescription: [REQUIRED()],
     description:      [LENGTH(10, 4000)]
   };
@@ -140,17 +139,13 @@ export class StoryModel extends BaseModel implements HasUpload {
 
   setPublished(published: boolean): Observable<boolean> {
     if (!published && this.doc.has('prx:unpublish')) {
-      this.isPublishing = true;
       return this.doc.follow('prx:unpublish', {method: 'post'}).map(doc => {
         this.init(this.parent, doc, false);
-        this.isPublishing = false;
         return false;
       });
     } else if (published && this.doc.has('prx:publish')) {
-      this.isPublishing = true;
       return this.doc.follow('prx:publish', {method: 'post'}).map(doc => {
         this.init(this.parent, doc, false);
-        this.isPublishing = false;
         return true;
       });
     } else {

--- a/src/app/story/directives/basic.component.ts
+++ b/src/app/story/directives/basic.component.ts
@@ -7,11 +7,11 @@ import { StoryModel, TabService } from '../../shared';
   template: `
     <form *ngIf="story">
 
-      <publish-fancy-field [model]="story" textinput="true" name="title" label="Episode Title" required>
+      <publish-fancy-field textinput required [model]="story" name="title" label="Episode Title">
         <div class="fancy-hint">Write a short, Tweetable title. Think newspaper headline.</div>
       </publish-fancy-field>
 
-      <publish-fancy-field [model]="story" textinput="true" name="shortDescription" label="Teaser" required>
+      <publish-fancy-field textinput required [model]="story" name="shortDescription" label="Teaser" [strict]="strict">
         <div class="fancy-hint">Provide a short description for your episode listing.
         Think of this as a first impression for your listeners.</div>
       </publish-fancy-field>
@@ -24,9 +24,9 @@ import { StoryModel, TabService } from '../../shared';
 
       <hr/>
 
-      <publish-fancy-field label="Audio Files" required>
+      <publish-fancy-field required label="Audio Files">
         <publish-spinner *ngIf="!story?.versions"></publish-spinner>
-        <publish-upload *ngFor="let v of story?.versions" [version]="v"></publish-upload>
+        <publish-upload *ngFor="let v of story?.versions" [version]="v" [strict]="strict"></publish-upload>
         <h1 *ngIf="story?.versions?.length === 0">
           You have no audio templates for this episode. How did that happen?
         </h1>
@@ -34,12 +34,12 @@ import { StoryModel, TabService } from '../../shared';
 
       <publish-fancy-field label="Cover Image">
       <div class="fancy-hint">Provide an image for your episode, if desired.</div>
-        <publish-image-upload [model]="story" minWidth=1400 minHeight=1400></publish-image-upload>
+        <publish-image-upload [model]="story" minWidth=1400 minHeight=1400 [strict]="strict"></publish-image-upload>
       </publish-fancy-field>
 
       <hr/>
 
-      <publish-fancy-field [model]="story" textinput="true" name="tags" label="Categories">
+      <publish-fancy-field textinput [model]="story" name="tags" label="Categories" [strict]="strict">
         <div class="fancy-hint">A comma-separated list of tags relevant to the content of your episode.</div>
       </publish-fancy-field>
 
@@ -79,4 +79,9 @@ export class BasicComponent implements OnDestroy {
   get releasedAtChanged(): boolean {
     return this.story && this.story.changed('releasedAt', false);
   }
+
+  get strict(): boolean {
+    return (this.story && this.story.publishedAt) ? true : false;
+  }
+
 }

--- a/src/app/story/directives/hero.component.spec.ts
+++ b/src/app/story/directives/hero.component.spec.ts
@@ -1,0 +1,67 @@
+import { cit, create, provide, stubPipe } from '../../../testing';
+import { Router } from '@angular/router';
+import { RouterStub } from '../../../testing/stub.router';
+import { StoryHeroComponent } from './hero.component';
+
+describe('StoryHeroComponent', () => {
+
+  create(StoryHeroComponent);
+
+  provide(Router, RouterStub);
+
+  stubPipe('timeago');
+
+  cit('shows edit vs create state', (fix, el, comp) => {
+    expect(el).toContainText('Create Episode');
+    comp.id = 1234;
+    fix.detectChanges();
+    expect(el).toContainText('Edit Episode');
+  });
+
+  cit('unstrictly saves new stories', (fix, el, comp) => {
+    comp.story = {isNew: true,  invalid: () => 'bad'};
+    fix.detectChanges();
+    expect(el).toContainText('Create');
+    expect(el).toContainText('Invalid episode');
+    comp.story.invalid = (f, strict) => strict ? 'bad' : null;
+    fix.detectChanges();
+    expect(el).not.toContainText('Invalid episode');
+  });
+
+  cit('unstrictly saves unpublished stories', (fix, el, comp) => {
+    comp.story = {changed: () => null, invalid: () => 'bad'};
+    fix.detectChanges();
+    expect(el).toContainText('Save');
+    expect(el).toContainText('Invalid episode');
+    comp.story.invalid = (f, strict) => strict ? 'bad' : null;
+    fix.detectChanges();
+    expect(el).not.toContainText('Invalid episode');
+  });
+
+  cit('strictly allows publishing', (fix, el, comp) => {
+    comp.story = {changed: () => null, invalid: () => 'bad'};
+    fix.detectChanges();
+    expect(el).toContainText('Publish');
+    expect(el).toContainText('Not ready to publish');
+    comp.story.invalid = (f, strict) => strict ? 'bad' : null;
+    fix.detectChanges();
+    expect(el).toContainText('Not ready to publish');
+    comp.story.invalid = (f, strict) => null;
+    fix.detectChanges();
+    expect(el).not.toContainText('Not ready to publish');
+  });
+
+  cit('strictly saves published stories', (fix, el, comp) => {
+    comp.story = {publishedAt: new Date(), isPublished: () => null, changed: () => null, invalid: () => 'bad'};
+    fix.detectChanges();
+    expect(el).toContainText('Save');
+    expect(el).toContainText('Invalid episode');
+    comp.story.invalid = (f, strict) => strict ? 'bad' : null;
+    fix.detectChanges();
+    expect(el).toContainText('Invalid episode');
+    comp.story.invalid = (f, strict) => null;
+    fix.detectChanges();
+    expect(el).not.toContainText('Invalid Episode');
+  });
+
+});

--- a/src/app/story/directives/hero.component.ts
+++ b/src/app/story/directives/hero.component.ts
@@ -29,7 +29,7 @@ import { StoryModel } from '../../shared';
           (click)="discard()">Discard</publish-button>
 
         <template [ngIf]="stateNew">
-          <publish-button green [model]="story" [disabled]="normalInvalid"
+          <publish-button green=1 [model]="story" [disabled]="normalInvalid"
               visible=1 (click)="save()">Create
             <div *ngIf="normalInvalid" class="invalid-tip create">
               <h4>Invalid episode</h4>

--- a/src/app/story/directives/hero.component.ts
+++ b/src/app/story/directives/hero.component.ts
@@ -25,29 +25,44 @@ import { StoryModel } from '../../shared';
         <p *ngIf="story?.publishedAt">{{publishedOnText}}</p>
       </div>
       <div class="hero-actions" *ngIf="story">
+        <publish-button [model]="story" working=0 disabled=0 plain=1
+          (click)="discard()">Discard</publish-button>
 
-        <template [ngIf]="story.isNew">
-          <publish-button [model]="story" plain=1 working=0 disabled=0 (click)="discard()">Discard</publish-button>
-          <publish-button [model]="story" visible=1 green=1 (click)="save()">Create
-            <div *ngIf="story.invalid()" class="invalid-tip create">
+        <template [ngIf]="stateNew">
+          <publish-button green [model]="story" [disabled]="normalInvalid"
+              visible=1 (click)="save()">Create
+            <div *ngIf="normalInvalid" class="invalid-tip create">
               <h4>Invalid episode</h4>
+              <p>Add a title and resolve validation errors</p>
+            </div>
+          </publish-button>
+        </template>
+
+        <template [ngIf]="stateUnpublished">
+          <publish-button [model]="story" [disabled]="normalInvalid" (click)="save()">Save
+            <div *ngIf="normalInvalid" class="invalid-tip">
+              <h4>Invalid episode</h4>
+              <p>Resolve all validation errors</p>
+            </div>
+          </publish-button>
+          <publish-button [model]="story" [visible]="!story.changed()" [disabled]="strictInvalid"
+              [working]="isPublishing" (click)="togglePublish()" orange=1>Publish
+            <div *ngIf="strictInvalid" class="invalid-tip publish">
+              <h4>Not ready to publish</h4>
               <p>Fill out all required fields</p>
             </div>
           </publish-button>
         </template>
 
-        <template [ngIf]="!story.isNew">
-          <publish-button [model]="story" plain=1 working=0 disabled=0 (click)="discard()">Discard</publish-button>
-          <publish-button [model]="story" (click)="save()">Save
-            <div *ngIf="story.invalid()" class="invalid-tip">
-              <h4>Invalid changes</h4>
-              <p>Correct them before saving</p>
+        <template [ngIf]="statePublished">
+          <publish-button [model]="story" (click)="save()" [disabled]="strictInvalid">Save
+            <div *ngIf="strictInvalid" class="invalid-tip">
+              <h4>Invalid episode</h4>
+              <p>Resolve all validation errors</p>
             </div>
           </publish-button>
-          <publish-button [model]="story" [visible]="!story.changed()"
-             [working]="story.isPublishing" (click)="togglePublish()" orange=1>
-            {{story.publishedAt ? 'Unpublish' : 'Publish'}}
-          </publish-button>
+          <publish-button [model]="story" [visible]="!story.changed()" [working]="isPublishing"
+            (click)="togglePublish()" orange=1>Unpublish</publish-button>
         </template>
 
       </div>
@@ -55,14 +70,20 @@ import { StoryModel } from '../../shared';
     `
 })
 
-export class StoryHeroComponent implements OnInit, OnChanges {
+export class StoryHeroComponent implements OnInit, OnChanges, DoCheck {
 
   @Input() id: number;
   @Input() story: StoryModel;
 
   series: HalDoc;
 
-  now = new Date();
+  stateNew: boolean;
+  stateUnpublished: boolean;
+  statePublished: boolean;
+  isPublishing: boolean;
+
+  strictInvalid: string;
+  normalInvalid: string;
 
   constructor(private router: Router) {}
 
@@ -75,7 +96,13 @@ export class StoryHeroComponent implements OnInit, OnChanges {
   }
 
   ngDoCheck() {
-    this.now = new Date(); // expression changed after checked if new Date() in getter, but it does need to get updated on change cycles
+    if (this.story) {
+      this.stateNew = this.story.isNew;
+      this.stateUnpublished = !this.stateNew && !this.story.publishedAt;
+      this.statePublished = !this.stateNew && !this.stateUnpublished;
+      this.strictInvalid = this.story.invalid(null, true);
+      this.normalInvalid = this.story.invalid(null, false);
+    }
   }
 
   updateBanner() {
@@ -102,8 +129,9 @@ export class StoryHeroComponent implements OnInit, OnChanges {
   }
 
   togglePublish() {
+    this.isPublishing = true;
     this.story.setPublished(!this.story.publishedAt).subscribe(() => {
-      // nothing to do
+      this.isPublishing = false;
     });
   }
 
@@ -112,7 +140,7 @@ export class StoryHeroComponent implements OnInit, OnChanges {
   }
 
   get publishedOnText() {
-    if (this.now.valueOf() >= new Date(this.story.publishedAt.valueOf()).valueOf()) {
+    if (this.story.isPublished()) {
       return `Published on ${this.formatDatetime(this.story.publishedAt)}`;
     } else {
       return `Will be published on ${this.formatDatetime(this.story.publishedAt)}`;

--- a/src/app/upload/upload.component.ts
+++ b/src/app/upload/upload.component.ts
@@ -47,6 +47,7 @@ import { AudioVersionModel } from '../shared';
 export class UploadComponent implements OnInit, DoCheck {
 
   @Input() version: AudioVersionModel;
+  @Input() strict: boolean;
 
   versionDescription: string;
 
@@ -75,11 +76,11 @@ export class UploadComponent implements OnInit, DoCheck {
     this.invalidClass = false;
     this.invalidMessage = null;
     if (this.version) {
-      if (this.version.invalid('files')) {
+      if (this.version.invalid('files', this.strict)) {
         this.invalidClass = this.versionUploadedInvalid();
-      } else if (this.version.invalid('self') && this.version.changed()) {
+      } else if (this.version.invalid('self', this.strict) && this.version.changed()) {
         this.invalidClass = true;
-        this.invalidMessage = this.version.invalid('self');
+        this.invalidMessage = this.version.invalid('self', this.strict);
       } else if (this.version.changed('files')) {
         this.changedClass = !this.versionUndeletedHaveChanged();
       } else if (this.version.changed(null, false)) {
@@ -89,7 +90,7 @@ export class UploadComponent implements OnInit, DoCheck {
   }
 
   versionUploadedInvalid(): boolean {
-    return this.version.files.filter(f => !f.isUploading).some(f => !!f.invalid());
+    return this.version.files.filter(f => !f.isUploading).some(f => !!f.invalid(null, this.strict));
   }
 
   versionUndeletedHaveChanged(): boolean {


### PR DESCRIPTION
Loosens up story validations per #275.

- New or Unpublished stories can save with only a title.
  - Other fields/files/etc aren't required.  But if you enter a non-blank thing, it's going to be validated
- Publish button is disabled until strict validations pass
- Published stories disable the save button until strict validations pass

Also cleaned up the dashboard/search cards a bit, to make them load less data.  And to standardize on what sort of statuses we display in them.