### PR TITLE
Unsaved changes primary button label changed to Discard

### DIFF
--- a/src/app/app-error.service.ts
+++ b/src/app/app-error.service.ts
@@ -18,7 +18,7 @@ export class AppErrorService implements ErrorHandler {
         <hr/>
         <pre>${err.stack}</pre>
       `,
-      buttons: ['Okay'],
+      secondaryButton: 'Okay',
       height: 400,
       width: 700
     });

--- a/src/app/core/modal/modal.component.css
+++ b/src/app/core/modal/modal.component.css
@@ -59,11 +59,11 @@ footer {
 footer button {
   margin-left: 10px;
 }
-footer button:last-child {
+footer button.secondary {
   color: #777;
   background: #fff;
 }
-footer button:last-child:hover {
+footer button.secondary:hover {
   color: #fff;
   background-color: #f59f51;
 }

--- a/src/app/core/modal/modal.component.spec.ts
+++ b/src/app/core/modal/modal.component.spec.ts
@@ -41,7 +41,7 @@ describe('ModalComponent', () => {
 
   cit('shows footer buttons', (fix, el, comp) => {
     comp.shown = true;
-    comp.state = {buttons: ['foo', 'bar']};
+    comp.state = {primaryButton: 'foo', secondaryButton: 'bar'};
     fix.detectChanges();
     expect(el.query(By.css('button.close'))).toBeNull();
     let buttons = el.queryAll(By.css('footer button'));
@@ -68,18 +68,18 @@ describe('ModalComponent', () => {
     expect(comp.shown).toEqual(false);
   });
 
-  cit('matches the escape key to the cancel button', (fix, el, comp) => {
+  cit('matches the escape key to the secondary button', (fix, el, comp) => {
     comp.shown = true;
-    comp.state = {buttons: ['Cancel', 'Okay']};
+    comp.state = {primaryButton: 'Okay', secondaryButton: 'Cancel'};
     fix.detectChanges();
     spyOn(comp, 'buttonClick').and.stub();
     simulateKey('Escape');
     expect(comp.buttonClick).toHaveBeenCalledWith('Cancel');
   });
 
-  cit('matches the enter key to the okay button', (fix, el, comp) => {
+  cit('matches the enter key to the primary button', (fix, el, comp) => {
     comp.shown = true;
-    comp.state = {buttons: ['Cancel', 'Nothing', 'Ok', 'Whatever']};
+    comp.state = {primaryButton: 'Ok', secondaryButton: 'Cancel'};
     fix.detectChanges();
     spyOn(comp, 'buttonClick').and.stub();
     simulateKey('Enter');

--- a/src/app/core/modal/modal.component.ts
+++ b/src/app/core/modal/modal.component.ts
@@ -9,15 +9,17 @@ import { ModalService, ModalState } from './modal.service';
     <div *ngIf="shown" class="modal"
       [style.height.px]="state.height" [style.marginTop.px]="-state.height / 2"
       [style.width.px]="state.width" [style.marginLeft.px]="-state.width / 2">
-      <button *ngIf="!state.buttons" class="close icon-cancel" (click)="close()"></button>
+      <button *ngIf="!state.primaryButton && !state.secondaryButton" class="close icon-cancel" (click)="close()"></button>
       <header *ngIf="state.title">
         <h1>{{state.title}}</h1>
       </header>
       <section *ngIf="state.body" [innerHTML]="state.body">
       </section>
-      <footer *ngIf="state.buttons">
-        <button *ngFor="let label of state.buttons" [class]="buttonClass(label)"
-          (click)="buttonClick(label)">{{label}}</button>
+      <footer *ngIf="state.primaryButton || state.secondaryButton">
+        <button *ngIf="state.primaryButton" class="button primary"
+          (click)="buttonClick(state.primaryButton)">{{state.primaryButton}}</button>
+        <button *ngIf="state.secondaryButton" class="button secondary"
+          (click)="buttonClick(state.secondaryButton)">{{state.secondaryButton}}</button>
       </footer>
     </div>
     `
@@ -42,20 +44,10 @@ export class ModalComponent {
 
   onKey(event: KeyboardEvent) {
     if ((event.key && event.key === 'Escape') || event.keyCode === 27) {
-      let cancel = (this.state.buttons || []).find(name => {
-        return ['cancel', 'no', 'nope'].indexOf(name.toLowerCase()) > -1;
-      });
-      cancel ? this.buttonClick(cancel) : this.close();
+      this.state.secondaryButton ? this.buttonClick(this.state.secondaryButton) : this.close();
     } else if ((event.key && event.key === 'Enter') || event.keyCode === 13) {
-      let okay = (this.state.buttons || []).find(name => {
-        return ['ok', 'okay', 'yes', 'discard'].indexOf(name.toLowerCase()) > -1;
-      });
-      okay ? this.buttonClick(okay) : this.close();
+      this.state.primaryButton ? this.buttonClick(this.state.primaryButton) : this.close();
     }
-  }
-
-  buttonClass(label: string) {
-    return 'button';
   }
 
   buttonClick(label: string) {

--- a/src/app/core/modal/modal.component.ts
+++ b/src/app/core/modal/modal.component.ts
@@ -48,7 +48,7 @@ export class ModalComponent {
       cancel ? this.buttonClick(cancel) : this.close();
     } else if ((event.key && event.key === 'Enter') || event.keyCode === 13) {
       let okay = (this.state.buttons || []).find(name => {
-        return ['ok', 'okay', 'yes'].indexOf(name.toLowerCase()) > -1;
+        return ['ok', 'okay', 'yes', 'discard'].indexOf(name.toLowerCase()) > -1;
       });
       okay ? this.buttonClick(okay) : this.close();
     }

--- a/src/app/core/modal/modal.service.spec.ts
+++ b/src/app/core/modal/modal.service.spec.ts
@@ -34,9 +34,9 @@ describe('ModalService', () => {
     });
 
     let callbacked = false;
-    modal.prompt('hello', '<a href="blah">world</a>', (okay: boolean) => {
+    modal.confirm('hello', '<a href="blah">world</a>', (confirm: boolean) => {
       callbacked = true;
-      expect(okay).toEqual(true);
+      expect(confirm).toEqual(true);
     });
     expect(callbacked).toBeTruthy();
   });

--- a/src/app/core/modal/modal.service.ts
+++ b/src/app/core/modal/modal.service.ts
@@ -6,7 +6,8 @@ export interface ModalState {
   hide: boolean;
   title: string;
   body: string;
-  buttons: string[];
+  primaryButton: string;
+  secondaryButton: string;
   buttonCallback: Function;
   height: number;
   width: number;
@@ -33,13 +34,14 @@ export class ModalService {
     }
   }
 
-  prompt(title: string, message: string, callback: Function, buttons = ['Okay', 'Cancel']) {
+  prompt(title: string, message: string, callback: Function, primaryButtonLabel = 'Okay', secondaryButtonLabel = 'Cancel') {
     this.emit({
       title: title,
       body: message ? `<p>${message}</p>` : undefined,
-      buttons,
+      primaryButton: primaryButtonLabel,
+      secondaryButton: secondaryButtonLabel,
       buttonCallback: (label: string) => {
-        if (callback) { callback(buttons.length > 0 && label === buttons[0]); }
+        if (callback) { callback(label === primaryButtonLabel); }
       }
     });
   }

--- a/src/app/core/modal/modal.service.ts
+++ b/src/app/core/modal/modal.service.ts
@@ -34,7 +34,7 @@ export class ModalService {
     }
   }
 
-  prompt(title: string, message: string, callback: Function, primaryButtonLabel = 'Okay', secondaryButtonLabel = 'Cancel') {
+  confirm(title: string, message: string, callback: Function, primaryButtonLabel = 'Okay', secondaryButtonLabel = 'Cancel') {
     this.emit({
       title: title,
       body: message ? `<p>${message}</p>` : undefined,

--- a/src/app/core/modal/modal.service.ts
+++ b/src/app/core/modal/modal.service.ts
@@ -33,13 +33,13 @@ export class ModalService {
     }
   }
 
-  prompt(title: string, message: string, callback: Function) {
+  prompt(title: string, message: string, callback: Function, buttons = ['Okay', 'Cancel']) {
     this.emit({
       title: title,
       body: message ? `<p>${message}</p>` : undefined,
-      buttons: ['Okay', 'Cancel'],
+      buttons,
       buttonCallback: (label: string) => {
-        if (callback) { callback(label === 'Okay'); }
+        if (callback) { callback(buttons.length > 0 && label === buttons[0]); }
       }
     });
   }

--- a/src/app/series/directives/file-template.component.ts
+++ b/src/app/series/directives/file-template.component.ts
@@ -22,7 +22,7 @@ import { AudioVersionTemplateModel, AudioFileTemplateModel } from '../../shared'
       </div>
 
       <div class="remove">
-        <button *ngIf="canRemoveFile" type="button" class="btn-icon icon-cancel" (click)="promptToRemoveFile()"></button>
+        <button *ngIf="canRemoveFile" type="button" class="btn-icon icon-cancel" (click)="confirmRemoveFile()"></button>
       </div>
 
       <p *ngIf="invalid" class="error">{{invalid | capitalize}}</p>
@@ -53,11 +53,11 @@ export class FileTemplateComponent {
     }
   }
 
-  promptToRemoveFile() {
+  confirmRemoveFile() {
     if (this.hasStories() && !this.file.isNew) {
       let confirmMsg = `Are you sure you want to remove the ${this.file.label} segment?
       This change could affect your already published episodes.`;
-      this.modal.prompt('', confirmMsg, (confirm) => {
+      this.modal.confirm('', confirmMsg, (confirm) => {
         if (confirm) {
           this.removeFile();
         }

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -111,16 +111,16 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
 
   get newFeedUrlConfirm(): string {
     if (this.podcast) {
-      let prompt = 'Are you sure you want to change your feed URL';
+      let confirmMsg = 'Are you sure you want to change your feed URL';
       if (this.podcast.original['newFeedUrl'] || this.podcast['publicFeedUrl']) {
-        prompt += ` from "${this.podcast.original['newFeedUrl'] || this.podcast['publicFeedUrl']}"`;
+        confirmMsg += ` from "${this.podcast.original['newFeedUrl'] || this.podcast['publicFeedUrl']}"`;
       }
       if (this.podcast.newFeedUrl) {
-        prompt += ` to "${this.podcast.newFeedUrl}"? This will point your subscribers to a new feed location.`;
+        confirmMsg += ` to "${this.podcast.newFeedUrl}"? This will point your subscribers to a new feed location.`;
       } else {
-        prompt += '?';
+        confirmMsg += '?';
       }
-      return prompt;
+      return confirmMsg;
     }
   }
 

--- a/src/app/series/directives/series-templates.component.ts
+++ b/src/app/series/directives/series-templates.component.ts
@@ -27,7 +27,7 @@ import {
         <div *ngIf="!v.isDestroy" class="version">
           <header>
             <strong>{{v?.label}}</strong>
-            <button type="button" class="btn-icon icon-cancel" (click)="promptToRemoveVersion(v)"></button>
+            <button type="button" class="btn-icon icon-cancel" (click)="confirmRemoveVersion(v)"></button>
           </header>
           <section>
             <publish-fancy-field required textinput [model]="v" name="label" label="Template Label">
@@ -53,7 +53,7 @@ import {
               </div>
               <publish-file-template *ngFor="let t of v.fileTemplates" [file]="t" [version]="v"></publish-file-template>
               <button tabindex=-1 class="add-segment" *ngIf="canAddFile(v)" type="button"
-                (click)="promptToAddFile($event, v)"><i class="icon-plus"></i>Add Segment</button>
+                (click)="confirmAddFile($event, v)"><i class="icon-plus"></i>Add Segment</button>
             </publish-fancy-field>
           </section>
         </div>
@@ -90,11 +90,11 @@ export class SeriesTemplatesComponent implements OnDestroy {
     this.series.versionTemplates.push(draft);
   }
 
-  promptToRemoveVersion(version: AudioVersionTemplateModel) {
+  confirmRemoveVersion(version: AudioVersionTemplateModel) {
     if (this.hasStories()) {
       let confirmMsg = `Are you sure you want to remove the ${version.label} template?
       This change could affect your already published episodes.`;
-      this.modal.prompt('', confirmMsg, (confirm) => {
+      this.modal.confirm('', confirmMsg, (confirm) => {
         if (confirm) {
           this.removeVersion(version);
         }
@@ -116,14 +116,14 @@ export class SeriesTemplatesComponent implements OnDestroy {
     return version.fileTemplates.filter(f => !f.isDestroy).length < 10;
   }
 
-  promptToAddFile(event: MouseEvent, version: AudioVersionTemplateModel) {
+  confirmAddFile(event: MouseEvent, version: AudioVersionTemplateModel) {
     if (event.target['blur']) {
       event.target['blur']();
     }
     if (this.hasStories()) {
       let confirmMsg = `Are you sure you want to add a segment to your ${version.label} template?
       This change could invalidate your already published episodes.`;
-      this.modal.prompt('', confirmMsg, (confirm) => {
+      this.modal.confirm('', confirmMsg, (confirm) => {
         if (confirm) {
           this.addFile(version);
         }

--- a/src/app/series/series.component.spec.ts
+++ b/src/app/series/series.component.spec.ts
@@ -18,7 +18,7 @@ describe('SeriesComponent', () => {
   let modalAlertTitle: any;
   provide(ModalService, {
     alert: (a) => modalAlertTitle = a,
-    prompt: (p) => modalAlertTitle = p
+    confirm: (p) => modalAlertTitle = p
   });
 
   let auth;
@@ -80,7 +80,7 @@ describe('SeriesComponent', () => {
     expect(modalAlertTitle).toEqual('Really delete?');
   });
 
-  cit('prompts for leaving with unsaved changes', (fix, el, comp) => {
+  cit('confirms discarding unsaved changes before leaving', (fix, el, comp) => {
     activatedRoute.testParams = {id: '99'};
     auth.mock('prx:series', {id: 99, title: 'my series title', appVersion: 'v4'});
     fix.detectChanges();
@@ -90,7 +90,7 @@ describe('SeriesComponent', () => {
     expect(modalAlertTitle).toMatch(/unsaved changes/i);
   });
 
-  cit('does not prompt for unsaved changes after delete', (fix, el, comp) => {
+  cit('does not confirm for unsaved changes after delete', (fix, el, comp) => {
     activatedRoute.testParams = {id: '99'};
     auth.mock('prx:series', {id: 99, title: 'my series title', appVersion: 'v4'});
     fix.detectChanges();

--- a/src/app/series/series.component.ts
+++ b/src/app/series/series.component.ts
@@ -82,7 +82,7 @@ export class SeriesComponent implements OnInit {
     if (event.target['blur']) {
       event.target['blur']();
     }
-    this.modal.prompt(
+    this.modal.confirm(
       'Really delete?',
       'Are you sure you want to delete this series? This action cannot be undone.',
       (okay: boolean) => {
@@ -102,7 +102,7 @@ export class SeriesComponent implements OnInit {
   canDeactivate(next: any, prev: any): boolean | Observable<boolean> {
     if (this.series && this.series.changed() && !this.series.isDestroy) {
       let thatsOkay = new Subject<boolean>();
-      this.modal.prompt(
+      this.modal.confirm(
         'Unsaved changes',
         `This series has unsaved changes. You may discard the changes and
           continue or click 'Cancel' to complete and ${this.series.isNew ? 'create' : 'save'} the series.`,

--- a/src/app/series/series.component.ts
+++ b/src/app/series/series.component.ts
@@ -104,15 +104,16 @@ export class SeriesComponent implements OnInit {
       let thatsOkay = new Subject<boolean>();
       this.modal.prompt(
         'Unsaved changes',
-        `This series has unsaved changes. Click 'Okay' to discard the changes and
-          continue or 'Cancel' to complete and ${this.series.isNew ? 'create' : 'save'} the series.`,
+        `This series has unsaved changes. You may discard the changes and
+          continue or click 'Cancel' to complete and ${this.series.isNew ? 'create' : 'save'} the series.`,
         (okay: boolean) => {
           if (okay) {
             this.discard();
           }
           thatsOkay.next(okay);
           thatsOkay.complete();
-        }
+        },
+        ['Discard', 'Cancel']
       );
       return thatsOkay;
     } else {

--- a/src/app/series/series.component.ts
+++ b/src/app/series/series.component.ts
@@ -113,7 +113,7 @@ export class SeriesComponent implements OnInit {
           thatsOkay.next(okay);
           thatsOkay.complete();
         },
-        ['Discard', 'Cancel']
+        'Discard'
       );
       return thatsOkay;
     } else {

--- a/src/app/series/series.component.ts
+++ b/src/app/series/series.component.ts
@@ -106,11 +106,11 @@ export class SeriesComponent implements OnInit {
         'Unsaved changes',
         `This series has unsaved changes. You may discard the changes and
           continue or click 'Cancel' to complete and ${this.series.isNew ? 'create' : 'save'} the series.`,
-        (okay: boolean) => {
-          if (okay) {
+        (confirm: boolean) => {
+          if (confirm) {
             this.discard();
           }
-          thatsOkay.next(okay);
+          thatsOkay.next(confirm);
           thatsOkay.complete();
         },
         'Discard'

--- a/src/app/series/series.component.ts
+++ b/src/app/series/series.component.ts
@@ -85,8 +85,8 @@ export class SeriesComponent implements OnInit {
     this.modal.confirm(
       'Really delete?',
       'Are you sure you want to delete this series? This action cannot be undone.',
-      (okay: boolean) => {
-        if (okay) {
+      (confirm: boolean) => {
+        if (confirm) {
           if (this.series.changed()) {
             this.discard();
           }

--- a/src/app/shared/form/advanced-confirm.directive.spec.ts
+++ b/src/app/shared/form/advanced-confirm.directive.spec.ts
@@ -14,7 +14,7 @@ describe('AdvancedConfirmDirective', () => {
   let modalAlertMessage: any;
   beforeEach(() => modalAlertMessage = null);
   provide(ModalService, {
-    prompt: (title, message, callback) => modalAlertMessage = message
+    confirm: (title, message, callback) => modalAlertMessage = message
   });
 
   cit('forces user to confirm changes to advanced fields', (fix, el, comp) => {

--- a/src/app/shared/form/advanced-confirm.directive.ts
+++ b/src/app/shared/form/advanced-confirm.directive.ts
@@ -13,14 +13,14 @@ export class AdvancedConfirmDirective implements Directive {
   @Input() publishName: string;
   @Input() publishEvent = 'blur';
 
-  @HostListener('blur') onBlur() { return this.publishEvent === 'blur' && this.prompt(); }
-  @HostListener('change') onChange() { return this.publishEvent === 'change' && this.prompt(); }
+  @HostListener('blur') onBlur() { return this.publishEvent === 'blur' && this.confirm(); }
+  @HostListener('change') onChange() { return this.publishEvent === 'change' && this.confirm(); }
 
   constructor(private modal: ModalService) {}
 
-  prompt() {
+  confirm() {
     if (this.publishAdvancedConfirm && this.shouldConfirm()) {
-      this.modal.prompt('', this.publishAdvancedConfirm, this.resetFieldOnCancel.bind(this));
+      this.modal.confirm('', this.publishAdvancedConfirm, this.resetFieldOnCancel.bind(this));
     }
   }
 

--- a/src/app/story/directives/podcast.component.ts
+++ b/src/app/story/directives/podcast.component.ts
@@ -79,16 +79,16 @@ export class PodcastComponent implements OnDestroy {
 
   get guidConfirm(): string {
     if (this.episode) {
-      let prompt = 'Are you sure you want to change the permanent GUID for this episode';
+      let confirmMsg = 'Are you sure you want to change the permanent GUID for this episode';
       if (this.episode.original['guid']) {
-        prompt += ` from "${this.episode.original['guid']}"`;
+        confirmMsg += ` from "${this.episode.original['guid']}"`;
       }
       if (this.episode.guid) {
-        prompt += ` to "${this.episode.guid}"? This should only be done in special cases.`;
+        confirmMsg += ` to "${this.episode.guid}"? This should only be done in special cases.`;
       } else {
-        prompt += '?';
+        confirmMsg += '?';
       }
-      return prompt;
+      return confirmMsg;
     }
   }
 

--- a/src/app/story/directives/status.component.spec.ts
+++ b/src/app/story/directives/status.component.spec.ts
@@ -15,7 +15,7 @@ describe('StoryStatusComponent', () => {
   let modalAlertBody: any;
   provide(ModalService, {
     show: (data) => modalAlertBody = data.body,
-    prompt: (title, body) => modalAlertBody = body
+    confirm: (title, body) => modalAlertBody = body
   });
   beforeEach(() => modalAlertBody = null);
 

--- a/src/app/story/directives/status.component.ts
+++ b/src/app/story/directives/status.component.ts
@@ -144,7 +144,7 @@ export class StoryStatusComponent implements DoCheck {
       }
     }
 
-    this.modal.show({title: title, body: `<ul>${msg}</ul>`, buttons: ['Okay']});
+    this.modal.show({title: title, body: `<ul>${msg}</ul>`, secondaryButton: 'Okay'});
   }
 
   toggleEdit() {

--- a/src/app/story/story.component.spec.ts
+++ b/src/app/story/story.component.spec.ts
@@ -17,7 +17,7 @@ describe('StoryComponent', () => {
   let modalAlertTitle: any;
   provide(ModalService, {
     alert: (a) => modalAlertTitle = a,
-    prompt: (p) => modalAlertTitle = p
+    confirm: (p) => modalAlertTitle = p
   });
   beforeEach(() => modalAlertTitle = null);
 
@@ -57,7 +57,7 @@ describe('StoryComponent', () => {
     expect(comp.story.parent).toBeNull();
   });
 
-  cit('prompts for leaving with unsaved changes', (fix, el, comp) => {
+  cit('confirms discarding unsaved changes before leaving', (fix, el, comp) => {
     activatedRoute.testParams = {id: 1234};
     fix.detectChanges();
     expect(comp.canDeactivate()).toEqual(true);
@@ -66,7 +66,7 @@ describe('StoryComponent', () => {
     expect(modalAlertTitle).toMatch(/unsaved changes/i);
   });
 
-  cit('does not prompt for unsaved changes after delete', (fix, el, comp) => {
+  cit('does not confirm for unsaved changes after delete', (fix, el, comp) => {
     activatedRoute.testParams = {id: 1234};
     fix.detectChanges();
     comp.story.isDestroy = true;

--- a/src/app/story/story.component.ts
+++ b/src/app/story/story.component.ts
@@ -106,15 +106,16 @@ export class StoryComponent implements OnInit {
       let thatsOkay = new Subject<boolean>();
       this.modal.prompt(
         'Unsaved changes',
-        `This episode has unsaved changes. Click 'Okay' to discard the changes and
-          continue or 'Cancel' to complete and save the episode.`,
+        `This episode has unsaved changes. You may discard the changes and
+          continue or click 'Cancel' to complete and save the episode.`,
         (okay: boolean) => {
           if (okay) {
             this.story.discard();
           }
           thatsOkay.next(okay);
           thatsOkay.complete();
-        }
+        },
+        ['Discard', 'Cancel']
       );
       return thatsOkay;
     } else {
@@ -122,25 +123,25 @@ export class StoryComponent implements OnInit {
     }
   }
 
-confirmDelete(event: MouseEvent): void {
-  if (event.target['blur']) {
-    event.target['blur']();
-  }
-  this.modal.prompt(
-    'Really delete?',
-    'Are you sure you want to delete this episode?  This action cannot be undone.',
-    (okay: boolean) => {
-      if (okay) {
-        if (this.story.changed()) {
-          this.story.discard();
-        }
-        this.story.isDestroy = true;
-        this.story.save().subscribe(() => {
-          this.router.navigate(['/']);
-        });
-      }
+  confirmDelete(event: MouseEvent): void {
+    if (event.target['blur']) {
+      event.target['blur']();
     }
-  );
-}
+    this.modal.prompt(
+      'Really delete?',
+      'Are you sure you want to delete this episode?  This action cannot be undone.',
+      (okay: boolean) => {
+        if (okay) {
+          if (this.story.changed()) {
+            this.story.discard();
+          }
+          this.story.isDestroy = true;
+          this.story.save().subscribe(() => {
+            this.router.navigate(['/']);
+          });
+        }
+      }
+    );
+  }
 
 }

--- a/src/app/story/story.component.ts
+++ b/src/app/story/story.component.ts
@@ -104,7 +104,7 @@ export class StoryComponent implements OnInit {
   canDeactivate(next: any, prev: any): boolean | Observable<boolean> {
     if (this.story && this.story.changed() && !this.story.isDestroy) {
       let thatsOkay = new Subject<boolean>();
-      this.modal.prompt(
+      this.modal.confirm(
         'Unsaved changes',
         `This episode has unsaved changes. You may discard the changes and
           continue or click 'Cancel' to complete and save the episode.`,
@@ -127,7 +127,7 @@ export class StoryComponent implements OnInit {
     if (event.target['blur']) {
       event.target['blur']();
     }
-    this.modal.prompt(
+    this.modal.confirm(
       'Really delete?',
       'Are you sure you want to delete this episode?  This action cannot be undone.',
       (okay: boolean) => {

--- a/src/app/story/story.component.ts
+++ b/src/app/story/story.component.ts
@@ -108,11 +108,11 @@ export class StoryComponent implements OnInit {
         'Unsaved changes',
         `This episode has unsaved changes. You may discard the changes and
           continue or click 'Cancel' to complete and save the episode.`,
-        (okay: boolean) => {
-          if (okay) {
+        (confirm: boolean) => {
+          if (confirm) {
             this.story.discard();
           }
-          thatsOkay.next(okay);
+          thatsOkay.next(confirm);
           thatsOkay.complete();
         },
         'Discard'
@@ -130,8 +130,8 @@ export class StoryComponent implements OnInit {
     this.modal.confirm(
       'Really delete?',
       'Are you sure you want to delete this episode?  This action cannot be undone.',
-      (okay: boolean) => {
-        if (okay) {
+      (confirm: boolean) => {
+        if (confirm) {
           if (this.story.changed()) {
             this.story.discard();
           }

--- a/src/app/story/story.component.ts
+++ b/src/app/story/story.component.ts
@@ -115,7 +115,7 @@ export class StoryComponent implements OnInit {
           thatsOkay.next(okay);
           thatsOkay.complete();
         },
-        ['Discard', 'Cancel']
+        'Discard'
       );
       return thatsOkay;
     } else {

--- a/src/app/upload/shared/audio-cancel.directive.spec.ts
+++ b/src/app/upload/shared/audio-cancel.directive.spec.ts
@@ -26,10 +26,10 @@ describe('AudioCancelDirective', () => {
   let modalAlertTitle: any;
   beforeEach(() => modalAlertTitle = null);
   provide(ModalService, {
-    prompt: (p) => modalAlertTitle = p
+    confirm: (p) => modalAlertTitle = p
   });
 
-  cit('prompts before deleting audio', (fix, el, comp) => {
+  cit('confirms before deleting audio', (fix, el, comp) => {
     comp.file = {canceled: false, destroy: () => true};
     comp.version = {removeUpload: () => true};
     fix.detectChanges();

--- a/src/app/upload/shared/audio-cancel.directive.ts
+++ b/src/app/upload/shared/audio-cancel.directive.ts
@@ -19,7 +19,7 @@ export class AudioCancelDirective {
     if (this.publishAudioCancel.isUploading) {
       this.cancelAndDestroy();
     } else {
-      this.modal.prompt(
+      this.modal.confirm(
         'Really delete audio file?',
         'This action cannot be undone.',
         (okay: boolean) => okay && this.cancelAndDestroy()

--- a/src/app/upload/shared/audio-cancel.directive.ts
+++ b/src/app/upload/shared/audio-cancel.directive.ts
@@ -20,9 +20,9 @@ export class AudioCancelDirective {
       this.cancelAndDestroy();
     } else {
       this.modal.confirm(
-        'Really delete audio file?',
-        'This action cannot be undone.',
-        (okay: boolean) => okay && this.cancelAndDestroy()
+        'Really delete?',
+        'Are you sure you want to remove this audio file?',
+        (confirm: boolean) => confirm && this.cancelAndDestroy()
       );
     }
   }


### PR DESCRIPTION
#325 "Discard Changes" doesn't feel right. It's too big, and all of our other buttons are a single verb.
<img width="501" alt="screen shot 2017-02-02 at 1 20 03 pm" src="https://cloud.githubusercontent.com/assets/2250413/22564972/2307b9e4-e94c-11e6-9c07-b27315a923c4.png">
