### PR TITLE
Add podcast fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "evaporate": "^1.6.3",
     "express": "^4.14.0",
     "express-http-proxy": "^0.10.1",
+    "langmap": "0.0.14",
     "moment": "^2.17.1",
     "morgan": "^1.7.0",
     "newrelic": "1.34.0",

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -107,6 +107,10 @@
       </div>
     </publish-fancy-field>
 
+    <publish-fancy-field label="Language" [model]="podcast" name="language" [select]="languageOptions">
+      <div class="fancy-hint">Select which language your podcast is in.</div>
+    </publish-fancy-field>
+
     <publish-advanced-section>
       <publish-fancy-field label="New Feed Url" textinput [model]="podcast" name="newFeedUrl" [advancedConfirm]="newFeedUrlConfirm">
         <div class="fancy-hint">

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -55,12 +55,32 @@
       <div class="fancy-hint">A link to the homepage for your podcast.</div>
     </publish-fancy-field>
 
+    <publish-fancy-field label="Owner Information">
+      <div class="fancy-hint">Set the iTunes owner name and email for this podcast.</div>
+      <div class="span-fields">
+        <publish-fancy-field label="Name" textinput [model]="podcast" name="ownerName" small=1>
+        </publish-fancy-field>
+        <publish-fancy-field label="Email" textinput [model]="podcast" name="ownerEmail" small=1>
+        </publish-fancy-field>
+      </div>
+    </publish-fancy-field>
+
     <publish-fancy-field label="Author Information">
-      <div class="fancy-hint">Set the author name and email to be associated with this podcast.</div>
+      <div class="fancy-hint">Set the author name and email for this podcast.</div>
       <div class="span-fields">
         <publish-fancy-field label="Name" textinput [model]="podcast" name="authorName" small=1>
         </publish-fancy-field>
         <publish-fancy-field label="Email" textinput [model]="podcast" name="authorEmail" small=1>
+        </publish-fancy-field>
+      </div>
+    </publish-fancy-field>
+
+    <publish-fancy-field label="Managing Editor Information">
+      <div class="fancy-hint">Set the managing editor name and email for this podcast.</div>
+      <div class="span-fields">
+        <publish-fancy-field label="Name" textinput [model]="podcast" name="managingEditorName" small=1>
+        </publish-fancy-field>
+        <publish-fancy-field label="Email" textinput [model]="podcast" name="managingEditorEmail" small=1>
         </publish-fancy-field>
       </div>
     </publish-fancy-field>

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -101,11 +101,23 @@
       </div>
     </publish-fancy-field>
 
+    <publish-fancy-field label="Copyright" textinput [model]="podcast" name="copyright">
+      <div class="fancy-hint">
+        Copyright notice for content in the podcast.
+      </div>
+    </publish-fancy-field>
+
     <publish-advanced-section>
       <publish-fancy-field label="New Feed Url" textinput [model]="podcast" name="newFeedUrl" [advancedConfirm]="newFeedUrlConfirm">
         <div class="fancy-hint">
           If your podcast feed is moving, use this field to point to the new URL where your podcast is located.
           The current feed should be maintained until all of your subscribers have migrated.
+        </div>
+      </publish-fancy-field>
+
+      <publish-fancy-field label="Complete" checkbox [model]="podcast" name="complete" [advancedConfirm]="completeConfirm" prompt="The podcast is complete.">
+        <div class="fancy-hint">
+          Checking the box indicates that the podcast is complete and you will not post any more episodes in the future.
         </div>
       </publish-fancy-field>
     </publish-advanced-section>

--- a/src/app/series/directives/series-podcast.component.spec.ts
+++ b/src/app/series/directives/series-podcast.component.spec.ts
@@ -79,4 +79,8 @@ describe('SeriesPodcastComponent', () => {
     expect(comp.podcast.set).toHaveBeenCalledWith('subCategory', '');
   });
 
+  cit('gets a list of language options', (fix, el, comp) => {
+    let langs = comp.getLanguageOptions();
+    expect(langs.length).toEqual(210);
+  });
 });

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -122,6 +122,13 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
     }
   }
 
+  get completeConfirm(): string {
+    if (this.podcast) {
+      let confirmMsg = 'Are you sure you want to set this as complete, and there will be no more episodes in the podcast?';
+      return confirmMsg;
+    }
+  }
+
   get versionTemplateConfirm(): string {
     if (this.distribution && this.audioVersionOptions && this.series.hasStories) {
       let url = this.distribution.versionTemplateUrl;

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -2,6 +2,7 @@ import { Component, OnDestroy, DoCheck } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { SeriesModel, DistributionModel, FeederPodcastModel,
          TabService, CATEGORIES, SUBCATEGORIES } from '../../shared';
+import * as languageMappingList from 'langmap';
 
 @Component({
   styleUrls: ['series-podcast.component.css'],
@@ -24,8 +25,10 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
   initialDistributions: DistributionModel[];
   distribution: DistributionModel;
   podcast: FeederPodcastModel;
+  languageOptions: string[][];
 
   constructor(tab: TabService) {
+    this.languageOptions = this.getLanguageOptions();
     this.tabSub = tab.model.subscribe((s: SeriesModel) => {
       this.series = s;
       this.series.loadRelated('versionTemplates').subscribe(() => {
@@ -36,6 +39,18 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
       });
       this.loadDistributions();
     });
+  }
+
+  getLanguageOptions(): string[][] {
+    let result:string[][] = [];
+    for (let key in languageMappingList) {
+      if (languageMappingList.hasOwnProperty(key)) {
+        let name:string = `${languageMappingList[key]['englishName']} (${key.toLowerCase()})`;
+        let val:string = key.toLowerCase();
+        result.push([name, val]);
+      }
+    }
+    return result;
   }
 
   ngDoCheck() {

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -123,7 +123,7 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
   }
 
   get completeConfirm(): string {
-    if (this.podcast) {
+    if (this.podcast && this.podcast.complete) {
       let confirmMsg = 'Are you sure you want to set this as complete, and there will be no more episodes in the podcast?';
       return confirmMsg;
     }

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -139,7 +139,7 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
 
   get completeConfirm(): string {
     if (this.podcast && this.podcast.complete) {
-      let confirmMsg = 'Are you sure this podcast is complete? Apps will assume this is show over, and won\'t look new episodes.';
+      let confirmMsg = 'Are you sure this podcast is complete? Apps will assume this show is over, and won\'t look for new episodes.';
       return confirmMsg;
     }
   }

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -139,7 +139,7 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
 
   get completeConfirm(): string {
     if (this.podcast && this.podcast.complete) {
-      let confirmMsg = 'Are you sure you want to set this as complete, and there will be no more episodes in the podcast?';
+      let confirmMsg = 'Are you sure this podcast is complete? Apps will assume this is show over, and won\'t look new episodes.';
       return confirmMsg;
     }
   }
@@ -155,5 +155,4 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
       `;
     }
   }
-
 }

--- a/src/app/shared/form/fancy-field.component.css
+++ b/src/app/shared/form/fancy-field.component.css
@@ -59,6 +59,12 @@ input, textarea {
 input:focus, textarea:focus {
   color: #000;
 }
+input[type='checkbox'] {
+  width: 20px;
+  vertical-align: middle;
+}
+input[type='checkbox'] + label {
+}
 textarea {
   height: 100px;
 }

--- a/src/app/shared/form/fancy-field.component.css
+++ b/src/app/shared/form/fancy-field.component.css
@@ -63,8 +63,6 @@ input[type='checkbox'] {
   width: 20px;
   vertical-align: middle;
 }
-input[type='checkbox'] + label {
-}
 textarea {
   height: 100px;
 }

--- a/src/app/shared/form/fancy-field.component.html
+++ b/src/app/shared/form/fancy-field.component.html
@@ -21,6 +21,12 @@
     <input *ngIf="type == 'number'" [id]="name" type="number"
       [ngModel]="model[name]" (ngModelChange)="doOnChange($event)"
       [publishAdvancedConfirm]="advancedConfirm" [publishName]="name" [publishModel]="model"/>
+    <fieldset *ngIf="type == 'checkbox'" >
+      <input [id]="name" type="checkbox"
+        [ngModel]="model[name]" (ngModelChange)="doOnChange($event)"
+        [publishAdvancedConfirm]="advancedConfirm" [publishName]="name" [publishModel]="model"/>
+      <label [for]="name">{{prompt}}</label>
+    </fieldset>
     <textarea *ngIf="type == 'textarea'" [id]="name"
       [publishAdvancedConfirm]="advancedConfirm" [publishName]="name" [publishModel]="model"
       [(ngModel)]="model[name]" (ngModelChange)="doOnChange($event)"></textarea>
@@ -34,6 +40,7 @@
 
   <template [ngIf]="!model">
     <input *ngIf="type == 'textinput'" [id]="name" type="text" disabled=true/>
+    <input *ngIf="type == 'checkbox'" [id]="name" type="checkbox" disabled=true/>
     <textarea *ngIf="type == 'textarea'" [id]="name" disabled=true></textarea>
     <select *ngIf="type == 'select'" [id]="name" disabled=true></select>
   </template>

--- a/src/app/shared/form/fancy-field.component.html
+++ b/src/app/shared/form/fancy-field.component.html
@@ -25,7 +25,7 @@
       <input [id]="name" type="checkbox"
         [ngModel]="model[name]" (ngModelChange)="doOnChange($event)"
         [publishAdvancedConfirm]="advancedConfirm" [publishName]="name" [publishModel]="model"/>
-      <label [for]="name">{{prompt}}</label>
+      <label class="prompt" [for]="name">{{prompt}}</label>
     </fieldset>
     <textarea *ngIf="type == 'textarea'" [id]="name"
       [publishAdvancedConfirm]="advancedConfirm" [publishName]="name" [publishModel]="model"

--- a/src/app/shared/form/fancy-field.component.spec.ts
+++ b/src/app/shared/form/fancy-field.component.spec.ts
@@ -7,9 +7,11 @@ describe('FancyFieldComponent', () => {
     template: `
       <publish-fancy-field [model]="model" [name]="name" [changed]="changed" [invalid]="invalid"
         [textinput]="textinput" [number]="number" [textarea]="textarea" [select]="select"
-        [label]="label" [invalidlabel]="invalidlabel" [small]="small" [required]="required">
+        [label]="label" [invalidlabel]="invalidlabel" [small]="small" [required]="required"
+        [checkbox]="checkbox "[prompt]="prompt">
         <div class="fancy-hint" *ngIf="hint">{{hint}}</div>
         <h1 *ngIf="nested">{{nested}}</h1>
+        <label class="prompt" [for]="name">{{prompt}}</label>
       </publish-fancy-field>
     `
   });
@@ -20,7 +22,6 @@ describe('FancyFieldComponent', () => {
     expect(el).toQuery('.field');
     expect(el).not.toQuery('h1');
     expect(el).not.toQuery('h3');
-    expect(el).not.toQuery('label');
     expect(el).toQueryText('p.hint', '');
   });
 
@@ -50,6 +51,12 @@ describe('FancyFieldComponent', () => {
     comp.hint = 'the hint content';
     fix.detectChanges();
     expect(el).toQueryText('p.hint', 'the hint content');
+  });
+
+  cit('renders the prompt', (fix, el, comp) => {
+    comp.prompt = 'the prompt content';
+    fix.detectChanges();
+    expect(el).toQueryText('label.prompt', 'the prompt content');
   });
 
   cit('renders arbitrary nested content', (fix, el, comp) => {
@@ -150,5 +157,4 @@ describe('FancyFieldComponent', () => {
     fix.detectChanges();
     expect(el).toQueryText('p.error', 'some message Newer Label something');
   });
-
 });

--- a/src/app/shared/form/fancy-field.component.ts
+++ b/src/app/shared/form/fancy-field.component.ts
@@ -23,6 +23,7 @@ export class FancyFieldComponent {
   @Input() hideinvalid: boolean;
   @Input() advancedConfirm: string;
   @Input() strict: boolean;
+  @Input() prompt: string;
 
   // Form field types (intercepted with defaults)
   type: string;
@@ -36,6 +37,8 @@ export class FancyFieldComponent {
   @Input()
   set select(opts: any) { this.type = 'select'; this.setOptions(opts); }
   get select() { return this._select; }
+  @Input()
+  set checkbox(any: any) { this.type = 'checkbox'; }
 
   // Field attributes
   _small = false;

--- a/src/app/shared/model/feeder-podcast.model.spec.ts
+++ b/src/app/shared/model/feeder-podcast.model.spec.ts
@@ -5,7 +5,7 @@ describe('FeederPodcastModel', () => {
 
   let series = cms.mock('prx:series', {id: 'series1'});
   let dist = series.mock('prx:distributions', {id: 'dist1', kind: 'podcast'});
-  let authorDist = series.mock('prx:accounts', {name: 'Foo', email: 'Bar'});
+  let roleDist = series.mock('prx:accounts', {name: 'Foo', email: 'Bar'});
 
   beforeEach(() => window.localStorage.clear());
 
@@ -52,10 +52,14 @@ describe('FeederPodcastModel', () => {
   });
 
   it('allows user to override account name and set author email for podcast', () => {
-    let doc = authorDist.mock('some-feeder', {author: {name: 'Foo2', email: 'Bar2'}});
-    let podcast = new FeederPodcastModel(series, dist, doc);
-    expect(podcast.authorName).toEqual('Foo2');
-    expect(podcast.authorEmail).toEqual('Bar2');
+    ['author', 'owner', 'managingEditor'].forEach((role) => {
+      let roleObj = {};
+      roleObj[role] = {name: 'Foo2', email: 'Bar2'};
+      let doc = roleDist.mock('some-feeder', roleObj);
+      let podcast = new FeederPodcastModel(series, dist, doc);
+      expect(podcast[`${role}Name`]).toEqual('Foo2');
+      expect(podcast[`${role}Email`]).toEqual('Bar2');
+    });
   });
 
   it('ensures URLs have http(s)', () => {

--- a/src/app/shared/model/feeder-podcast.model.spec.ts
+++ b/src/app/shared/model/feeder-podcast.model.spec.ts
@@ -70,4 +70,9 @@ describe('FeederPodcastModel', () => {
     expect(podcast.enclosurePrefix).toEqual('http://redirect.me');
   });
 
+  it ('allows user to set other feed attributes', () => {
+    let podcast = new FeederPodcastModel(series, dist);
+    podcast.set('copyright', 'Copyright © 2017 PRX. All rights reserved.');
+    expect(podcast.copyright).toEqual('Copyright © 2017 PRX. All rights reserved.');
+  });
 });

--- a/src/app/shared/model/feeder-podcast.model.spec.ts
+++ b/src/app/shared/model/feeder-podcast.model.spec.ts
@@ -74,5 +74,14 @@ describe('FeederPodcastModel', () => {
     let podcast = new FeederPodcastModel(series, dist);
     podcast.set('copyright', 'Copyright © 2017 PRX. All rights reserved.');
     expect(podcast.copyright).toEqual('Copyright © 2017 PRX. All rights reserved.');
+
+    podcast.set('complete', true);
+    expect(podcast.complete).toEqual(true);
+  });
+
+  it('makes language lower case', () => {
+    let doc = dist.mock('some-feeder', {language: 'en-US'});
+    let podcast = new FeederPodcastModel(series, dist, doc);
+    expect(podcast.language).toEqual('en-us');
   });
 });

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -10,7 +10,7 @@ export class FeederPodcastModel extends BaseModel {
   publishedUrl: string;
 
   // writeable
-  SETABLE = ['category', 'subCategory', 'explicit', 'link', 'newFeedUrl', 'publicFeedUrl', 'enclosurePrefix', 'authorName', 'authorEmail', 'copyright', 'complete'];
+  SETABLE = ['category', 'subCategory', 'explicit', 'link', 'newFeedUrl', 'publicFeedUrl', 'enclosurePrefix', 'authorName', 'authorEmail', 'copyright', 'complete', 'language'];
   URLS = ['link', 'newFeedUrl', 'publicFeedUrl', 'enclosurePrefix'];
   category = '';
   subCategory = '';
@@ -23,6 +23,7 @@ export class FeederPodcastModel extends BaseModel {
   authorEmail = '';
   copyright = '';
   complete = false;
+  language = '';
   hasPublicFeed = false;
 
   VALIDATORS = {
@@ -54,23 +55,12 @@ export class FeederPodcastModel extends BaseModel {
   }
 
   decode() {
-    this.id = this.doc['id'];
-
+    this.complete = this.doc['complete'];
     this.copyright = this.doc['copyright'] || '';
     this.enclosurePrefix = this.doc['enclosurePrefix'] || '';
+    this.id = this.doc['id'];
     this.link = this.doc['link'] || '';
     this.newFeedUrl = this.doc['newFeedUrl'] || '';
-
-    this.explicit = this.doc['explicit'] || '';
-    if (this.explicit) {
-      this.explicit = this.explicit.charAt(0).toUpperCase() + this.explicit.slice(1);
-    }
-
-    this.publishedUrl = this.doc['publishedUrl'] || '';
-    if (this.doc['url']) {
-      this.publicFeedUrl = this.doc['url'];
-      this.hasPublicFeed = true;
-    }
 
     if (this.doc['author']) {
       if (this.doc['author']['name']) {
@@ -94,22 +84,35 @@ export class FeederPodcastModel extends BaseModel {
       this.category = '';
       this.subCategory = '';
     }
+
+    this.explicit = this.doc['explicit'] || '';
+    if (this.explicit) {
+      this.explicit = this.explicit.charAt(0).toUpperCase() + this.explicit.slice(1);
+    }
+
+    this.language = this.doc['language'] || '';
+    if (this.language) {
+      this.language = this.language.toLowerCase();
+    }
+
+    this.publishedUrl = this.doc['publishedUrl'] || '';
+    if (this.doc['url']) {
+      this.publicFeedUrl = this.doc['url'];
+      this.hasPublicFeed = true;
+    }
   }
 
   encode(): {} {
     let data = <any> {};
 
     // unset with nulls instead of blank strings
+    data.complete = this.complete;
     data.copyright = this.copyright || null;
     data.enclosurePrefix = this.enclosurePrefix || null;
+    data.language = this.language || null;
     data.link = this.link || null;
     data.newFeedUrl = this.newFeedUrl || null;
     data.url = this.publicFeedUrl || null;
-
-    data.explicit = this.explicit || null;
-    if (data.explicit) {
-      data.explicit = data.explicit.toLowerCase();
-    }
 
     if (this.authorName || this.authorEmail) {
       data.author = {
@@ -128,6 +131,12 @@ export class FeederPodcastModel extends BaseModel {
     } else {
       data.itunesCategories = [];
     }
+
+    data.explicit = this.explicit || null;
+    if (data.explicit) {
+      data.explicit = data.explicit.toLowerCase();
+    }
+
     return data;
   }
 
@@ -140,5 +149,4 @@ export class FeederPodcastModel extends BaseModel {
       newModel.set(fld, this[fld]);
     }
   }
-
 }

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -11,7 +11,7 @@ export class FeederPodcastModel extends BaseModel {
 
   // writeable
   SETABLE = ['category', 'subCategory', 'explicit', 'link', 'newFeedUrl', 'publicFeedUrl', 'enclosurePrefix', 'copyright', 'complete', 'language',
-             'authorName', 'authorEmail', 'ownerName', 'ownerEmail','managingEditorName', 'managingEditorEmail'];
+             'authorName', 'authorEmail', 'ownerName', 'ownerEmail', 'managingEditorName', 'managingEditorEmail'];
   URLS = ['link', 'newFeedUrl', 'publicFeedUrl', 'enclosurePrefix'];
   category = '';
   subCategory = '';
@@ -118,12 +118,10 @@ export class FeederPodcastModel extends BaseModel {
     data.url = this.publicFeedUrl || null;
 
     ['author', 'owner', 'managingEditor'].forEach((role) => {
-      if (this[`${role}Name`] || this[`${role}Email`]) {
-        data[role] = {
-          name: this[`${role}Name`],
-          email: this[`${role}Email`]
-        };
-      }
+      data[role] = {
+        name: this[`${role}Name`] || null,
+        email: this[`${role}Email`] || null
+      };
     });
 
     // we can always send a categories array

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -10,7 +10,8 @@ export class FeederPodcastModel extends BaseModel {
   publishedUrl: string;
 
   // writeable
-  SETABLE = ['category', 'subCategory', 'explicit', 'link', 'newFeedUrl', 'publicFeedUrl', 'enclosurePrefix', 'authorName', 'authorEmail', 'copyright', 'complete', 'language'];
+  SETABLE = ['category', 'subCategory', 'explicit', 'link', 'newFeedUrl', 'publicFeedUrl', 'enclosurePrefix', 'copyright', 'complete', 'language',
+             'authorName', 'authorEmail', 'ownerName', 'ownerEmail','managingEditorName', 'managingEditorEmail'];
   URLS = ['link', 'newFeedUrl', 'publicFeedUrl', 'enclosurePrefix'];
   category = '';
   subCategory = '';
@@ -62,14 +63,16 @@ export class FeederPodcastModel extends BaseModel {
     this.link = this.doc['link'] || '';
     this.newFeedUrl = this.doc['newFeedUrl'] || '';
 
-    if (this.doc['author']) {
-      if (this.doc['author']['name']) {
-        this.authorName = this.doc['author']['name'];
+    ['author', 'owner', 'managingEditor'].forEach((role) => {
+      if (this.doc[role]) {
+        if (this.doc[role]['name']) {
+          this[`${role}Name`] = this.doc[role]['name'];
+        }
+        if (this.doc[role]['email']) {
+          this[`${role}Email`] = this.doc[role]['email'];
+        }
       }
-      if (this.doc['author']['email']) {
-        this.authorEmail = this.doc['author']['email'];
-      }
-    }
+    });
 
     // just ignore all but first category/subcategory
     let cat = (this.doc['itunesCategories'] || [])[0];
@@ -114,12 +117,14 @@ export class FeederPodcastModel extends BaseModel {
     data.newFeedUrl = this.newFeedUrl || null;
     data.url = this.publicFeedUrl || null;
 
-    if (this.authorName || this.authorEmail) {
-      data.author = {
-        name: this.authorName,
-        email: this.authorEmail
-       };
-    }
+    ['author', 'owner', 'managingEditor'].forEach((role) => {
+      if (this[`${role}Name`] || this[`${role}Email`]) {
+        data[role] = {
+          name: this[`${role}Name`],
+          email: this[`${role}Email`]
+        };
+      }
+    });
 
     // we can always send a categories array
     data.itunesCategories = [];

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -10,7 +10,7 @@ export class FeederPodcastModel extends BaseModel {
   publishedUrl: string;
 
   // writeable
-  SETABLE = ['category', 'subCategory', 'explicit', 'link', 'newFeedUrl', 'publicFeedUrl', 'enclosurePrefix', 'authorName', 'authorEmail', 'copyright'];
+  SETABLE = ['category', 'subCategory', 'explicit', 'link', 'newFeedUrl', 'publicFeedUrl', 'enclosurePrefix', 'authorName', 'authorEmail', 'copyright', 'complete'];
   URLS = ['link', 'newFeedUrl', 'publicFeedUrl', 'enclosurePrefix'];
   category = '';
   subCategory = '';

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -10,7 +10,7 @@ export class FeederPodcastModel extends BaseModel {
   publishedUrl: string;
 
   // writeable
-  SETABLE = ['category', 'subCategory', 'explicit', 'link', 'newFeedUrl', 'publicFeedUrl', 'enclosurePrefix', 'authorName', 'authorEmail'];
+  SETABLE = ['category', 'subCategory', 'explicit', 'link', 'newFeedUrl', 'publicFeedUrl', 'enclosurePrefix', 'authorName', 'authorEmail', 'copyright'];
   URLS = ['link', 'newFeedUrl', 'publicFeedUrl', 'enclosurePrefix'];
   category = '';
   subCategory = '';
@@ -21,6 +21,8 @@ export class FeederPodcastModel extends BaseModel {
   enclosurePrefix = '';
   authorName = '';
   authorEmail = '';
+  copyright = '';
+  complete = false;
   hasPublicFeed = false;
 
   VALIDATORS = {
@@ -53,17 +55,23 @@ export class FeederPodcastModel extends BaseModel {
 
   decode() {
     this.id = this.doc['id'];
-    this.publishedUrl = this.doc['publishedUrl'] || '';
+
+    this.copyright = this.doc['copyright'] || '';
+    this.enclosurePrefix = this.doc['enclosurePrefix'] || '';
+    this.link = this.doc['link'] || '';
+    this.newFeedUrl = this.doc['newFeedUrl'] || '';
+
     this.explicit = this.doc['explicit'] || '';
     if (this.explicit) {
       this.explicit = this.explicit.charAt(0).toUpperCase() + this.explicit.slice(1);
     }
-    this.link = this.doc['link'] || '';
-    this.newFeedUrl = this.doc['newFeedUrl'] || '';
+
+    this.publishedUrl = this.doc['publishedUrl'] || '';
     if (this.doc['url']) {
       this.publicFeedUrl = this.doc['url'];
       this.hasPublicFeed = true;
     }
+
     if (this.doc['author']) {
       if (this.doc['author']['name']) {
         this.authorName = this.doc['author']['name'];
@@ -72,7 +80,6 @@ export class FeederPodcastModel extends BaseModel {
         this.authorEmail = this.doc['author']['email'];
       }
     }
-    this.enclosurePrefix = this.doc['enclosurePrefix'] || '';
 
     // just ignore all but first category/subcategory
     let cat = (this.doc['itunesCategories'] || [])[0];
@@ -92,14 +99,17 @@ export class FeederPodcastModel extends BaseModel {
   encode(): {} {
     let data = <any> {};
 
-    // unset things with nulls instead of blank strings
+    // unset with nulls instead of blank strings
+    data.copyright = this.copyright || null;
+    data.enclosurePrefix = this.enclosurePrefix || null;
+    data.link = this.link || null;
+    data.newFeedUrl = this.newFeedUrl || null;
+    data.url = this.publicFeedUrl || null;
+
     data.explicit = this.explicit || null;
     if (data.explicit) {
       data.explicit = data.explicit.toLowerCase();
     }
-    data.link = this.link || null;
-    data.newFeedUrl = this.newFeedUrl || null;
-    data.url = this.publicFeedUrl || null;
 
     if (this.authorName || this.authorEmail) {
       data.author = {
@@ -107,8 +117,6 @@ export class FeederPodcastModel extends BaseModel {
         email: this.authorEmail
        };
     }
-
-    data.enclosurePrefix = this.enclosurePrefix || null;
 
     // we can always send a categories array
     data.itunesCategories = [];

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -3,6 +3,11 @@
 
 declare var System: any;
 
+declare module 'langmap' {
+  export namespace languageMappingList {
+  }
+}
+
 // extend jasmine matchers
 declare module jasmine {
   interface Matchers {


### PR DESCRIPTION
Working on #317 

To the podcast info form:
- [x] Add `copyright`
- [x] Add `complete` 
- [x] Advanced confirm on `complete`
- [x] Add `language`
- [x] Add `managingEditor`
- [x] Add `owner`

To make this happen:
- [x] Add checkbox to fancy field
- [x] Get a list of languages to select from
- [x] Write a better advanced confirm message for `complete`

also fixes #343 