### PR TITLE
Editable public feed

### DIFF
--- a/src/app/series/directives/series-podcast.component.css
+++ b/src/app/series/directives/series-podcast.component.css
@@ -3,24 +3,9 @@
   width: 250px;
   margin-right: 40px;
 }
-.prx-feed-url input, .feed-url input {
-  padding: 10px 8px;
-  color: #939393;
-  margin-bottom: 4px;
-}
 .prx-feed-url input {
+  padding: 10px 8px;
+  margin-bottom: 4px;
+  color: #939393;
   width: 100%;
-}
-.feed-url input {
-  min-width: 400px;
-}
-.feed-url button, .feed-url .button {
-  padding-top: 9px;
-  padding-bottom: 8px;
-}
-.feed-url button {
-  background-color: #f59f51;
-}
-.feed-url button:hover, .feed-url button:focus {
-  background-color: #e28b42;
 }

--- a/src/app/series/directives/series-podcast.component.css
+++ b/src/app/series/directives/series-podcast.component.css
@@ -3,9 +3,23 @@
   width: 250px;
   margin-right: 40px;
 }
-.prx-feed-url input {
+.prx-feed-url input, .feed-url input {
   padding: 10px 8px;
   margin-bottom: 4px;
-  color: #939393;
+}
+.prx-feed-url input {
   width: 100%;
+}
+.feed-url input {
+  min-width: 400px;
+}
+.feed-url button, .feed-url .button {
+  padding-top: 9px;
+  padding-bottom: 8px;
+}
+.feed-url button {
+  background-color: #f59f51;
+}
+.feed-url button:hover, .feed-url button:focus {
+  background-color: #e28b42;
 }

--- a/src/app/series/directives/series-podcast.component.css
+++ b/src/app/series/directives/series-podcast.component.css
@@ -10,6 +10,9 @@
 .prx-feed-url input {
   width: 100%;
 }
+input.changed {
+  outline: 5px auto #f09b4c;
+}
 .feed-url input {
   min-width: 400px;
 }

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -119,7 +119,7 @@
 
     <prx-fancy-field *ngIf="podcast?.hasPublicFeed" label="Public Feed Url" textinput [model]="podcast" name="publicFeedUrl" [advancedConfirm]="publicFeedChangeConfirm">
       <div class="fancy-hint">
-        The public URL for your podcast feed. Feel free to share this URL with listeners. If you need to alter this URL once your feed is live, set the <a target="_blank" rel="noopener" href="this.itunesNewFeedURLDoc">New Feed URL</a> as well.
+        The public URL for your podcast feed. Feel free to share this URL with listeners. If you need to alter this URL once you have subscribers, set the <a target="_blank" rel="noopener" href="this.itunesNewFeedURLDoc">New Feed URL</a> as well.
       </div>
       <p *ngIf="showNewFeedCheckbox">
         <input type="checkbox" (change)="setNewFeedToPublicFeed($event)" [checked]="podcast.publicFeedUrl === podcast.newFeedUrl" id="matchFeeds">

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -117,10 +117,17 @@
       <input type="text" readonly [ngModel]="podcast?.publishedUrl" name="publishedUrl"/>
     </prx-fancy-field>
 
-    <prx-fancy-field *ngIf="podcast?.hasPublicFeed" label="Public Feed Url" textinput [model]="podcast" name="publicFeedUrl" [advancedConfirm]="publicFeedChangeConfirm">
+    <prx-fancy-field *ngIf="podcast?.hasPublicFeed" label="Public Feed Url" class="feed-url">
       <div class="fancy-hint">
         The public URL for your podcast feed. Feel free to share this URL with listeners. If you need to alter this URL once you have subscribers, set the <a target="_blank" rel="noopener" href="this.itunesNewFeedURLDoc">New Feed URL</a> as well.
       </div>
+      <input type="text"
+             [ngModel]="podcast?.publicFeedUrl"
+             name="publicFeedUrl" #pubFeed
+             [prxAdvancedConfirm]="publicFeedChangeConfirm" [prxModel]="podcast" prxName="publicFeedUrl" (ngModelChange)="podcast.set('publicFeedUrl', $event)"
+      />
+      <button [publishCopyInput]="pubFeed">Copy</button>
+      <a class="button" target="_blank" rel="noopener" [href]="podcast?.publicFeedUrl">Open Link</a>
       <p *ngIf="showNewFeedCheckbox">
         <input type="checkbox" (change)="setNewFeedToPublicFeed($event)" [checked]="podcast.publicFeedUrl === podcast.newFeedUrl" id="matchFeeds">
         <label for="matchFeeds">Check to set your podcast's New Feed URL to this URL as well.</label>

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -117,21 +117,20 @@
       <input type="text" readonly [ngModel]="podcast?.publishedUrl" name="publishedUrl"/>
     </prx-fancy-field>
 
-    <prx-fancy-field label="Public Feed Url" class="feed-url">
-      <div *ngIf="podcast?.hasPublicFeed">
-        <div class="fancy-hint">
-          The public URL for your podcast feed. Feel free to share this URL with listeners. If you need to alter this URL, please
-          do so safely by using the New Feed Url field in the Advanced settings.
-        </div>
-        <input type="text" readonly [ngModel]="podcast?.publicFeedUrl" name="publicFeedUrl" #pubFeed/>
-        <button [publishCopyInput]="pubFeed">Copy</button>
-        <a class="button" target="_blank" rel="noopener" [href]="podcast?.publicFeedUrl">Open Link</a>
+    <prx-fancy-field *ngIf="podcast?.hasPublicFeed" label="Public Feed Url" textinput [model]="podcast" name="publicFeedUrl" [advancedConfirm]="publicFeedChangeConfirm">
+      <div class="fancy-hint">
+        The public URL for your podcast feed. Feel free to share this URL with listeners. If you need to alter this URL once your feed is live, set the <a target="_blank" rel="noopener" href="this.itunesNewFeedURLDoc">New Feed URL</a> as well.
       </div>
-      <prx-fancy-field textinput [model]="podcast" name="publicFeedUrl" *ngIf="!podcast?.hasPublicFeed">
-        <div class="fancy-hint">
-          If you already have a public URL for your podcast feed (e.g., feedburner), enter it here.
-        </div>
-      </prx-fancy-field>
+      <p *ngIf="showNewFeedCheckbox">
+        <input type="checkbox" (change)="setNewFeedToPublicFeed($event)" [checked]="podcast.publicFeedUrl === podcast.newFeedUrl" id="matchFeeds">
+        <label for="matchFeeds">Check to set your podcast's New Feed URL to this URL as well.</label>
+      </p>
+    </prx-fancy-field>
+
+    <prx-fancy-field *ngIf="!podcast?.hasPublicFeed" label="Public Feed Url" textinput [model]="podcast" name="publicFeedUrl">
+      <div class="fancy-hint">
+        If you already have a public URL for your podcast feed (e.g., feedburner), enter it here.
+      </div>
     </prx-fancy-field>
 
     <prx-fancy-field label="Enclosure Prefix Url" textinput [model]="podcast" name="enclosurePrefix">

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -121,17 +121,15 @@
       <div class="fancy-hint">
         The public URL for your podcast feed. Feel free to share this URL with listeners. If you need to alter this URL once you have subscribers, set the <a target="_blank" rel="noopener" href="this.itunesNewFeedURLDoc">New Feed URL</a> as well.
       </div>
-      <input type="text"
-             [ngModel]="podcast?.publicFeedUrl"
-             name="publicFeedUrl" #pubFeed
-             [prxAdvancedConfirm]="publicFeedChangeConfirm" [prxModel]="podcast" prxName="publicFeedUrl" (ngModelChange)="podcast.set('publicFeedUrl', $event)"
-      />
-      <button [publishCopyInput]="pubFeed">Copy</button>
-      <a class="button" target="_blank" rel="noopener" [href]="podcast?.publicFeedUrl">Open Link</a>
-      <p *ngIf="showNewFeedCheckbox">
+      <p>
         <input type="checkbox" (change)="setNewFeedToPublicFeed($event)" [checked]="podcast.publicFeedUrl === podcast.newFeedUrl" id="matchFeeds">
         <label for="matchFeeds">Check to set your podcast's New Feed URL to this URL as well.</label>
       </p>
+      <input type="text" [ngModel]="podcast?.publicFeedUrl" name="publicFeedUrl" #pubFeed
+       [prxAdvancedConfirm]="publicFeedChangeConfirm" [prxModel]="podcast" prxName="publicFeedUrl" (ngModelChange)="podcast.set('publicFeedUrl', $event)"
+       [class.changed]="podcast.changed('publicFeedUrl', false)"/>
+      <button [publishCopyInput]="pubFeed">Copy</button>
+      <a class="button" target="_blank" rel="noopener" [href]="podcast?.publicFeedUrl">Open Link</a>
     </prx-fancy-field>
 
     <prx-fancy-field *ngIf="!podcast?.hasPublicFeed" label="Public Feed Url" textinput [model]="podcast" name="publicFeedUrl">

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -18,6 +18,8 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
   itunesRequirementsDoc = 'https://help.apple.com/itc/podcasts_connect/#/itc1723472cb';
   itunesExplicitDoc = 'https://support.apple.com/en-us/HT202005';
   itunesCategoryDoc = 'https://help.apple.com/itc/podcasts_connect/#/itc9267a2f12';
+  itunesNewFeedURLDoc = 'https://help.apple.com/itc/podcasts_connect/#/itca489031e0';
+  showNewFeedCheckbox = false;
   audioVersionOptions: string[][];
 
   tabSub: Subscription;
@@ -69,6 +71,7 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
     } else {
       this.state = null;
     }
+    this.showCheckboxIfUrlChanged();
   }
 
   ngOnDestroy(): any {
@@ -121,6 +124,34 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
     }
     if (this.podcast && this.subCategories.indexOf(this.podcast.subCategory) < 0) {
       this.podcast.set('subCategory', '');
+    }
+  }
+
+  setNewFeedToPublicFeed(e: Event) {
+    if (e.currentTarget && e.currentTarget['checked']) {
+      this.podcast.newFeedUrl = this.podcast.publicFeedUrl;
+    }
+  }
+
+  showCheckboxIfUrlChanged() {
+    if (this.podcast) {
+      let changedOne = this.podcast.changed('publicFeedUrl') && !this.podcast.changed('newFeedUrl');
+      if (this.showNewFeedCheckbox || changedOne) {
+        this.showNewFeedCheckbox = true;
+      }
+    }
+  }
+
+  get publicFeedChangeConfirm(): string {
+    if (this.podcast && this.podcast.original['publicFeedUrl']) {
+      let confirmMsg = `Are you sure you want to change your public feed URL
+                       from "${this.podcast.original['publicFeedUrl']}" to "${this.podcast.publicFeedUrl}"?
+                       This will point your subscribers to a new feed location.
+                       If you have existing subscribers at ${this.podcast.original['publicFeedUrl']},
+                       make sure to set the <a target="_blank" rel="noopener"
+                       href="${this.itunesNewFeedURLDoc}">New Feed URL</a>
+                       as well to avoid losing subscribers.`;
+      return confirmMsg;
     }
   }
 

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -19,7 +19,6 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
   itunesExplicitDoc = 'https://support.apple.com/en-us/HT202005';
   itunesCategoryDoc = 'https://help.apple.com/itc/podcasts_connect/#/itc9267a2f12';
   itunesNewFeedURLDoc = 'https://help.apple.com/itc/podcasts_connect/#/itca489031e0';
-  showNewFeedCheckbox = false;
   audioVersionOptions: string[][];
 
   tabSub: Subscription;
@@ -71,7 +70,6 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
     } else {
       this.state = null;
     }
-    this.showCheckboxIfUrlChanged();
   }
 
   ngOnDestroy(): any {
@@ -130,15 +128,6 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
   setNewFeedToPublicFeed(e: Event) {
     if (e.currentTarget && e.currentTarget['checked']) {
       this.podcast.newFeedUrl = this.podcast.publicFeedUrl;
-    }
-  }
-
-  showCheckboxIfUrlChanged() {
-    if (this.podcast) {
-      let changedOne = this.podcast.changed('publicFeedUrl') && !this.podcast.changed('newFeedUrl');
-      if (this.showNewFeedCheckbox || changedOne) {
-        this.showNewFeedCheckbox = true;
-      }
     }
   }
 


### PR DESCRIPTION
In the interest of soliciting feedback, here's one approach to #431: 
- allow edits to public feed URL
- show a checkbox users can check to set the new feed URL to this as well
- lots of messaging that if the feed is live and the public URL changes, the new feed URL should be set as well to redirect subscribers; plus lots of linking to Apple docs on how to handle source feed change. 
