### PR TITLE
Get phantom working in alpine

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,9 @@
 .gitignore
 coverage
 dist
+Dockerfile
 docker-compose.yml
+README.md
 node_modules
 tmp
 typings

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,22 @@ ENV TINI_VERSION v0.9.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static /tini
 RUN chmod +x /tini
 
-WORKDIR /app
+ENV APP_HOME /app
+ENV PHANTOM true
+RUN mkdir -p $APP_HOME
+WORKDIR $APP_HOME
 EXPOSE 4200
 
-ADD . ./
+ENTRYPOINT ["/tini", "--", "./bin/application"]
+CMD [ "serve" ]
 
+ADD ./package.json ./
 RUN apk --update add --virtual build-dependencies git python build-base curl bash && \
   curl -Ls "https://github.com/dustinblackman/phantomized/releases/download/2.1.1/dockerized-phantomjs.tar.gz" | tar xz -C / && \
   npm install --unsafe-perm --loglevel error && \
-  npm run build && \
   apk del build-dependencies && \
   npm cache clean && \
   rm -rf /usr/share/man /tmp/* /var/tmp/* /var/cache/apk/* /root/.npm /root/.node-gyp
 
-ENV PHANTOM true
-ENTRYPOINT ["/tini", "--", "./bin/application"]
-CMD [ "serve" ]
+ADD . ./
+RUN npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,14 @@ EXPOSE 4200
 
 ADD . ./
 
-RUN npm set progress=false && \
-    npm install --no-optional --unsafe-perm && \
-    npm run build
+RUN apk --update add --virtual build-dependencies git python build-base curl bash && \
+  curl -Ls "https://github.com/dustinblackman/phantomized/releases/download/2.1.1/dockerized-phantomjs.tar.gz" | tar xz -C / && \
+  npm install --unsafe-perm --loglevel error && \
+  npm run build && \
+  apk del build-dependencies && \
+  npm cache clean && \
+  rm -rf /usr/share/man /tmp/* /var/tmp/* /var/cache/apk/* /root/.npm /root/.node-gyp
 
+ENV PHANTOM true
 ENTRYPOINT ["/tini", "--", "./bin/application"]
 CMD [ "serve" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,10 +16,10 @@ ENTRYPOINT ["/tini", "--", "./bin/application"]
 CMD [ "serve" ]
 
 ADD ./package.json ./
-RUN apk --update add --virtual build-dependencies git python build-base curl bash && \
+RUN apk --update add curl && \
   curl -Ls "https://github.com/dustinblackman/phantomized/releases/download/2.1.1/dockerized-phantomjs.tar.gz" | tar xz -C / && \
   npm install --unsafe-perm --loglevel error && \
-  apk del build-dependencies && \
+  apk del curl && \
   npm cache clean && \
   rm -rf /usr/share/man /tmp/* /var/tmp/* /var/cache/apk/* /root/.npm /root/.node-gyp
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,7 @@ Enter in the client id in `.env`, setting `AUTH_CLIENT_ID` to the value from abo
 
 ## Local Install
 
-Due to the complexity of installing node-sass in alpine-linux, it may be easier
-to just develop locally for the time being.  Just make sure you have a modern
-node version installed (6.x.x, ideally).
+Make sure you're running the node version in `.nvmrc`, and you're off!
 
 ``` sh
 # install dependencies
@@ -73,28 +71,29 @@ echo 4200 > ~/.pow/publish.prx
 # dev server
 npm start
 open http://publish.prx.dev
+
+# run tests in Chrome
+npm test
 ```
 
 ## Docker Install
 
 Or if you really want to, you can develop via docker-compose.
-This guide assumes you already have npm, docker and dinghy installed.
-
-TODO: hot reloading not supported yet - this just builds the prod js.
+This guide assumes you already have docker and dinghy installed.
 
 ``` sh
 # build a docker image
 docker-compose build
 
-# install dev dependencies locally, so docker can mount those folders
-npm install
-
 # make sure your AUTH_CLIENT_ID is the .docker one
 vim .env
 
-# run the docker image, will detect changes to local file system
+# run the dev server
 docker-compose up
 
 # open up a browser to view
 open http://publish.prx.docker
+
+# run tests in PhantomJS
+docker-compose run publish test
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,23 @@
-app:
+publish:
   build: .
   volumes:
-    - .:/app
+    - ./bin:/app/bin
+    - ./e2e:/app/e2e
+    - ./lib:/app/lib
+    - ./src:/app/src
+    - ./.angular-cli.json:/app/.angular-cli.json
+    - ./codecov.yml:/app/codecov.yml
+    - ./karma.conf.js:/app/karma.conf.js
+    - ./newrelic.js:/app/newrelic.js
+    - ./package.json:/app/package.json
+    - ./protractor.conf.js:/app/protractor.conf.js
+    - ./tsconfig.json:/app/tsconfig.json
+    - ./tslint.json:/app/tslint.json
   env_file:
     - .env
   ports:
     - "4200:4200"
-  command: serve
+    - "4201:4201"
+  command: start
   environment:
     VIRTUAL_HOST: publish.prx.docker

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -52,7 +52,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: [process.env.PHANTOM ? 'PhantomJS' : 'Chrome'],
     singleRun: false
   });
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -23,7 +23,7 @@ app.use('/pub', proxy(env.CMS_HOST, {forwardPath: (req, res) => `/pub${req.url}`
 util.buildIndex(isDist); // throw compilation errors right away
 app.use(function sendIndex(req, res, next) {
   if (util.isIndex(req.path)) {
-    if (req.headers['x-forwarded-proto'] === 'http') {
+    if (req.headers['x-forwarded-proto'] === 'http' && !req.headers['host'].match(/\.docker/)) {
       res.redirect(`https://${req.headers.host}${req.url}`);
     } else {
       res.setHeader('Content-Type', 'text/html');

--- a/lib/util.js
+++ b/lib/util.js
@@ -108,7 +108,7 @@ exports.isIndex = (path) => {
  */
 exports.ngServe = (port) => {
   let ng = `${__dirname}/../node_modules/.bin/ng`;
-  return spawn(ng, ['serve', '--port', port], {stdio: 'inherit'});
+  return spawn(ng, ['serve', '--port', port, '--host', '0.0.0.0'], {stdio: 'inherit'});
 };
 
 /**


### PR DESCRIPTION
Fixes #26.

- [x] Get phantomjs working in alpine
- [x] Get docker-compose tests working
- [x] Get docker-compose dev server working

Finally found an alpine+phantom project that works.  And doesn't require building from source.  Not quite as slick as a selenium/webdriver solution, but after struggling with that for awhile, I gave up.

This will install dev/optional dependencies into the docker container.  Which results in a slightly larger image.  But much better than non-alpine builds, which were pushing 1GB.