### PR TITLE
Better duration picker

### DIFF
--- a/src/app/shared/form/fancy-duration.component.css
+++ b/src/app/shared/form/fancy-duration.component.css
@@ -1,6 +1,9 @@
 input {
   width: auto;
-  max-width: 50px;
+  max-width: 60px;
+  padding-left: 6px;
+  padding-right: 0;
+  text-align: center;
 }
 b {
   color: #343434;
@@ -14,6 +17,7 @@ b {
   margin-left: 16px;
 }
 .tiny input {
-  padding: 7px 0px 5px 4px;
-  max-width: 36px;
+  padding-top: 7px;
+  padding-bottom: 5px;
+  max-width: 44px;
 }

--- a/src/app/shared/form/fancy-duration.component.ts
+++ b/src/app/shared/form/fancy-duration.component.ts
@@ -18,12 +18,15 @@ import { BaseModel } from '../model/base.model';
       </template>
       <template [ngIf]="model">
         <input [id]="hoursName" type="number" min="0" [ngModel]="hours | padzero"
+          #hoursInput (click)="selectAllContent(hoursInput)"
           (ngModelChange)="set('hours', $event)" [class.changed]="hoursChanged"/>
         <b>:</b>
         <input [id]="minutesName" type="number" min="0" [ngModel]="minutes | padzero"
+          #minutesInput (click)="selectAllContent(minutesInput)"
           (ngModelChange)="set('minutes', $event)" [class.changed]="minutesChanged"/>
         <b>:</b>
         <input [id]="secondsName" type="number" min="0" [ngModel]="seconds | padzero"
+          #secondsInput (click)="selectAllContent(secondsInput)"
           (ngModelChange)="set('seconds', $event)" [class.changed]="secondsChanged"/>
       </template>
     </div>
@@ -78,6 +81,10 @@ export class FancyDurationComponent implements DoCheck {
     }
     let total = this.hours * 3600 + this.minutes * 60 + this.seconds;
     this.model.set(this.name, total || 0);
+  }
+
+  selectAllContent(input: HTMLInputElement) {
+    if (input.select) { input.select(); }
   }
 
 }

--- a/src/app/shared/form/padzero.pipe.spec.ts
+++ b/src/app/shared/form/padzero.pipe.spec.ts
@@ -11,8 +11,8 @@ describe('PadZeroPipe', () => {
     expect(pipe.transform(86739)).toMatch('86739');
   });
 
-  it('stringifies things it does not understand', () => {
-    expect(pipe.transform(<any> 'foobar')).toMatch('foobar');
+  it('stringifies non numbers', () => {
+    expect(pipe.transform(<any> 'foobar')).toMatch('NaN');
   });
 
 });

--- a/src/app/shared/form/padzero.pipe.ts
+++ b/src/app/shared/form/padzero.pipe.ts
@@ -5,12 +5,13 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class PadZeroPipe implements PipeTransform {
 
-  transform(value: number): string {
-    if (value < 10) {
-      return `0${value}`;
-    } else {
-      return `${value}`;
+  transform(value: any, length = 2): string {
+    let num = parseInt(value, 10);
+    let padded = `${num}`;
+    while (padded.length < length) {
+      padded = `0${padded}`;
     }
+    return padded;
   }
 
 }

--- a/src/app/shared/model/audio-file-template.model.ts
+++ b/src/app/shared/model/audio-file-template.model.ts
@@ -77,11 +77,4 @@ export class AudioFileTemplateModel extends BaseModel {
     }
   }
 
-  set(field: string, value: any, forceOriginal = false) {
-    super.set(field, value, forceOriginal);
-    if (field === 'lengthMinimum' && value >= this.lengthMaximum) {
-      super.set('lengthMaximum', value + 60);
-    }
-  }
-
 }

--- a/src/app/shared/model/audio-version-template.model.ts
+++ b/src/app/shared/model/audio-version-template.model.ts
@@ -54,8 +54,8 @@ export class AudioVersionTemplateModel extends BaseModel {
   decode() {
     this.id = this.doc['id'];
     this.label = this.doc['label'] || '';
-    this.lengthMinimum = this.doc['lengthMinimum'];
-    this.lengthMaximum = this.doc['lengthMaximum'];
+    this.lengthMinimum = this.doc['lengthMinimum'] || null;
+    this.lengthMaximum = this.doc['lengthMaximum'] || null;
   }
 
   encode(): {} {
@@ -75,13 +75,6 @@ export class AudioVersionTemplateModel extends BaseModel {
       return this.invalid('lengthMinimum') || this.invalid('lengthMaximum');
     } else {
       return super.invalid(field);
-    }
-  }
-
-  set(field: string, value: any, forceOriginal = false) {
-    super.set(field, value, forceOriginal);
-    if (field === 'lengthMinimum' && value >= this.lengthMaximum) {
-      super.set('lengthMaximum', value + 60);
     }
   }
 

--- a/src/app/shared/model/invalid/template.invalid.spec.ts
+++ b/src/app/shared/model/invalid/template.invalid.spec.ts
@@ -21,11 +21,11 @@ describe('TemplateInvalid', () => {
       expect(invalid('lengthMaximum', null)).toBeNull();
     });
 
-    it('requires both min and max', () => {
+    it('does not require both min and max', () => {
       let invalid = build(0, 4);
       expect(invalid('lengthMinimum', null)).toBeNull();
       invalid = build(4, 0);
-      expect(invalid('lengthMaximum', null)).toMatch('greater than minimum');
+      expect(invalid('lengthMaximum', null)).toBeNull();
     });
 
     it('checks for positive numbers', () => {

--- a/src/app/shared/model/invalid/template.invalid.ts
+++ b/src/app/shared/model/invalid/template.invalid.ts
@@ -6,13 +6,13 @@ import { BaseInvalid } from './base.invalid';
  * Audio version template length
  */
 const checkMinimum = (min, max): string => {
-  if (!min && !max) {
+  if (!min) {
     return null; // allow unset
   } else if (isNaN(parseInt(min, 10))) {
     return `Minimum is not a number`;
   } else if (min < 0) {
     return `Minimum must be a positive number`;
-  } else if (min >= max) {
+  } else if (max && min >= max) {
     return 'Minimum must be less than maximum';
   } else {
     return null;
@@ -20,13 +20,13 @@ const checkMinimum = (min, max): string => {
 };
 
 const checkMaximum = (min, max): string => {
-  if (!min && !max) {
+  if (!max) {
     return null; // allow unset
   } else if (isNaN(parseInt(max, 10))) {
     return `Maximum is not a number`;
   } else if (max < 0) {
     return `Maximum must be a positive number`;
-  } else if (max <= min) {
+  } else if (min && max <= min) {
     return 'Maximum must be greater than minimum';
   } else {
     return null;


### PR DESCRIPTION
Fixes #298.

- [x] Make number inputs lightly wider
- [x] Select all text on click
- [x] Handle strip leading zeroes off numbers
  - Mixed results on how this works in the browser.  If you type fast enough, or repeat characters, change detection doesn't seem to get a chance to update the field.  Ah well.  Good enough!
- [x] Allow 0 max value