### PR TITLE
change episodes in series link style

### DIFF
--- a/src/app/series/series.component.css
+++ b/src/app/series/series.component.css
@@ -1,6 +1,15 @@
 /*
  * Series edit styling
  */
+.links {
+  margin-top: 30px;
+  padding-left: 20px;
+}
+
+.links a {
+  margin-top: 10px;
+}
+
 .extras {
   text-align: center;
   margin-top: 30px;

--- a/src/app/series/series.component.html
+++ b/src/app/series/series.component.html
@@ -32,8 +32,10 @@
     <a routerLinkActive="active" [routerLinkActiveOptions]="{exact:true}" [routerLink]="base">Basic Info</a>
     <a routerLinkActive="active" [routerLink]="[base, 'templates']">Audio Templates</a>
     <a routerLinkActive="active" [routerLink]="[base, 'podcast']">Podcast Distribution</a>
-    <a *ngIf="series && !series?.isNew" routerLinkActive="active" [routerLink]="[base, 'list']">{{storyCount}} {{storyNoun}} in Series</a>
   </nav>
+  <div class="links" *ngIf="series && !series?.isNew">
+    <a routerLinkActive="active" [routerLink]="[base, 'list']">{{storyCount}} {{storyNoun}} in Series</a>
+  </div>
   <div class="extras">
     <button *ngIf="id && storyCount == 0" class="delete" (click)="confirmDelete()">Delete</button>
   </div>


### PR DESCRIPTION
#195 

Somehow I keep making unpopular UI choices, so I went with the safe bet here and only changed the one thing that was requested. My other thoughts were as follows:

a list of links (workflow is often Create Series/Podcast/Whatever -> Add Episode, and I feel we should have a link for that)
<img width="518" alt="screen shot 2017-01-27 at 4 53 19 pm" src="https://cloud.githubusercontent.com/assets/2250413/22390869/599fccaa-e4b3-11e6-8808-fd442191af18.png">
since we don't like icons
<img width="519" alt="screen shot 2017-01-27 at 5 05 44 pm" src="https://cloud.githubusercontent.com/assets/2250413/22390876/6a272398-e4b3-11e6-807f-378ce224d4b8.png">
I don't like that full sentence search link at the bottom of the page. Add episode isn't very useful hidden down there either.
<img width="530" alt="screen shot 2017-01-27 at 5 02 44 pm" src="https://cloud.githubusercontent.com/assets/2250413/22390879/6d9dc658-e4b3-11e6-9810-e6442df28a86.png">


