### PR TITLE
Add public feed url to feeder podcast.

### DIFF
--- a/src/app/series/directives/series-podcast.component.css
+++ b/src/app/series/directives/series-podcast.component.css
@@ -4,11 +4,16 @@
   margin-right: 40px;
 }
 .prx-feed-url input, .feed-url input {
-  min-width: 400px;
   padding: 10px 8px;
   color: #939393;
   background: #fff;
   margin-bottom: 4px;
+}
+.prx-feed-url input {
+  width: 100%;
+}
+.feed-url input {
+  min-width: 400px;
 }
 .feed-url button, .feed-url .button {
   padding-top: 9px;

--- a/src/app/series/directives/series-podcast.component.css
+++ b/src/app/series/directives/series-podcast.component.css
@@ -3,7 +3,7 @@
   width: 250px;
   margin-right: 40px;
 }
-.feed-url input {
+.prx-feed-url input, .feed-url input {
   min-width: 400px;
   padding: 10px 8px;
   color: #939393;

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -17,13 +17,6 @@
 
   <div *ngSwitchCase="'editing'">
 
-    <publish-fancy-field label="PRX Feed" class="feed-url" *ngIf="!distribution.isNew">
-      <div class="fancy-hint">The public URL of your PRX podcast feed.</div>
-      <input type="text" readonly [ngModel]="podcast?.publishedUrl" name="publishedUrl" #pubFeed/>
-      <button [publishCopyInput]="pubFeed">Copy</button>
-      <a class="button" target="_blank" rel="noopener" [href]="podcast?.publishedUrl">Open Link</a>
-    </publish-fancy-field>
-
     <publish-fancy-field label="Author Information">
       <div class="fancy-hint">Set the author name and email to be associated with this podcast.</div>
       <div class="span-fields">
@@ -74,9 +67,33 @@
       <div class="fancy-hint">A link to the homepage for your podcast.</div>
     </publish-fancy-field>
 
-    <publish-fancy-field label="Public Feed Url" textinput [model]="podcast" name="publicFeedUrl">
-      <div class="fancy-hint">
-        If you already have a public url for your podcast feed (e.g., feedburner), enter it here.
+    <publish-fancy-field label="PRX Feed" class="prx-feed-url" *ngIf="!distribution.isNew">
+      <div class="fancy-hint" *ngIf="podcast?.hasPublicFeed">
+        The private url for your PRX podcast feed, providing the content for <a href="{{podcast.publicFeedUrl}}">your public feed</a>.
+      </div>
+      <div class="fancy-hint" *ngIf="!podcast?.hasPublicFeed">
+        The URL for your PRX podcast feed. It's encouraged for podcasters to use a  public proxy like feedburner (potentially with a custom domain)
+        for sharing with listeners. If you already have a public URL for your podcast feed, enter it in the next field, or feel free to
+        <a href="https://support.google.com/feedburner/answer/78475?hl=en" title="Feedburner Help">create one.</a>
+      </div>
+      <input type="text" readonly [ngModel]="podcast?.publishedUrl" name="publishedUrl"/>
+    </publish-fancy-field>
+
+    <publish-fancy-field label="Public Feed Url" class="feed-url">
+      <div *ngIf="podcast?.hasPublicFeed">
+        <div class="fancy-hint">
+          The public URL for your podcast feed. Feel free to share this URL with listeners. If you need to alter this URL, please
+          do so safely by using the New Feed Url field in the Advanced settings.
+        </div>
+        <input type="text" readonly [ngModel]="podcast?.publicFeedUrl" name="publicFeedUrl" #pubFeed/>
+        <button [publishCopyInput]="pubFeed">Copy</button>
+        <a class="button" target="_blank" rel="noopener" [href]="podcast?.publicFeedUrl">Open Link</a>
+      </div>
+      <div *ngIf="!podcast?.hasPublicFeed">
+        <div class="fancy-hint">
+          <input type="text" [ngModel]="podcast?.publicFeedUrl" name="publicFeedUrl"/>
+          If you already have a public url for your podcast feed (e.g., feedburner), enter it here.
+        </div>
       </div>
     </publish-fancy-field>
 

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -89,12 +89,11 @@
         <button [publishCopyInput]="pubFeed">Copy</button>
         <a class="button" target="_blank" rel="noopener" [href]="podcast?.publicFeedUrl">Open Link</a>
       </div>
-      <div *ngIf="!podcast?.hasPublicFeed">
+      <publish-fancy-field textinput [model]="podcast" name="publicFeedUrl" *ngIf="!podcast?.hasPublicFeed">
         <div class="fancy-hint">
-          <input type="text" [ngModel]="podcast?.publicFeedUrl" name="publicFeedUrl"/>
           If you already have a public url for your podcast feed (e.g., feedburner), enter it here.
         </div>
-      </div>
+      </publish-fancy-field>
     </publish-fancy-field>
 
     <publish-fancy-field label="New Feed Url" textinput [model]="podcast" name="newFeedUrl" [advancedConfirm]="newFeedUrlConfirm">

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -69,7 +69,7 @@
 
     <publish-fancy-field label="PRX Feed" class="prx-feed-url" *ngIf="!distribution.isNew">
       <div class="fancy-hint" *ngIf="podcast?.hasPublicFeed">
-        The private url for your PRX podcast feed, providing the content for <a href="{{podcast.publicFeedUrl}}">your public feed</a>.
+        The private URL for your PRX podcast feed, providing the content for <a href="{{podcast.publicFeedUrl}}">your public feed</a>.
       </div>
       <div class="fancy-hint" *ngIf="!podcast?.hasPublicFeed">
         The URL for your PRX podcast feed. It's encouraged for podcasters to use a  public proxy like feedburner (potentially with a custom domain)

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -66,12 +66,18 @@
       </div>
     </publish-fancy-field>
 
+    <publish-fancy-field label="Podcast Audio" [select]="audioVersionOptions" [model]="distribution" name="versionTemplateUrl" required>
+      <div class="fancy-hint">Select which audio template should be used with your podcast.</div>
+    </publish-fancy-field>
+
     <publish-fancy-field label="Homepage Link" required textinput [model]="podcast" name="link">
       <div class="fancy-hint">A link to the homepage for your podcast.</div>
     </publish-fancy-field>
 
-    <publish-fancy-field label="Podcast Audio" [select]="audioVersionOptions" [model]="distribution" name="versionTemplateUrl" required>
-      <div class="fancy-hint">Select which audio template should be used with your podcast.</div>
+    <publish-fancy-field label="Public Feed Url" textinput [model]="podcast" name="publicFeedUrl">
+      <div class="fancy-hint">
+        If you already have a public url for your podcast feed (e.g., feedburner), enter it here.
+      </div>
     </publish-fancy-field>
 
     <publish-fancy-field label="New Feed Url" textinput [model]="podcast" name="newFeedUrl" [advancedConfirm]="newFeedUrlConfirm">

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -17,16 +17,6 @@
 
   <div *ngSwitchCase="'editing'">
 
-    <publish-fancy-field label="Author Information">
-      <div class="fancy-hint">Set the author name and email to be associated with this podcast.</div>
-      <div class="span-fields">
-        <publish-fancy-field label="Name" textinput [model]="podcast" name="authorName" small=1>
-        </publish-fancy-field>
-        <publish-fancy-field label="Email" textinput [model]="podcast" name="authorEmail" small=1>
-        </publish-fancy-field>
-      </div>
-    </publish-fancy-field>
-
     <publish-fancy-field label="iTunes Categories" required=1>
       <div class="fancy-hint">Select the
         <a [href]="itunesCategoryDoc"
@@ -65,6 +55,16 @@
 
     <publish-fancy-field label="Homepage Link" required textinput [model]="podcast" name="link">
       <div class="fancy-hint">A link to the homepage for your podcast.</div>
+    </publish-fancy-field>
+
+    <publish-fancy-field label="Author Information">
+      <div class="fancy-hint">Set the author name and email to be associated with this podcast.</div>
+      <div class="span-fields">
+        <publish-fancy-field label="Name" textinput [model]="podcast" name="authorName" small=1>
+        </publish-fancy-field>
+        <publish-fancy-field label="Email" textinput [model]="podcast" name="authorEmail" small=1>
+        </publish-fancy-field>
+      </div>
     </publish-fancy-field>
 
     <publish-fancy-field label="PRX Feed" class="prx-feed-url" *ngIf="!distribution.isNew">

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -104,9 +104,9 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
 
   get newFeedUrlConfirm(): string {
     if (this.podcast) {
-      let prompt = 'Are you sure you want to change New Feed URL';
-      if (this.podcast.original['newFeedUrl']) {
-        prompt += ` from "${this.podcast.original['newFeedUrl']}"`;
+      let prompt = 'Are you sure you want to change your feed URL';
+      if (this.podcast.original['newFeedUrl'] || this.podcast['publicFeedUrl']) {
+        prompt += ` from "${this.podcast.original['newFeedUrl'] || this.podcast['publicFeedUrl']}"`;
       }
       if (this.podcast.newFeedUrl) {
         prompt += ` to "${this.podcast.newFeedUrl}"? This will point your subscribers to a new feed location.`;

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -24,7 +24,9 @@ export class FeederPodcastModel extends BaseModel {
 
   VALIDATORS = {
     link: [REQUIRED(), URL('Not a valid URL')],
-    newFeedUrl: [URL('Not a valid URL')]  };
+    newFeedUrl: [URL('Not a valid URL')],
+    publicFeedUrl: [URL('Not a valid URL')]
+  };
 
   constructor(private series: HalDoc, distrib: HalDoc, podcast?: HalDoc, loadRelated = true) {
     super();

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -10,12 +10,14 @@ export class FeederPodcastModel extends BaseModel {
   publishedUrl: string;
 
   // writeable
-  SETABLE = ['category', 'subCategory', 'explicit', 'link', 'newFeedUrl', 'authorName', 'authorEmail'];
+  SETABLE = ['category', 'subCategory', 'explicit', 'link', 'newFeedUrl', 'publicFeedUrl', 'authorName', 'authorEmail'];
+  URLS = ['link', 'newFeedUrl', 'publicFeedUrl'];
   category: string = '';
   subCategory: string = '';
   explicit: string = '';
   link: string = '';
   newFeedUrl: string = '';
+  publicFeedUrl: string = '';
   authorName: string = '';
   authorEmail: string = '';
 
@@ -51,6 +53,7 @@ export class FeederPodcastModel extends BaseModel {
     }
     this.link = this.doc['link'] || '';
     this.newFeedUrl = this.doc['newFeedUrl'] || '';
+    this.publicFeedUrl = this.doc['url'] || '';
     if (this.doc['author']) {
       if (this.doc['author']['name']) {
         this.authorName = this.doc['author']['name'];
@@ -85,6 +88,7 @@ export class FeederPodcastModel extends BaseModel {
     }
     data.link = this.link || null;
     data.newFeedUrl = this.newFeedUrl || null;
+    data.url = this.publicFeedUrl || null;
 
     if (this.authorName || this.authorEmail) {
       data.author = {
@@ -127,7 +131,7 @@ export class FeederPodcastModel extends BaseModel {
   }
 
   set(field: string, value: any, forceOriginal = false) {
-    if (['link', 'newFeedUrl'].indexOf(field) > -1) {
+    if (this.URLS.indexOf(field) > -1) {
       value = this.createLink(value);
     }
     super.set(field, value, forceOriginal);

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -20,6 +20,7 @@ export class FeederPodcastModel extends BaseModel {
   publicFeedUrl: string = '';
   authorName: string = '';
   authorEmail: string = '';
+  hasPublicFeed: boolean = false;
 
   VALIDATORS = {
     link: [REQUIRED(), URL('Not a valid URL')],
@@ -53,7 +54,10 @@ export class FeederPodcastModel extends BaseModel {
     }
     this.link = this.doc['link'] || '';
     this.newFeedUrl = this.doc['newFeedUrl'] || '';
-    this.publicFeedUrl = this.doc['url'] || '';
+    if (this.doc['url']) {
+      this.publicFeedUrl = this.doc['url'];
+      this.hasPublicFeed = true;
+    }
     if (this.doc['author']) {
       if (this.doc['author']['name']) {
         this.authorName = this.doc['author']['name'];

--- a/src/app/story/directives/player.component.ts
+++ b/src/app/story/directives/player.component.ts
@@ -105,8 +105,8 @@ export class PlayerComponent implements OnDestroy, DoCheck {
 
   fromFeeder(story: StoryModel, dist: DistributionModel) {
     dist.loadRelated('podcast').subscribe(() => {
-      if (dist.podcast && dist.podcast.publishedUrl) {
-        this.feedUrl = dist.podcast.publishedUrl;
+      if (dist.podcast && (dist.podcast.publicFeedUrl || dist.podcast.publishedUrl)) {
+        this.feedUrl = dist.podcast.publicFeedUrl || dist.podcast.publishedUrl;
       } else {
         this.loadError = 'Error - unable to find the public URL of your podcast!';
       }


### PR DESCRIPTION
Adds public feed URL to Feeder Podcast Model for #197, and makes player component use it if set. Reworks location + appearance of new feed url + PRX feed so they work more intuitively with the public feed URL field as well. 