### PR TITLE
Fallback to native validation

### DIFF
--- a/src/app/core/audio/player.service.ts
+++ b/src/app/core/audio/player.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { AudioPlayback, AuroraPlayback, NativePlayback, PlaybackMetadata,
   UnsupportedFileError } from './playback';
-import { AudioValidation, AuroraValidation, ValidationMetadata } from './validation';
+import { AudioValidation, AuroraValidation, NativeValidation, ValidationMetadata } from './validation';
 
 @Injectable()
 export class PlayerService {
@@ -35,7 +35,9 @@ export class PlayerService {
   }
 
   checkFile(file: File): Observable<ValidationMetadata> {
-    return this.auroraValidation(file).validate();
+    return this.auroraValidation(file)
+      .validate()
+      .timeoutWith(500, this.nativeValidation(file).validate());
   }
 
   private nativePlayback(fileOrUrl: File | string): AudioPlayback {
@@ -44,6 +46,10 @@ export class PlayerService {
 
   private auroraPlayback(fileOrUrl: File | string): AudioPlayback {
     return this.playback = new AuroraPlayback(fileOrUrl);
+  }
+
+  private nativeValidation(fileOrUrl: File | string): AudioValidation {
+    return new NativeValidation(fileOrUrl);
   }
 
   private auroraValidation(fileOrUrl: File | string): AudioValidation {

--- a/src/app/core/audio/validation/index.ts
+++ b/src/app/core/audio/validation/index.ts
@@ -1,2 +1,3 @@
 export * from './validation';
 export * from './aurora-validation';
+export * from './native-validation';

--- a/src/app/core/audio/validation/native-validation.ts
+++ b/src/app/core/audio/validation/native-validation.ts
@@ -1,0 +1,57 @@
+import { Observable, Subscriber } from 'rxjs';
+import { ValidationMetadata, AudioValidation } from './validation';
+
+export class NativeValidation implements AudioValidation {
+
+  private fileName: string;
+  private fileSrc: string;
+  private element: HTMLAudioElement;
+  private data: ValidationMetadata;
+  private sub: Subscriber<ValidationMetadata>;
+
+  constructor(src: File | string) {
+    this.data = <ValidationMetadata> {};
+    if (src instanceof File) {
+      this.fileName = src.name;
+      this.fileSrc = URL.createObjectURL(src);
+      if (src.type) {
+        this.data.format = src.type.split('/').pop();
+      }
+    } else {
+      this.fileName = src.split('/').pop();
+      this.fileSrc = src;
+    }
+  }
+
+  validate(): Observable<ValidationMetadata> {
+    return Observable.create(sub => {
+      this.element = document.createElement('audio');
+      this.element.addEventListener('canplaythrough', event => {
+        this.data.duration = (event.currentTarget['duration'] || 0) * 1000;
+        sub.next(this.data);
+        sub.complete();
+        this.cleanup();
+      });
+      this.element.addEventListener('error', event => {
+        this.data.duration = 0;
+        this.data.format = 'unknown';
+        sub.next(this.data);
+        sub.complete();
+        this.cleanup();
+      });
+      this.element.src = this.fileSrc;
+    });
+  }
+
+  private cleanup() {
+    if (this.fileSrc) {
+      URL.revokeObjectURL(this.fileSrc);
+      this.fileSrc = null;
+    }
+    if (this.element) {
+      this.element.remove();
+      this.element = null;
+    }
+  }
+
+}


### PR DESCRIPTION
If Aurora validation is taking too long (it fails on mp3s with large id3 images) ... fallback to native <audio> to get the type/duration.

Not always accurate, and lacks bitrate/frequency, but should work for podcast mp3s.