### PR TITLE
Safe localstorage methods

### DIFF
--- a/src/app/shared/model/base.model.ts
+++ b/src/app/shared/model/base.model.ts
@@ -1,6 +1,7 @@
 import { Observable, ReplaySubject } from 'rxjs';
 import { HalDoc } from '../../core';
 import { BaseInvalid } from './invalid';
+import { BaseStorage } from './base.storage';
 
 interface ValidatorMap  { [key: string]: BaseInvalid[]; }
 interface RelatedMap    { [key: string]: Observable<any>; }
@@ -265,23 +266,22 @@ export abstract class BaseModel {
 
   store() {
     this.lastStored = new Date();
-    if (window && window.localStorage && this.key()) {
+    if (this.key()) {
       let changed = {};
       this.SETABLE.filter(f => this.changed(f)).forEach(f => changed[f] = this[f]);
       if (Object.keys(changed).length > 0) {
         changed['lastStored'] = this.lastStored;
-        window.localStorage.setItem(this.key(), JSON.stringify(changed));
+        BaseStorage.setItem(this.key(), changed);
       } else {
-        window.localStorage.removeItem(this.key());
+        BaseStorage.removeItem(this.key());
       }
     }
   }
 
   restore() {
-    if (window && window.localStorage && this.key()) {
-      let json = window.localStorage.getItem(this.key());
-      if (json) {
-        let data = JSON.parse(json);
+    if (this.key()) {
+      let data = BaseStorage.getItem(this.key());
+      if (data) {
         for (let key of Object.keys(data)) {
           if (this.SETABLE.indexOf(key) > -1) {
             this[key] = data[key];
@@ -295,14 +295,14 @@ export abstract class BaseModel {
   }
 
   unstore() {
-    if (window && window.localStorage && this.key()) {
-      window.localStorage.removeItem(this.key());
+    if (this.key()) {
+      BaseStorage.removeItem(this.key());
     }
   }
 
   isStored(): boolean {
-    if (window && window.localStorage && this.key()) {
-      return window.localStorage.getItem(this.key()) ? true : false;
+    if (this.key()) {
+      return BaseStorage.getItem(this.key()) ? true : false;
     } else {
       return false;
     }

--- a/src/app/shared/model/base.storage.spec.ts
+++ b/src/app/shared/model/base.storage.spec.ts
@@ -1,0 +1,55 @@
+import { BaseStorage } from './base.storage';
+
+describe('BaseStorage', () => {
+
+  beforeEach(() => BaseStorage.clear());
+
+  it('uses localstorage by default', () => {
+    expect(localStorage.length).toEqual(0);
+    expect(BaseStorage.getItem('foo')).toBeNull();
+
+    BaseStorage.setItem('foo', {id: 'foo'});
+    expect(localStorage.length).toEqual(1);
+    expect(BaseStorage.getItem('foo')).toEqual({id: 'foo'});
+
+    BaseStorage.removeItem('foo');
+    expect(localStorage.length).toEqual(0);
+    expect(BaseStorage.getItem('foo')).toBeNull();
+  });
+
+  it('falls back to in-memory storage', () => {
+    spyOn(localStorage, 'setItem').and.throwError('no localstorage');
+    BaseStorage.setItem('foo', {id: 'foo'});
+    expect(localStorage.length).toEqual(0);
+    expect(BaseStorage.getItem('foo')).toEqual({id: 'foo'});
+
+    BaseStorage.removeItem('foo');
+    expect(localStorage.length).toEqual(0);
+    expect(BaseStorage.getItem('foo')).toBeNull();
+  });
+
+  it('falls back at any time', () => {
+    let originalSetItem = localStorage.setItem.bind(localStorage);
+    spyOn(localStorage, 'setItem').and.callFake((key, val) => {
+      if (key === 'foo') {
+        originalSetItem('foo', val);
+      } else {
+        throw new Error('bad stuff happens');
+      }
+    });
+
+    BaseStorage.setItem('foo', {id: 'foo'});
+    BaseStorage.setItem('bar', {id: 'bar'});
+    expect(localStorage.length).toEqual(1);
+    expect(BaseStorage.getItem('foo')).toEqual({id: 'foo'});
+    expect(BaseStorage.getItem('bar')).toEqual({id: 'bar'});
+
+    BaseStorage.removeItem('bar');
+    expect(localStorage.length).toEqual(1);
+    BaseStorage.removeItem('foo');
+    expect(localStorage.length).toEqual(0);
+    expect(BaseStorage.getItem('foo')).toBeNull();
+    expect(BaseStorage.getItem('bar')).toBeNull();
+  });
+
+});

--- a/src/app/shared/model/base.storage.ts
+++ b/src/app/shared/model/base.storage.ts
@@ -1,0 +1,49 @@
+/**
+ * Safe localstorage with in-memory fallback
+ */
+export abstract class BaseStorage {
+
+  private static DATA: { [key: string]: string; } = {};
+
+  static getItem(key: string): any {
+    let json = this.DATA[key];
+    try {
+      json = localStorage.getItem(key) || json;
+    } catch (e) {}
+
+    if (json) {
+      try {
+        return JSON.parse(json);
+      } catch (e) {
+        this.removeItem(key);
+        return null;
+      }
+    } else {
+      return null;
+    }
+  }
+
+  static setItem(key: string, data: {}) {
+    let json = JSON.stringify(data);
+    try {
+      localStorage.setItem(key, json);
+    } catch (e) {
+      this.DATA[key] = json;
+    }
+  }
+
+  static removeItem(key) {
+    delete this.DATA[key];
+    try {
+      localStorage.removeItem(key);
+    } catch (e) {}
+  }
+
+  static clear() {
+    this.DATA = {};
+    try {
+      localStorage.clear();
+    } catch (e) {}
+  }
+
+}


### PR DESCRIPTION
See #408.

There are conditions where localStorage methods will throw errors.  Some mobile platforms, safari private browsing, localStorage full, some security settings, etc.  Catch any and all localStorage errors, and gracefully fall back to in-memory storage.

Shouldn't have too much of an impact on Publish when using in-memory.  Other than when you refresh the page, you lose local changes.

A bit tricky to test, since you can't even log into publish in private browsing mode.  (The security settings are a lot more strict).  But you can simulate by doing something like `localStorage.setItem = function() { throw new Error('bad'); }` in the console.