### PR TITLE
Podcast template picker updates

### DIFF
--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -49,7 +49,8 @@
       </div>
     </publish-fancy-field>
 
-    <publish-fancy-field label="Podcast Audio" [select]="audioVersionOptions" [model]="distribution" name="versionTemplateUrl" required>
+    <publish-fancy-field required label="Podcast Audio" name="versionTemplateUrl"
+      [select]="audioVersionOptions" [model]="distribution" [advancedConfirm]="versionTemplateConfirm">
       <div class="fancy-hint">Select which audio template should be used with your podcast.</div>
     </publish-fancy-field>
 

--- a/src/app/series/directives/series-podcast.component.spec.ts
+++ b/src/app/series/directives/series-podcast.component.spec.ts
@@ -30,6 +30,13 @@ describe('SeriesPodcastComponent', () => {
     expect(el).not.toContainText('Create Podcast');
   });
 
+  cit('picks your only audio version template from the dropdown', (fix, el, comp) => {
+    comp.series = {loadRelated: () => Observable.of(null), distributions: []};
+    comp.audioVersionOptions = [['Something', 'some-href']];
+    comp.createDistribution();
+    expect(comp.distribution.versionTemplateUrl).toEqual('some-href');
+  });
+
   cit('finds podcast distributions for the series', (fix, el, comp) => {
     comp.series = {
       loadRelated: () => Observable.of(null),

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -17,6 +17,7 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
   itunesExplicitDoc = 'https://support.apple.com/en-us/HT202005';
   itunesCategoryDoc = 'https://help.apple.com/itc/podcasts_connect/#/itc9267a2f12';
   audioVersionOptions: string[][];
+  hasStories: boolean;
 
   tabSub: Subscription;
   state: string;
@@ -28,6 +29,7 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
   constructor(tab: TabService) {
     this.tabSub = tab.model.subscribe((s: SeriesModel) => {
       this.series = s;
+      this.hasStories = s.doc ? s.doc.count('prx:stories') > 0 : false;
       this.series.loadRelated('versionTemplates').subscribe(() => {
         let realTemplates = this.series.versionTemplates.filter(t => t.doc);
         this.audioVersionOptions = realTemplates.map(tpl => {
@@ -123,14 +125,13 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
   }
 
   get versionTemplateConfirm(): string {
-    if (this.distribution && this.audioVersionOptions) {
+    if (this.distribution && this.audioVersionOptions && this.hasStories) {
       let url = this.distribution.versionTemplateUrl;
       let match = this.audioVersionOptions.find(opt => opt[1] === url);
       let name = match ? match[0] : ''; // options are [[display, value]]
       return `
         Are you sure you want to use <b>${name}</b> as the audio for your podcast?
-        Changing this field can have catastrophic consequences for any previously
-        published episodes.
+        This will change the audio files used in all published episodes of your podcast.
       `;
     }
   }

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -122,4 +122,16 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
     }
   }
 
+  get versionTemplateConfirm(): string {
+    if (this.distribution && this.audioVersionOptions) {
+      let url = this.distribution.versionTemplateUrl;
+      let name = this.audioVersionOptions.find(opt => opt[1] === url)[0];
+      return `
+        Are you sure you want to use <b>${name}</b> as the audio for your podcast?
+        Changing this field can have catastrophic consequences for any previously
+        published episodes.
+      `;
+    }
+  }
+
 }

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -125,7 +125,8 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
   get versionTemplateConfirm(): string {
     if (this.distribution && this.audioVersionOptions) {
       let url = this.distribution.versionTemplateUrl;
-      let name = this.audioVersionOptions.find(opt => opt[1] === url)[0];
+      let match = this.audioVersionOptions.find(opt => opt[1] === url);
+      let name = match ? match[0] : ''; // options are [[display, value]]
       return `
         Are you sure you want to use <b>${name}</b> as the audio for your podcast?
         Changing this field can have catastrophic consequences for any previously

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -85,6 +85,11 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
     podcastDist.loadRelated('podcast').subscribe(() => {
       this.podcast = podcastDist.podcast;
     });
+    this.series.loadRelated('versionTemplates').subscribe(() => {
+      if (this.audioVersionOptions.length === 1) {
+        podcastDist.set('versionTemplateUrl', this.audioVersionOptions[0][1], true);
+      }
+    });
   }
 
   setSubCategories() {

--- a/src/app/shared/form/advanced-confirm.directive.ts
+++ b/src/app/shared/form/advanced-confirm.directive.ts
@@ -7,21 +7,33 @@ import { BaseModel } from '../model/base.model';
 })
 
 export class AdvancedConfirmDirective implements Directive {
-  @Input('advancedFieldName') fieldName: string;
-  @Input('advancedModel') model: BaseModel;
-  @Input('publishAdvancedConfirm') confirmText: string;
 
-  @HostListener('blur') onBlur() {
-    if (this.confirmText && !this.model.isNew && !this.model.invalid(this.fieldName) && this.model.changed(this.fieldName)) {
-      this.modal.prompt('', this.confirmText, this.resetFieldOnCancel.bind(this));
-    }
-  }
+  @Input() publishAdvancedConfirm: string;
+  @Input() publishModel: BaseModel;
+  @Input() publishName: string;
+  @Input() publishEvent = 'blur';
+
+  @HostListener('blur') onBlur() { return this.publishEvent === 'blur' && this.prompt(); }
+  @HostListener('change') onChange() { return this.publishEvent === 'change' && this.prompt(); }
 
   constructor(private modal: ModalService) {}
 
+  prompt(msg?: string) {
+    if (this.publishAdvancedConfirm && this.shouldConfirm()) {
+      this.modal.prompt('', this.publishAdvancedConfirm, this.resetFieldOnCancel.bind(this));
+    }
+  }
+
+  shouldConfirm(): boolean {
+    return (this.publishModel && this.publishName)
+      && !this.publishModel.isNew
+      && !this.publishModel.invalid(this.publishName)
+      && this.publishModel.changed(this.publishName);
+  }
+
   resetFieldOnCancel(confirm) {
     if (!confirm) {
-      this.model.set(this.fieldName, this.model.original[this.fieldName]);
+      this.publishModel.set(this.publishName, this.publishModel.original[this.publishName]);
     }
   }
 }

--- a/src/app/shared/form/fancy-field.component.html
+++ b/src/app/shared/form/fancy-field.component.html
@@ -17,16 +17,16 @@
     <ng-content select=".prefix"></ng-content>
     <input *ngIf="type == 'textinput'" [id]="name" type="text"
       [ngModel]="model[name]" (ngModelChange)="onChange($event)"
-      [publishAdvancedConfirm]="advancedConfirm" [advancedFieldName]="name" [advancedModel]="model"/>
+      [publishAdvancedConfirm]="advancedConfirm" [publishName]="name" [publishModel]="model"/>
     <input *ngIf="type == 'number'" [id]="name" type="number"
       [ngModel]="model[name]" (ngModelChange)="onChange($event)"
-      [publishAdvancedConfirm]="advancedConfirm" [advancedFieldName]="name" [advancedModel]="model"/>
+      [publishAdvancedConfirm]="advancedConfirm" [publishName]="name" [publishModel]="model"/>
     <textarea *ngIf="type == 'textarea'" [id]="name"
-      [publishAdvancedConfirm]="advancedConfirm" [advancedFieldName]="name" [advancedModel]="model"
+      [publishAdvancedConfirm]="advancedConfirm" [publishName]="name" [publishModel]="model"
       [(ngModel)]="model[name]" (ngModelChange)="onChange($event)"></textarea>
     <select *ngIf="type == 'select'" [id]="name"
-      [(ngModel)]="model[name]" (ngModelChange)="onChange($event)"
-      [publishAdvancedConfirm]="advancedConfirm" [advancedFieldName]="name" [advancedModel]="model">
+      [(ngModel)]="model[name]" (ngModelChange)="onChange($event)" publishEvent="change"
+      [publishAdvancedConfirm]="advancedConfirm" [publishName]="name" [publishModel]="model">
       <option *ngFor="let opt of select" [value]="opt[1]">{{opt[0]}}</option>
     </select>
     <ng-content select=".suffix"></ng-content>

--- a/src/app/shared/model/distribution.model.ts
+++ b/src/app/shared/model/distribution.model.ts
@@ -96,7 +96,7 @@ export class DistributionModel extends BaseModel {
   encode(): {} {
     let data = <any> {};
     data.kind = this.kind;
-    if (this.versionTemplateUrl && this.changed('versionTemplateUrl')) {
+    if (this.versionTemplateUrl && (this.isNew || this.changed('versionTemplateUrl'))) {
       data.set_audio_version_template_uri = this.versionTemplateUrl;
     }
     return data;


### PR DESCRIPTION
Fixes #227.

- If there's only 1 audio-version-template for the series, just default to that when creating the podcast
- If > 1, make them explicitly pick it
- Annoy-on-change for the dropdown
- Fix some linting with the advanced confirm directive (doesn't seem to like `@Input('name') differentName`)