### PR TITLE
Update Story Search options and appearance

### DIFF
--- a/src/app/search/directives/search-story-form.component.spec.ts
+++ b/src/app/search/directives/search-story-form.component.spec.ts
@@ -13,7 +13,7 @@ describe('SearchStoryFormComponent', () => {
     comp.model = new SearchStory();
     comp.model.fromRouteParams({tab: SearchComponent.TAB_STORIES});
     expect(comp.model.perPage).toEqual(12);
-    expect(comp.model.orderBy).toEqual('updated_at');
+    expect(comp.model.orderBy).toEqual('published_at');
     expect(comp.model.orderDesc).toBe(true);
   });
 

--- a/src/app/search/directives/series-card.component.ts
+++ b/src/app/search/directives/series-card.component.ts
@@ -15,7 +15,7 @@ import { SeriesModel } from '../../shared';
       <h2 class="series-title"><a [routerLink]="seriesLink">{{seriesTitle}}</a></h2>
       <p class="series-info">
         <span class="episode-count">{{seriesEpisodeCount}} Ep.</span>
-        <span class="updated-at">{{seriesUpdatedAt | date:"MM/dd/yy"}}</span>
+        <span class="updated-at">Updated {{seriesUpdatedAt | date:"MM/dd/yy"}}</span>
       </p>
     </section>
     <section class="series-detail">

--- a/src/app/search/directives/story-card.component.css
+++ b/src/app/search/directives/story-card.component.css
@@ -69,14 +69,14 @@ publish-image  {
   display: -ms-flexbox;
   display: flex;
 }
-.duration, .modified, .play-count {
+.duration, .published, .play-count {
   width: calc(100%/3);
 }
 .play-count {
   flex: 2 2 60px;
   white-space: nowrap;
 }
-.duration, .modified {
+.duration, .published {
   flex: 1 1 60px;
 }
 .play-count > i {

--- a/src/app/search/directives/story-card.component.css
+++ b/src/app/search/directives/story-card.component.css
@@ -70,9 +70,6 @@ publish-image  {
   display: flex;
   justify-content: space-between;
 }
-.play-count > i {
-  display: inline-block;
-}
 
 publish-text-overflow-fade {
   display: block;

--- a/src/app/search/directives/story-card.component.css
+++ b/src/app/search/directives/story-card.component.css
@@ -68,16 +68,7 @@ publish-image  {
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-}
-.duration, .published, .play-count {
-  width: calc(100%/3);
-}
-.play-count {
-  flex: 2 2 60px;
-  white-space: nowrap;
-}
-.duration, .published {
-  flex: 1 1 60px;
+  justify-content: space-between;
 }
 .play-count > i {
   display: inline-block;

--- a/src/app/search/directives/story-card.component.ts
+++ b/src/app/search/directives/story-card.component.ts
@@ -17,7 +17,7 @@ import { StoryModel } from '../../shared';
       <section class="story-info">
         <span class="duration">{{storyDuration | duration}}</span>
         <span class="play-count"><i></i></span>
-        <span class="modified">{{storyDate | date:"MM/dd/yy"}}</span>
+        <span class="published">{{storyDate | date:"MM/dd/yy"}}</span>
       </section>
     </section>
     <section class="story-tags">
@@ -51,7 +51,7 @@ export class StoryCardComponent implements OnInit {
   ngOnInit() {
     this.storyId = this.story.id;
     this.storyTitle = this.story.title;
-    this.storyDate = this.story.publishedAt || this.story.updatedAt || this.story.lastStored;
+    this.storyDate = this.story.publishedAt;
     this.storyDescription = this.story.shortDescription;
     this.storyTags = this.story.splitTags();
     this.storyDuration = this.story.doc['duration'] || 0;

--- a/src/app/search/directives/story-card.component.ts
+++ b/src/app/search/directives/story-card.component.ts
@@ -15,9 +15,8 @@ import { StoryModel } from '../../shared';
       <h3 class="series-title">{{seriesTitle}}</h3>
 
       <section class="story-info">
-        <span class="duration">{{storyDuration | duration}}</span>
-        <span class="play-count"><i></i></span>
-        <span class="published">{{storyDate | date:"MM/dd/yy"}}</span>
+        <span>{{storyDuration | duration}}</span>
+        <span>{{storyDate | date:"MM/dd/yy"}}</span>
       </section>
     </section>
     <section class="story-tags">

--- a/src/app/search/directives/story-card.component.ts
+++ b/src/app/search/directives/story-card.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
 
-import { HalDoc } from '../../core';
 import { StoryModel } from '../../shared';
 
 @Component({

--- a/src/app/search/search-story.model.ts
+++ b/src/app/search/search-story.model.ts
@@ -5,10 +5,6 @@ export class SearchStory {
       name: 'Episode Title'
     },
     {
-      id: 'updated_at',
-      name: 'Last Updated'
-    },
-    {
       id: 'published_at',
       name: 'When Published'
     }
@@ -26,7 +22,7 @@ export class SearchStory {
     this.perPage = params['perPage'] || 12;
     this.seriesId = params['seriesId'] ? +params['seriesId'] : undefined;
     this.text = params['text'];
-    this.orderBy = params['orderBy'] || 'updated_at';
+    this.orderBy = params['orderBy'] || 'published_at';
     this.orderDesc = params['orderDesc'] === 'true' || params['orderDesc'] === undefined;
   }
 }

--- a/src/app/search/search.component.ts
+++ b/src/app/search/search.component.ts
@@ -113,7 +113,7 @@ export class SearchComponent implements OnInit {
       sorts = this.searchStoryParams.orderBy + ':';
       sorts += this.searchStoryParams.orderDesc ? 'desc' : 'asc';
       if (this.searchStoryParams.orderBy === 'published_at') {
-        sorts += 'updated_at:';
+        sorts += ', updated_at:';
         sorts += this.searchStoryParams.orderDesc ? 'desc' : 'asc';
       }
     }

--- a/src/app/shared/model/audio-file-template.model.ts
+++ b/src/app/shared/model/audio-file-template.model.ts
@@ -1,7 +1,7 @@
 import { Observable} from 'rxjs';
 import { HalDoc } from '../../core';
 import { BaseModel } from './base.model';
-import { REQUIRED, FILE_LENGTH } from './invalid';
+import { REQUIRED, LENGTH, FILE_LENGTH } from './invalid';
 
 export class AudioFileTemplateModel extends BaseModel {
 
@@ -16,7 +16,7 @@ export class AudioFileTemplateModel extends BaseModel {
   SETABLE = ['position', 'label', 'lengthMinimum', 'lengthMaximum'];
 
   VALIDATORS = {
-    label: [REQUIRED()],
+    label: [REQUIRED(), LENGTH(1, 255)],
     lengthMinimum: [FILE_LENGTH(this)],
     lengthMaximum: [FILE_LENGTH(this)]
   };

--- a/src/app/shared/model/audio-file.model.ts
+++ b/src/app/shared/model/audio-file.model.ts
@@ -1,7 +1,7 @@
 import { Observable } from 'rxjs';
 import { HalDoc, Upload } from '../../core';
 import { UploadableModel } from './upload';
-import { REQUIRED, FILE_TEMPLATED } from './invalid';
+import { REQUIRED, LENGTH, FILE_TEMPLATED } from './invalid';
 
 export class AudioFileModel extends UploadableModel {
 
@@ -18,7 +18,7 @@ export class AudioFileModel extends UploadableModel {
   SETABLE = ['label', 'position', 'format', 'duration', 'bitrate', 'frequency'];
 
   VALIDATORS = {
-    label: [REQUIRED()],
+    label: [REQUIRED(), LENGTH(1, 255)],
     self: [FILE_TEMPLATED()]
   };
 

--- a/src/app/shared/model/audio-version-template.model.ts
+++ b/src/app/shared/model/audio-version-template.model.ts
@@ -1,7 +1,7 @@
 import { Observable} from 'rxjs';
 import { HalDoc } from '../../core';
 import { BaseModel } from './base.model';
-import { REQUIRED, VERSION_LENGTH } from './invalid';
+import { REQUIRED, LENGTH, VERSION_LENGTH } from './invalid';
 import { AudioFileTemplateModel } from './audio-file-template.model';
 
 export class AudioVersionTemplateModel extends BaseModel {
@@ -15,7 +15,7 @@ export class AudioVersionTemplateModel extends BaseModel {
   SETABLE = ['label', 'lengthMinimum', 'lengthMaximum'];
 
   VALIDATORS = {
-    label: [REQUIRED()],
+    label: [REQUIRED(), LENGTH(1, 255)],
     lengthMinimum: [VERSION_LENGTH(this)],
     lengthMaximum: [VERSION_LENGTH(this)]
   };

--- a/src/app/shared/model/audio-version.model.ts
+++ b/src/app/shared/model/audio-version.model.ts
@@ -2,7 +2,7 @@ import { Observable } from 'rxjs';
 import { HalDoc, Upload } from '../../core';
 import { BaseModel } from './base.model';
 import { AudioFileModel } from './audio-file.model';
-import { VERSION_TEMPLATED } from './invalid';
+import { VERSION_TEMPLATED, LENGTH, REQUIRED} from './invalid';
 import { HasUpload, applyMixins } from './upload';
 
 export class AudioVersionModel extends BaseModel implements HasUpload {
@@ -17,7 +17,8 @@ export class AudioVersionModel extends BaseModel implements HasUpload {
   SETABLE = ['label', 'explicit', 'hasUploadMap'];
 
   VALIDATORS = {
-    self: [VERSION_TEMPLATED()]
+    self: [VERSION_TEMPLATED()],
+    label: [REQUIRED(), LENGTH(1, 255)]
   };
 
   public series: HalDoc;

--- a/src/app/shared/model/series.model.ts
+++ b/src/app/shared/model/series.model.ts
@@ -23,7 +23,7 @@ export class SeriesModel extends BaseModel implements HasUpload {
   SETABLE = ['title', 'description', 'shortDescription', 'hasUploadMap'];
 
   VALIDATORS = {
-    title:            [REQUIRED()],
+    title:            [REQUIRED(), LENGTH(1, 255)],
     description:      [LENGTH(10)],
     shortDescription: [REQUIRED()]
   };

--- a/src/app/shared/model/story.model.ts
+++ b/src/app/shared/model/story.model.ts
@@ -25,7 +25,7 @@ export class StoryModel extends BaseModel implements HasUpload {
   SETABLE = ['title', 'shortDescription', 'description', 'tags', 'hasUploadMap', 'releasedAt'];
 
   VALIDATORS = {
-    title:            [REQUIRED(true)],
+    title:            [REQUIRED(true), LENGTH(1, 255)],
     shortDescription: [REQUIRED()],
     description:      [LENGTH(10, 4000)]
   };


### PR DESCRIPTION
#302: 
- [x] removes updated_at from Story search options and never displays it on story card
- [x] only shows `published_at` date on Story card (won't show a `released_at` for a saved but unpublished story)
- [x] reinstates Story's ability to filter by `published_at` by fixing typo
- [x] clarifies that the date you see on Series is indeed `updated_at`
- [x] refactors story card styling slightly

#303: 
- [x] adds max-length validations of 255 char to all fields that have column type string in CMS. 