### PR TITLE
don't reopen delete modal on Enter

### DIFF
--- a/src/app/series/series.component.html
+++ b/src/app/series/series.component.html
@@ -37,6 +37,6 @@
     <a routerLinkActive="active" [routerLink]="[base, 'list']">{{storyCount}} {{storyNoun}} in Series</a>
   </div>
   <div class="extras">
-    <button *ngIf="id && storyCount == 0" class="delete" (click)="confirmDelete()">Delete</button>
+    <button *ngIf="id && storyCount == 0" class="delete" (click)="confirmDelete($event)">Delete</button>
   </div>
 </publish-tabs>

--- a/src/app/series/series.component.spec.ts
+++ b/src/app/series/series.component.spec.ts
@@ -76,7 +76,7 @@ describe('SeriesComponent', () => {
     expect(btn).not.toBeUndefined();
 
     expect(modalAlertTitle).toBeNull();
-    btn.triggerEventHandler('click', null);
+    btn.nativeElement.click();
     expect(modalAlertTitle).toEqual('Really delete?');
   });
 

--- a/src/app/series/series.component.ts
+++ b/src/app/series/series.component.ts
@@ -78,7 +78,10 @@ export class SeriesComponent implements OnInit {
     this.series.discard();
   }
 
-  confirmDelete(): void {
+  confirmDelete(event: MouseEvent): void {
+    if (event.target['blur']) {
+      event.target['blur']();
+    }
     this.modal.prompt(
       'Really delete?',
       'Are you sure you want to delete this series? This action cannot be undone.',

--- a/src/app/shared/form/button.component.ts
+++ b/src/app/shared/form/button.component.ts
@@ -18,7 +18,7 @@ import { BaseModel } from '../model/base.model';
 export class ButtonComponent {
 
   @Input() model: BaseModel;
-  @Output() click = new EventEmitter();
+  @Output() click = new EventEmitter<Event>();
 
   @Input() orange = false;
   @Input() plain = false;
@@ -55,7 +55,7 @@ export class ButtonComponent {
 
   onClick(event: Event) {
     event.stopPropagation();
-    this.click.emit();
+    this.click.emit(event);
   }
 
   private decode(val: any): any {

--- a/src/app/story/directives/status.component.ts
+++ b/src/app/story/directives/status.component.ts
@@ -19,7 +19,7 @@ import { StoryModel } from '../../shared';
           <publish-button *ngIf="editStatus" [model]="story" visible=1 orange=1 disabled=0
             [working]="isPublishing" (click)="togglePublish()">Unpublish</publish-button>
           <publish-button *ngIf="editStatus" [model]="story" visible=1 red=1 disabled=0 working=0
-            (click)="confirmDelete()">Delete</publish-button>
+            (click)="confirmDelete($event)">Delete</publish-button>
         </template>
       </dd>
 
@@ -164,7 +164,10 @@ export class StoryStatusComponent implements DoCheck {
     });
   }
 
-  confirmDelete(): void {
+  confirmDelete(event: MouseEvent): void {
+    if (event.target['blur']) {
+      event.target['blur']();
+    }
     this.modal.prompt(
       'Really delete?',
       'Are you sure you want to delete this episode?  This action cannot be undone.',


### PR DESCRIPTION
#311 The confirmation modal was being reopened when the Enter button was hit because it still had focus, so this blurs the focus from the Delete button to prevent it from re-opening the modal while the series/story is being deleted