### PR TITLE
discard changes before delete

### DIFF
--- a/src/app/series/series.component.ts
+++ b/src/app/series/series.component.ts
@@ -84,6 +84,9 @@ export class SeriesComponent implements OnInit {
       'Are you sure you want to delete this series? This action cannot be undone.',
       (okay: boolean) => {
         if (okay) {
+          if (this.series.changed()) {
+            this.discard();
+          }
           this.series.isDestroy = true;
           this.series.save().subscribe(() => {
             this.router.navigate(['/']);

--- a/src/app/story/story.component.ts
+++ b/src/app/story/story.component.ts
@@ -127,6 +127,9 @@ export class StoryComponent implements OnInit {
       'Are you sure you want to delete this episode?  This action cannot be undone.',
       (okay: boolean) => {
         if (okay) {
+          if (this.story.changed()) {
+            this.story.discard();
+          }
           this.story.isDestroy = true;
           this.story.save().subscribe(() => {
             this.router.navigate(['/']);


### PR DESCRIPTION
#279 Fixes deleting both episodes and series with unsaved related models. It used to be this bug was just on series, but it's on episodes now too. If you create an episode with just a title, then upload either an image or audio to it, do not Save, instead Delete the episode, you'll see an error because the related model isn't destroyed because it had changes pending. To address this issue, any changes on series or episodes are discarded before deletion.