### PR TITLE
Call new episodes drafts, and reinstate Delete button

### DIFF
--- a/src/app/story/directives/hero.component.spec.ts
+++ b/src/app/story/directives/hero.component.spec.ts
@@ -40,11 +40,11 @@ describe('StoryHeroComponent', () => {
   cit('unstrictly saves new stories', (fix, el, comp) => {
     comp.story = {isNew: true, changed: () => null,  invalid: () => 'bad'};
     fix.detectChanges();
-    expect(el).toContainText('Create');
-    expectDisabled(el, 'Create', true);
+    expect(el).toContainText('Save');
+    expectDisabled(el, 'Save', true);
     comp.story.invalid = (f, strict) => strict ? 'bad' : null;
     fix.detectChanges();
-    expectDisabled(el, 'Create', false);
+    expectDisabled(el, 'Save', false);
   });
 
   cit('unstrictly saves unpublished stories', (fix, el, comp) => {

--- a/src/app/story/directives/hero.component.ts
+++ b/src/app/story/directives/hero.component.ts
@@ -24,9 +24,7 @@ import { StoryModel } from '../../shared';
       <div class="hero-actions" *ngIf="story">
         <publish-button [model]="story" working=0 disabled=0 plain=1
           [visible]="isChanged" (click)="discard()">Discard</publish-button>
-        <publish-button *ngIf="story.isNew" green=1 visible=1 [model]="story"
-          [disabled]="isInvalid" (click)="save()">Create</publish-button>
-        <publish-button *ngIf="!story.isNew" [model]="story" [visible]="isChanged"
+        <publish-button [model]="story" [visible]="isChanged || story.isNew"
           [disabled]="isInvalid" (click)="save()">Save</publish-button>
         <publish-button *ngIf="!story.isNew" working=0 disabled=1
           [visible]="!isChanged">Saved</publish-button>

--- a/src/app/story/directives/status.component.spec.ts
+++ b/src/app/story/directives/status.component.spec.ts
@@ -30,7 +30,7 @@ describe('StoryStatusComponent', () => {
 
   cit('shows story status', (fix, el, comp) => {
     mockStory({isNew: true}, comp, fix);
-    expect(el).toQueryText('.status', 'New');
+    expect(el).toQueryText('.status', 'Draft');
     mockStory({isNew: false}, comp, fix);
     expect(el).toQueryText('.status', 'Draft');
     mockStory({publishedAt: new Date(), isPublished: () => false}, comp, fix);

--- a/src/app/story/directives/status.component.ts
+++ b/src/app/story/directives/status.component.ts
@@ -18,8 +18,6 @@ import { StoryModel } from '../../shared';
           <button *ngIf="!editStatus" class="btn-link edit-status" (click)="toggleEdit()">Edit</button>
           <publish-button *ngIf="editStatus" [model]="story" visible=1 orange=1 disabled=0
             [working]="isPublishing" (click)="togglePublish()">Unpublish</publish-button>
-          <publish-button *ngIf="editStatus" [model]="story" visible=1 red=1 disabled=0 working=0
-            (click)="confirmDelete($event)">Delete</publish-button>
         </template>
       </dd>
 
@@ -159,25 +157,6 @@ export class StoryStatusComponent implements DoCheck {
       this.isPublishing = false;
       this.editStatus = false;
     });
-  }
-
-  confirmDelete(event: MouseEvent): void {
-    if (event.target['blur']) {
-      event.target['blur']();
-    }
-    this.modal.prompt(
-      'Really delete?',
-      'Are you sure you want to delete this episode?  This action cannot be undone.',
-      (okay: boolean) => {
-        if (okay) {
-          this.story.discard();
-          this.story.isDestroy = true;
-          this.story.save().subscribe(() => {
-            this.router.navigate(['/']);
-          });
-        }
-      }
-    );
   }
 
 }

--- a/src/app/story/directives/status.component.ts
+++ b/src/app/story/directives/status.component.ts
@@ -96,10 +96,7 @@ export class StoryStatusComponent implements DoCheck {
   }
 
   setStatus() {
-    if (this.story.isNew) {
-      this.statusClass = 'status new';
-      this.statusText = 'New';
-    } else if (!this.story.publishedAt) {
+    if (this.story.isNew || !this.story.publishedAt) {
       this.statusClass = 'status draft';
       this.statusText = 'Draft';
     } else if (!this.story.isPublished()) {

--- a/src/app/story/story.component.ts
+++ b/src/app/story/story.component.ts
@@ -107,7 +107,7 @@ export class StoryComponent implements OnInit {
       this.modal.prompt(
         'Unsaved changes',
         `This episode has unsaved changes. Click 'Okay' to discard the changes and
-          continue or 'Cancel' to complete and ${this.story.isNew ? 'create' : 'save'} the episode.`,
+          continue or 'Cancel' to complete and save the episode.`,
         (okay: boolean) => {
           if (okay) {
             this.story.discard();

--- a/src/app/story/story.component.ts
+++ b/src/app/story/story.component.ts
@@ -18,6 +18,7 @@ import { StoryModel } from '../shared';
         <a *ngIf="distPlayer" routerLinkActive="active" [routerLink]="[base, 'player']">Embeddable Player</a>
       </nav>
       <publish-story-status [id]="id" [story]="story"></publish-story-status>
+      <button *ngIf="id" class="delete" (click)="confirmDelete($event)">Delete</button>
     </publish-tabs>
   `
 })
@@ -120,5 +121,26 @@ export class StoryComponent implements OnInit {
       return true;
     }
   }
+
+confirmDelete(event: MouseEvent): void {
+  if (event.target['blur']) {
+    event.target['blur']();
+  }
+  this.modal.prompt(
+    'Really delete?',
+    'Are you sure you want to delete this episode?  This action cannot be undone.',
+    (okay: boolean) => {
+      if (okay) {
+        if (this.story.changed()) {
+          this.story.discard();
+        }
+        this.story.isDestroy = true;
+        this.story.save().subscribe(() => {
+          this.router.navigate(['/']);
+        });
+      }
+    }
+  );
+}
 
 }


### PR DESCRIPTION
#333: call a new episode "Draft" instead of "New" and make the button text "Save" instead of "Create" (note: for now, just doing this for episode since that's what we got feedback on. Can change for Series too to match if we like.)
#339: reinstate good old Delete button (outside of status box to keep that very clean -- but we can put in status box if we like) 