### PR TITLE
Multiple series templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "morgan": "^1.8.1",
     "newrelic": "1.38.2",
     "ng2-dragula": "^1.3.1",
-    "ngx-prx-styleguide": "0.0.15",
+    "ngx-prx-styleguide": "0.0.16",
     "prosemirror-commands": "0.18.0",
     "prosemirror-inputrules": "0.18.0",
     "prosemirror-keymap": "0.18.0",

--- a/src/app/series/directives/file-template.component.spec.ts
+++ b/src/app/series/directives/file-template.component.spec.ts
@@ -14,7 +14,7 @@ describe('FileTemplateComponent', () => {
 
   cit('renders undestroyed file templates', (fix, el, comp) => {
     expect(el).not.toQuery('prx-fancy-field');
-    comp.file = new AudioFileTemplateModel(null);
+    comp.file = new AudioFileTemplateModel(null, 0, 1);
     comp.file.isDestroy = true;
     fix.detectChanges();
     expect(el).not.toQuery('prx-fancy-field');
@@ -24,7 +24,7 @@ describe('FileTemplateComponent', () => {
   });
 
   cit('only allows removing the last template in a version', (fix, el, comp) => {
-    comp.file = new AudioFileTemplateModel(null);
+    comp.file = new AudioFileTemplateModel(null, 0, 1);
     comp.version = {fileTemplates: [{}, comp.file, {}]};
     fix.detectChanges();
     expect(el).not.toQuery('.icon-cancel');
@@ -34,7 +34,7 @@ describe('FileTemplateComponent', () => {
   });
 
   cit('shows label and length validation errors', (fix, el, comp) => {
-    comp.file = new AudioFileTemplateModel(null);
+    comp.file = new AudioFileTemplateModel(null, 0, 1);
     fix.detectChanges();
     expect(el).toContainText('label is a required field');
     comp.file.set('label', 'foobar');

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -49,7 +49,7 @@
     <prx-fancy-field required label="Podcast Audio" name="versionTemplateUrls"
       [multiselect]="audioVersionOptions" [model]="distribution" [advancedConfirm]="versionTemplateConfirm">
       <div class="fancy-hint">
-        Select which template(s) should be used with your podcast. If an episodes
+        Select which template(s) should be used with your podcast. If an episode
         of your podcast provides more than one of these, the first one in this
         list will be used.
       </div>

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -47,8 +47,12 @@
     </prx-fancy-field>
 
     <prx-fancy-field required label="Podcast Audio" name="versionTemplateUrl"
-      [select]="audioVersionOptions" [model]="distribution" [advancedConfirm]="versionTemplateConfirm">
-      <div class="fancy-hint">Select which audio template should be used with your podcast.</div>
+      [multiselect]="audioVersionOptions" [model]="distribution" [advancedConfirm]="versionTemplateConfirm">
+      <div class="fancy-hint">
+        Select which template(s) should be used with your podcast. If an episodes
+        of your podcast provides more than one of these, the first one in this
+        list will be used.
+      </div>
     </prx-fancy-field>
 
     <prx-fancy-field label="Homepage Link" required textinput [model]="podcast" name="link">

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -27,7 +27,7 @@
       </div>
       <div class="span-fields">
         <prx-fancy-field label="Category" [model]="podcast" name="category"
-          [select]="categories" (change)="setSubCategories()" small=1>
+          [select]="categories" (onChange)="setSubCategories()" small=1>
         </prx-fancy-field>
         <prx-fancy-field *ngIf="subCategories.length" label="Sub-Category"
           [model]="podcast" name="subCategory" [select]="subCategories" small=1>
@@ -122,7 +122,7 @@
         The public URL for your podcast feed. Feel free to share this URL with listeners. If you need to alter this URL once you have subscribers, set the <a target="_blank" rel="noopener" href="this.itunesNewFeedURLDoc">New Feed URL</a> as well.
       </div>
       <p>
-        <input type="checkbox" (change)="setNewFeedToPublicFeed($event)" [checked]="podcast.publicFeedUrl === podcast.newFeedUrl" id="matchFeeds">
+        <input type="checkbox" (onChange)="setNewFeedToPublicFeed($event)" [checked]="podcast.publicFeedUrl === podcast.newFeedUrl" id="matchFeeds">
         <label for="matchFeeds">Check to set your podcast's New Feed URL to this URL as well.</label>
       </p>
       <input type="text" [ngModel]="podcast?.publicFeedUrl" name="publicFeedUrl" #pubFeed
@@ -151,7 +151,7 @@
       </div>
     </prx-fancy-field>
 
-    <prx-fancy-field label="Language" [model]="podcast" name="language" [select]="languageOptions">
+    <prx-fancy-field label="Language" [model]="podcast" name="language" [select]="languageOptions" searchable>
       <div class="fancy-hint">Select which language your podcast is in.</div>
     </prx-fancy-field>
 

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -126,7 +126,7 @@
         The public URL for your podcast feed. Feel free to share this URL with listeners. If you need to alter this URL once you have subscribers, set the <a target="_blank" rel="noopener" href="this.itunesNewFeedURLDoc">New Feed URL</a> as well.
       </div>
       <p>
-        <input type="checkbox" (onChange)="setNewFeedToPublicFeed($event)" [checked]="podcast.publicFeedUrl === podcast.newFeedUrl" id="matchFeeds">
+        <input type="checkbox" (change)="setNewFeedToPublicFeed($event)" [checked]="podcast.publicFeedUrl === podcast.newFeedUrl" id="matchFeeds">
         <label for="matchFeeds">Check to set your podcast's New Feed URL to this URL as well.</label>
       </p>
       <input type="text" [ngModel]="podcast?.publicFeedUrl" name="publicFeedUrl" #pubFeed

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -46,7 +46,7 @@
       </div>
     </prx-fancy-field>
 
-    <prx-fancy-field required label="Podcast Audio" name="versionTemplateUrl"
+    <prx-fancy-field required label="Podcast Audio" name="versionTemplateUrls"
       [multiselect]="audioVersionOptions" [model]="distribution" [advancedConfirm]="versionTemplateConfirm">
       <div class="fancy-hint">
         Select which template(s) should be used with your podcast. If an episodes

--- a/src/app/series/directives/series-podcast.component.spec.ts
+++ b/src/app/series/directives/series-podcast.component.spec.ts
@@ -35,7 +35,7 @@ describe('SeriesPodcastComponent', () => {
     comp.series = {loadRelated: () => Observable.of(null), distributions: []};
     comp.audioVersionOptions = [['Something', 'some-href']];
     comp.createDistribution();
-    expect(comp.distribution.versionTemplateUrl).toEqual('some-href');
+    expect(comp.distribution.versionTemplateUrls).toEqual(['some-href']);
   });
 
   cit('finds podcast distributions for the series', (fix, el, comp) => {

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -170,7 +170,7 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
   get versionTemplateConfirm(): string {
     if (this.distribution && this.audioVersionOptions && this.series.hasStories) {
       return `
-        Are you sure you want change the template(s) used for your podcast?
+        Are you sure you want to change the template(s) used for your podcast?
         This could change the audio files used in all published episodes of your podcast.
       `;
     }

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -87,6 +87,7 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
             this.podcast = this.distribution.podcast;
             this.setSubCategories();
           });
+          this.distribution.loadRelated('versionTemplates').subscribe();
         } else {
           this.podcast = null;
           this.setSubCategories();

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -12,9 +12,9 @@ import * as languageMappingList from 'langmap';
 
 export class SeriesPodcastComponent implements OnDestroy, DoCheck {
 
-  categories = [''].concat(CATEGORIES);
+  categories = CATEGORIES;
   subCategories: string[] = [];
-  explicitOpts = ['', 'Explicit', 'Clean'];
+  explicitOpts = ['Explicit', 'Clean'];
   itunesRequirementsDoc = 'https://help.apple.com/itc/podcasts_connect/#/itc1723472cb';
   itunesExplicitDoc = 'https://support.apple.com/en-us/HT202005';
   itunesCategoryDoc = 'https://help.apple.com/itc/podcasts_connect/#/itc9267a2f12';

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -105,7 +105,7 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
     });
     this.series.loadRelated('versionTemplates').subscribe(() => {
       if (this.audioVersionOptions.length === 1) {
-        podcastDist.set('versionTemplateUrl', this.audioVersionOptions[0][1], true);
+        podcastDist.set('versionTemplateUrls', [this.audioVersionOptions[0][1]], true);
       }
     });
   }
@@ -168,12 +168,9 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
 
   get versionTemplateConfirm(): string {
     if (this.distribution && this.audioVersionOptions && this.series.hasStories) {
-      let url = this.distribution.versionTemplateUrl;
-      let match = this.audioVersionOptions.find(opt => opt[1] === url);
-      let name = match ? match[0] : ''; // options are [[display, value]]
       return `
-        Are you sure you want to use <b>${name}</b> as the audio for your podcast?
-        This will change the audio files used in all published episodes of your podcast.
+        Are you sure you want change the template(s) used for your podcast?
+        This could change the audio files used in all published episodes of your podcast.
       `;
     }
   }

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -105,9 +105,7 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
       this.podcast = podcastDist.podcast;
     });
     this.series.loadRelated('versionTemplates').subscribe(() => {
-      if (this.audioVersionOptions.length === 1) {
-        podcastDist.set('versionTemplateUrls', [this.audioVersionOptions[0][1]], true);
-      }
+      podcastDist.set('versionTemplateUrls', [this.audioVersionOptions[0][1]], true);
     });
   }
 

--- a/src/app/series/directives/series-templates.component.css
+++ b/src/app/series/directives/series-templates.component.css
@@ -49,7 +49,7 @@
     width: auto;
   }
 }
-.add-version, .add-segment {
+.add-segment {
   margin-top: 20px;
 }
 .add-version i, .add-segment i {

--- a/src/app/series/directives/series-templates.component.css
+++ b/src/app/series/directives/series-templates.component.css
@@ -1,6 +1,9 @@
 /**
  * Series version/file templates
  */
+.version {
+  width: 100%;
+}
 .version header {
   background-color: #B8B8B8;
   padding: 16px 14px;

--- a/src/app/series/directives/series-templates.component.html
+++ b/src/app/series/directives/series-templates.component.html
@@ -19,14 +19,6 @@
           <div class="fancy-hint">A name for this audio template, such as "Podcast Audio" or "Clean Version"</div>
         </prx-fancy-field>
 
-        <prx-fancy-field required [select]="contentTypeOptions" [model]="v"
-          name="contentType" label="File Type" [disabled]="!v.isNew">
-          <div class="fancy-hint">
-            All files uploaded to this template must have this file type. This cannot
-            be changed once you save this template.
-          </div>
-        </prx-fancy-field>
-
         <prx-fancy-field *ngIf="v.isAudio" class="length" [model]="v" label="Total length" invalid="lengthAny">
           <div class="fancy-hint">
             The minimum and maximum HH:MM:SS durations for all the audio files. Used to ensure that each
@@ -53,9 +45,11 @@
   </ng-container>
 
   <section>
-    <button class="add-version" (click)="addVersion()"><i class="icon-plus white" aria-hidden="true"></i>
-      <ng-container *ngIf="!hasVersions()">Add a template</ng-container>
-      <ng-container *ngIf="hasVersions()">Add another template</ng-container>
+    <button class="add-version" (click)="addAudioVersion()">
+      <i class="icon-plus white" aria-hidden="true"></i> Add audio template
+    </button>
+    <button class="add-version" (click)="addVideoVersion()">
+      <i class="icon-plus white" aria-hidden="true"></i> Add video template
     </button>
   </section>
 </form>

--- a/src/app/series/directives/series-templates.component.html
+++ b/src/app/series/directives/series-templates.component.html
@@ -12,7 +12,8 @@
     <div *ngIf="!v.isDestroy" class="version">
       <header>
         <strong>{{v?.label}}</strong>
-        <button type="button" class="btn-icon icon-cancel grey-dove" (click)="confirmRemoveVersion(v)"></button>
+        <button type="button" class="btn-icon icon-cancel grey-dove"
+          aria-label="Remove" (click)="confirmRemoveVersion(v)"></button>
       </header>
       <section>
         <prx-fancy-field required textinput [model]="v" name="label" label="Template Label">

--- a/src/app/series/directives/series-templates.component.html
+++ b/src/app/series/directives/series-templates.component.html
@@ -1,0 +1,53 @@
+<form *ngIf="series">
+  <prx-fancy-field label="Audio Templates">
+    <div class="fancy-hint">
+      When you add episodes, you may want to have different versions of the audio (e.g., clean v. explicit).
+      This page lets you define templates for the versions each episode in this series should have, including
+      specific segment requirements (note: don't include ads here). Every episode using these templates will
+      be checked against them for validity.
+    </div>
+  </prx-fancy-field>
+
+  <ng-container *ngFor="let v of series.versionTemplates">
+    <div *ngIf="!v.isDestroy" class="version">
+      <header>
+        <strong>{{v?.label}} {{v?.newIndex}}</strong>
+        <button type="button" class="btn-icon icon-cancel grey-dove" (click)="confirmRemoveVersion(v)"></button>
+      </header>
+      <section>
+        <prx-fancy-field required textinput [model]="v" name="label" label="Template Label">
+          <div class="fancy-hint">A name for this audio template, such as "Podcast Audio" or "Clean Version"</div>
+        </prx-fancy-field>
+
+        <prx-fancy-field class="length" [model]="v" label="Total length" invalid="lengthAny">
+          <div class="fancy-hint">
+            The minimum and maximum HH:MM:SS durations for all the audio files. Used to ensure that each
+            of your episodes is the desired approximate length, and to prevent uploading bad audio.
+          </div>
+          <prx-fancy-duration [model]="v" name="lengthMinimum" label="Minimum"
+            [advancedConfirm]="lengthConfirm(v, v['lengthMinimum'] | duration, 'minimum')"></prx-fancy-duration>
+          <prx-fancy-duration [model]="v" name="lengthMaximum" label="Maximum"
+            [advancedConfirm]="lengthConfirm(v, v['lengthMaximum'] | duration, 'maximum')"></prx-fancy-duration>
+        </prx-fancy-field>
+
+        <prx-fancy-field label="Segments">
+          <div class="fancy-hint">
+            Describe the individual segment audio files required in this template. Give
+            them a label such as "Billboard" or "Part A", and an optional min/max length
+            to validate the specific file.
+          </div>
+          <publish-file-template *ngFor="let t of v.fileTemplates" [file]="t" [version]="v"></publish-file-template>
+          <button tabindex=-1 class="add-segment" *ngIf="canAddFile(v)" type="button"
+            (click)="confirmAddFile($event, v)"><i class="icon-plus white" aria-hidden="true"></i> Add Segment</button>
+        </prx-fancy-field>
+      </section>
+    </div>
+  </ng-container>
+
+  <section>
+    <button class="add-version" (click)="addVersion()"><i class="icon-plus white" aria-hidden="true"></i>
+      <ng-container *ngIf="!hasVersions()">Add a template</ng-container>
+      <ng-container *ngIf="hasVersions()">Add another template</ng-container>
+    </button>
+  </section>
+</form>

--- a/src/app/series/directives/series-templates.component.html
+++ b/src/app/series/directives/series-templates.component.html
@@ -11,7 +11,7 @@
   <ng-container *ngFor="let v of series.versionTemplates">
     <div *ngIf="!v.isDestroy" class="version">
       <header>
-        <strong>{{v?.label}} {{v?.newIndex}}</strong>
+        <strong>{{v?.label}}</strong>
         <button type="button" class="btn-icon icon-cancel grey-dove" (click)="confirmRemoveVersion(v)"></button>
       </header>
       <section>
@@ -19,7 +19,15 @@
           <div class="fancy-hint">A name for this audio template, such as "Podcast Audio" or "Clean Version"</div>
         </prx-fancy-field>
 
-        <prx-fancy-field class="length" [model]="v" label="Total length" invalid="lengthAny">
+        <prx-fancy-field required [select]="contentTypeOptions" [model]="v"
+          name="contentType" label="File Type" [disabled]="!v.isNew">
+          <div class="fancy-hint">
+            All files uploaded to this template must have this file type. This cannot
+            be changed once you save this template.
+          </div>
+        </prx-fancy-field>
+
+        <prx-fancy-field *ngIf="v.isAudio" class="length" [model]="v" label="Total length" invalid="lengthAny">
           <div class="fancy-hint">
             The minimum and maximum HH:MM:SS durations for all the audio files. Used to ensure that each
             of your episodes is the desired approximate length, and to prevent uploading bad audio.
@@ -30,7 +38,7 @@
             [advancedConfirm]="lengthConfirm(v, v['lengthMaximum'] | duration, 'maximum')"></prx-fancy-duration>
         </prx-fancy-field>
 
-        <prx-fancy-field label="Segments">
+        <prx-fancy-field *ngIf="v.isAudio" label="Segments">
           <div class="fancy-hint">
             Describe the individual segment audio files required in this template. Give
             them a label such as "Billboard" or "Part A", and an optional min/max length

--- a/src/app/series/directives/series-templates.component.spec.ts
+++ b/src/app/series/directives/series-templates.component.spec.ts
@@ -39,14 +39,13 @@ describe('SeriesTemplatesComponent', () => {
   });
 
   cit('adds a file template', (fix, el, comp) => {
-    let files = [];
-    comp.series = {versionTemplates: [{isAudio: true, fileTemplates: files}]};
+    let added = false;
+    comp.series = {versionTemplates: [{isAudio: true, fileTemplates: [], addFile: () => added = true}]};
     fix.detectChanges();
     expect(el).not.toQuery('publish-file-template');
     el.query(By.css('[label="Segments"] .icon-plus')).nativeElement.click();
     fix.detectChanges();
-    expect(el).toQuery('publish-file-template');
-    expect(files[0].label).toEqual('Segment A');
+    expect(added).toEqual(true);
   });
 
   cit('adds a destroyed file template', (fix, el, comp) => {

--- a/src/app/series/directives/series-templates.component.spec.ts
+++ b/src/app/series/directives/series-templates.component.spec.ts
@@ -17,12 +17,16 @@ describe('SeriesTemplatesComponent', () => {
     expect(el).not.toQuery('.version');
   });
 
-  cit('adds a new version template', (fix, el, comp) => {
+  cit('adds new version templates', (fix, el, comp) => {
     comp.series = {versionTemplates: []};
     fix.detectChanges();
     el.query(By.css('.add-version')).nativeElement.click();
     fix.detectChanges();
     expect(el).toQuery('[label="Template Label"]');
+    expect(el.queryAll(By.css('[label="Template Label"]')).length).toEqual(1);
+    el.query(By.css('.add-version')).nativeElement.click();
+    fix.detectChanges();
+    expect(el.queryAll(By.css('[label="Template Label"]')).length).toEqual(2);
   });
 
   cit('removes a version template', (fix, el, comp) => {
@@ -36,7 +40,7 @@ describe('SeriesTemplatesComponent', () => {
 
   cit('adds a file template', (fix, el, comp) => {
     let files = [];
-    comp.series = {versionTemplates: [{fileTemplates: files}]};
+    comp.series = {versionTemplates: [{isAudio: true, fileTemplates: files}]};
     fix.detectChanges();
     expect(el).not.toQuery('publish-file-template');
     el.query(By.css('[label="Segments"] .icon-plus')).nativeElement.click();
@@ -47,12 +51,21 @@ describe('SeriesTemplatesComponent', () => {
 
   cit('adds a destroyed file template', (fix, el, comp) => {
     let files = [{label: 'Foo', isDestroy: true}];
-    comp.series = {versionTemplates: [{fileTemplates: files}]};
+    comp.series = {versionTemplates: [{isAudio: true, fileTemplates: files}]};
     fix.detectChanges();
     expect(el).toQuery('publish-file-template');
     el.query(By.css('[label="Segments"] .icon-plus')).nativeElement.click();
     fix.detectChanges();
     expect(files[0].isDestroy).toEqual(false);
+  });
+
+  cit('hides segment info for video content types', (fix, el, comp) => {
+    comp.series = {versionTemplates: [{isAudio: true, fileTemplates: []}]};
+    fix.detectChanges();
+    expect(el).toQuery('[label="Segments"]');
+    comp.series = {versionTemplates: [{isAudio: false, fileTemplates: []}]};
+    fix.detectChanges();
+    expect(el).not.toQuery('[label="Segments"]');
   });
 
 });

--- a/src/app/series/directives/series-templates.component.ts
+++ b/src/app/series/directives/series-templates.component.ts
@@ -17,8 +17,6 @@ export class SeriesTemplatesComponent implements OnDestroy {
   series: SeriesModel;
   tabSub: Subscription;
 
-  contentTypeOptions = [['MP3 Audio', 'audio/mpeg'], ['MPEG Video', 'video/mpeg']];
-
   constructor(tab: TabService, private modal: ModalService) {
     this.tabSub = tab.model.subscribe((s: SeriesModel) => {
       this.series = s;
@@ -42,17 +40,32 @@ export class SeriesTemplatesComponent implements OnDestroy {
     return t && t.isNew && !t.changed();
   }
 
-  addVersion() {
+  addAudioVersion(): AudioVersionTemplateModel {
     let draft = new AudioVersionTemplateModel(this.series.doc, this.series.versionTemplates.length);
+    draft.set('contentType', 'audio/mpeg');
     if (this.hasDefaultVersion()) {
-      this.series.versionTemplates[0].set('label', 'Default Podcast Audio');
+      this.series.versionTemplates[0].set('label', '', true);
+      this.series.versionTemplates[0].set('label', 'Podcast Audio'); // force change
       draft.set('label', 'Some Other Audio');
     } else if (this.hasVersions()) {
       draft.set('label', 'Some Other Audio');
     } else {
       draft.set('label', 'Podcast Audio');
     }
+
+    let file = new AudioFileTemplateModel(this.series.doc, null, 1);
+    file.set('label', 'Main Segment');
+    draft.fileTemplates.push(file);
+
     this.series.versionTemplates.push(draft);
+    return draft;
+  }
+
+  addVideoVersion() {
+    let draft = this.addAudioVersion();
+    draft.set('contentType', 'video/mpeg');
+    draft.set('label', 'Podcast Video');
+    draft.fileTemplates[0].set('label', 'Video Segment');
   }
 
   confirmRemoveVersion(version: AudioVersionTemplateModel) {

--- a/src/app/series/directives/series-templates.component.ts
+++ b/src/app/series/directives/series-templates.component.ts
@@ -9,56 +9,7 @@ import {
 
 @Component({
   styleUrls: ['series-templates.component.css'],
-  template: `
-    <form *ngIf="series">
-      <prx-fancy-field label="Audio Templates">
-        <div class="fancy-hint">
-          When you add episodes, you may want to have different versions of the audio (e.g., clean v. explicit).
-          This page lets you define templates for the versions each episode in this series should have, including
-          specific segment requirements (note: don't include ads here). Every episode you add to this series will
-          be checked against these requirements for validity.
-        </div>
-        <button *ngIf="!hasVersions()" class="add-version"
-          (click)="addVersion()"><i class="icon-plus white" aria-hidden="true"></i> Add a template</button>
-      </prx-fancy-field>
-
-      <ng-container *ngFor="let v of series.versionTemplates">
-        <div *ngIf="!v.isDestroy" class="version">
-          <header>
-            <strong>{{v?.label}}</strong>
-            <button type="button" class="btn-icon icon-cancel grey-dove" (click)="confirmRemoveVersion(v)"></button>
-          </header>
-          <section>
-            <prx-fancy-field required textinput [model]="v" name="label" label="Template Label">
-              <div class="fancy-hint">A name for this audio template, such as "Podcast Audio" or "Clean Version"</div>
-            </prx-fancy-field>
-
-            <prx-fancy-field class="length" [model]="v" label="Total length" invalid="lengthAny">
-              <div class="fancy-hint">
-                The minimum and maximum HH:MM:SS durations for all the audio files. Used to ensure that each
-                of your episodes is the desired approximate length, and to prevent uploading bad audio.
-              </div>
-              <prx-fancy-duration [model]="v" name="lengthMinimum" label="Minimum"
-                [advancedConfirm]="lengthConfirm(v, v['lengthMinimum'] | duration, 'minimum')"></prx-fancy-duration>
-              <prx-fancy-duration [model]="v" name="lengthMaximum" label="Maximum"
-                [advancedConfirm]="lengthConfirm(v, v['lengthMaximum'] | duration, 'maximum')"></prx-fancy-duration>
-            </prx-fancy-field>
-
-            <prx-fancy-field label="Segments">
-              <div class="fancy-hint">
-                Describe the individual segment audio files required in this template. Give
-                them a label such as "Billboard" or "Part A", and an optional min/max length
-                to validate the specific file.
-              </div>
-              <publish-file-template *ngFor="let t of v.fileTemplates" [file]="t" [version]="v"></publish-file-template>
-              <button tabindex=-1 class="add-segment" *ngIf="canAddFile(v)" type="button"
-                (click)="confirmAddFile($event, v)"><i class="icon-plus white" aria-hidden="true"></i> Add Segment</button>
-            </prx-fancy-field>
-          </section>
-        </div>
-      </ng-container>
-    </form>
-  `
+  templateUrl: 'series-templates.component.html'
 })
 
 export class SeriesTemplatesComponent implements OnDestroy {
@@ -66,31 +17,44 @@ export class SeriesTemplatesComponent implements OnDestroy {
   series: SeriesModel;
   tabSub: Subscription;
 
-  constructor(tab: TabService,
-              private modal: ModalService) {
-    this.tabSub = tab.model.subscribe((s: SeriesModel) => this.series = s);
+  constructor(tab: TabService, private modal: ModalService) {
+    this.tabSub = tab.model.subscribe((s: SeriesModel) => {
+      this.series = s;
+    });
   }
 
   ngOnDestroy(): any {
     this.tabSub.unsubscribe();
   }
 
-  hasStories() {
+  hasStories(): boolean {
     return this.series && this.series.hasStories;
   }
 
-  hasVersions() {
-    return this.series.versionTemplates.some(f => !f.isDestroy);
+  hasVersions(): boolean {
+    return !!this.series.versionTemplates.some(f => !f.isDestroy);
+  }
+
+  hasDefaultVersion(): boolean {
+    let t = this.series.versionTemplates[0];
+    return t && t.isNew && !t.changed();
   }
 
   addVersion() {
-    let draft = new AudioVersionTemplateModel(this.series.doc);
-    draft.set('label', 'Podcast Audio');
+    let draft = new AudioVersionTemplateModel(this.series.doc, this.series.versionTemplates.length);
+    if (this.hasDefaultVersion()) {
+      this.series.versionTemplates[0].set('label', 'Default Podcast Audio');
+      draft.set('label', 'Some Other Audio');
+    } else if (this.hasVersions()) {
+      draft.set('label', 'Some Other Audio');
+    } else {
+      draft.set('label', 'Podcast Audio');
+    }
     this.series.versionTemplates.push(draft);
   }
 
   confirmRemoveVersion(version: AudioVersionTemplateModel) {
-    if (this.hasStories()) {
+    if (this.hasStories() && !version.isNew) {
       let confirmMsg = `Are you sure you want to remove the ${version.label} template?
       This change could affect your already published episodes.`;
       this.modal.confirm('', confirmMsg, (confirm) => {
@@ -119,7 +83,7 @@ export class SeriesTemplatesComponent implements OnDestroy {
     if (event.target['blur']) {
       event.target['blur']();
     }
-    if (this.hasStories()) {
+    if (this.hasStories() && !version.isNew) {
       let confirmMsg = `Are you sure you want to add a segment to your ${version.label} template?
       This change could invalidate your already published episodes.`;
       this.modal.confirm('', confirmMsg, (confirm) => {

--- a/src/app/series/directives/series-templates.component.ts
+++ b/src/app/series/directives/series-templates.component.ts
@@ -42,7 +42,7 @@ export class SeriesTemplatesComponent implements OnDestroy {
 
   addAudioVersion(): AudioVersionTemplateModel {
     let draft = new AudioVersionTemplateModel(this.series.doc, this.series.versionTemplates.length);
-    draft.set('contentType', 'audio/mpeg');
+    draft.set('contentType', AudioVersionTemplateModel.CONTENT_TYPES.MP3);
     if (this.hasDefaultVersion()) {
       this.series.versionTemplates[0].set('label', '', true);
       this.series.versionTemplates[0].set('label', 'Podcast Audio'); // force change
@@ -63,7 +63,7 @@ export class SeriesTemplatesComponent implements OnDestroy {
 
   addVideoVersion() {
     let draft = this.addAudioVersion();
-    draft.set('contentType', 'video/mpeg');
+    draft.set('contentType', AudioVersionTemplateModel.CONTENT_TYPES.VIDEO);
     draft.set('label', 'Podcast Video');
     draft.fileTemplates[0].set('label', 'Video Segment');
   }

--- a/src/app/series/directives/series-templates.component.ts
+++ b/src/app/series/directives/series-templates.component.ts
@@ -41,7 +41,8 @@ export class SeriesTemplatesComponent implements OnDestroy {
   }
 
   addAudioVersion(): AudioVersionTemplateModel {
-    let draft = new AudioVersionTemplateModel(this.series.doc, this.series.versionTemplates.length);
+    let index = this.series.versionTemplates.length;
+    let draft = new AudioVersionTemplateModel(this.series.doc, index);
     draft.set('contentType', AudioVersionTemplateModel.CONTENT_TYPES.MP3);
     if (this.hasDefaultVersion()) {
       this.series.versionTemplates[0].set('label', '', true);
@@ -52,11 +53,7 @@ export class SeriesTemplatesComponent implements OnDestroy {
     } else {
       draft.set('label', 'Podcast Audio');
     }
-
-    let file = new AudioFileTemplateModel(this.series.doc, null, 1);
-    file.set('label', 'Main Segment');
-    draft.fileTemplates.push(file);
-
+    draft.addFile('Main Segment');
     this.series.versionTemplates.push(draft);
     return draft;
   }
@@ -116,11 +113,7 @@ export class SeriesTemplatesComponent implements OnDestroy {
     if (existing) {
       existing.isDestroy = false;
     } else {
-      let count = version.fileTemplates.length;
-      let segLetter = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'[count % 26];
-      let draft = new AudioFileTemplateModel(version.parent, version.doc, count + 1);
-      draft.set('label', `Segment ${segLetter}`);
-      version.fileTemplates.push(draft);
+      version.addFile();
     }
   }
 

--- a/src/app/series/directives/series-templates.component.ts
+++ b/src/app/series/directives/series-templates.component.ts
@@ -17,6 +17,8 @@ export class SeriesTemplatesComponent implements OnDestroy {
   series: SeriesModel;
   tabSub: Subscription;
 
+  contentTypeOptions = [['MP3 Audio', 'audio/mpeg'], ['MPEG Video', 'video/mpeg']];
+
   constructor(tab: TabService, private modal: ModalService) {
     this.tabSub = tab.model.subscribe((s: SeriesModel) => {
       this.series = s;

--- a/src/app/series/series.component.ts
+++ b/src/app/series/series.component.ts
@@ -4,10 +4,11 @@ import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 
 import { CmsService } from '../core';
-import { ModalService, ToastrService } from 'ngx-prx-styleguide';
+import { ModalService, TabService, ToastrService } from 'ngx-prx-styleguide';
 import { SeriesModel } from '../shared';
 
 @Component({
+  providers: [TabService],
   selector: 'publish-series',
   styleUrls: ['series.component.css'],
   templateUrl: 'series.component.html'

--- a/src/app/series/series.module.ts
+++ b/src/app/series/series.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { SharedModule } from '../shared';
+import { TabModule } from 'ngx-prx-styleguide';
 import { seriesRouting, seriesProviders, seriesComponents } from './series.routing';
 
 @NgModule({
@@ -11,6 +12,7 @@ import { seriesRouting, seriesProviders, seriesComponents } from './series.routi
   imports: [
     CommonModule,
     SharedModule,
+    TabModule,
     seriesRouting
   ],
   providers: [

--- a/src/app/shared/model/audio-file-template.model.ts
+++ b/src/app/shared/model/audio-file-template.model.ts
@@ -12,6 +12,7 @@ export class AudioFileTemplateModel extends BaseModel {
   public lengthMaximum: number = null;
 
   private series: HalDoc;
+  private versionTemplateNewIndex: number = null;
 
   SETABLE = ['position', 'label', 'lengthMinimum', 'lengthMaximum'];
 
@@ -21,14 +22,20 @@ export class AudioFileTemplateModel extends BaseModel {
     lengthMaximum: [FILE_LENGTH(this)]
   };
 
-  constructor(series: HalDoc, versionTemplate?: HalDoc, fileOrPosition?: HalDoc | number) {
+  constructor(series: HalDoc, versionTemplate?: HalDoc | number, fileOrPosition?: HalDoc | number) {
     super();
     this.series = series;
-    if (typeof(fileOrPosition) === 'number') {
+    if (versionTemplate instanceof HalDoc && fileOrPosition instanceof HalDoc) {
+      this.init(versionTemplate, fileOrPosition);
+    } else if (versionTemplate instanceof HalDoc && typeof(fileOrPosition) === 'number') {
       this.position = fileOrPosition;
       this.init(versionTemplate);
+    } else if (typeof(versionTemplate) === 'number' && typeof(fileOrPosition) === 'number') {
+      this.versionTemplateNewIndex = versionTemplate;
+      this.position = fileOrPosition;
+      this.init();
     } else {
-      this.init(versionTemplate, fileOrPosition);
+      throw new Error('Bad arguments for AudioFileTemplateModel!');
     }
   }
 
@@ -37,10 +44,10 @@ export class AudioFileTemplateModel extends BaseModel {
       return `prx.audio-file-template.${this.doc.id}`;
     } else if (this.parent && this.position) {
       return `prx.audio-file-template.${this.parent.id}.${this.position}`;
-    } else if (this.series && this.position) {
-      return `prx.audio-file-template.series.${this.series.id}.${this.position}`;
-    } else if (this.position) {
-      return `prx.audio-file-template.series.new.${this.position}`;
+    } else if (this.series) {
+      return `prx.audio-file-template.series.${this.series.id}.${this.versionTemplateNewIndex}.${this.position}`;
+    } else {
+      return `prx.audio-file-template.series.new.${this.versionTemplateNewIndex}.${this.position}`;
     }
   }
 

--- a/src/app/shared/model/audio-file.model.spec.ts
+++ b/src/app/shared/model/audio-file.model.spec.ts
@@ -10,13 +10,13 @@ describe('AudioFileModel', () => {
     versionMock = cms.mock('prx:version', {id: 'the-version-id'});
     fileMock = null;
     if (typeof data === 'string') {
-      return new AudioFileModel(versionMock, data);
+      return new AudioFileModel(<any> {}, versionMock, data);
     } else if (data) {
       data.status = 'complete';
       fileMock = versionMock.mock('prx:audio', data);
-      return new AudioFileModel(versionMock, fileMock);
+      return new AudioFileModel(<any> {}, versionMock, fileMock);
     } else {
-      return new AudioFileModel(versionMock, null);
+      return new AudioFileModel(<any> {}, versionMock, null);
     }
   };
 
@@ -73,7 +73,7 @@ describe('AudioFileModel', () => {
     });
 
     it('will just call it a new file if nothing else', () => {
-      let nothin = new AudioFileModel(null, null);
+      let nothin = new AudioFileModel(null, null, null);
       expect(nothin.key()).toMatch(/\.new$/);
     });
 

--- a/src/app/shared/model/audio-file.model.ts
+++ b/src/app/shared/model/audio-file.model.ts
@@ -27,11 +27,13 @@ export class AudioFileModel extends UploadableModel {
     self: [FILE_TEMPLATED()]
   };
 
+  public versionTemplate: HalDoc;
   public template: HalDoc;
 
-  constructor(audioVersion?: HalDoc, file?: HalDoc | Upload | string) {
+  constructor(versionTpl?: HalDoc, version?: HalDoc, file?: HalDoc | Upload | string) {
     super();
-    this.initUpload(audioVersion, file);
+    this.versionTemplate = versionTpl;
+    this.initUpload(version, file);
   }
 
   setTemplate(template: HalDoc) {
@@ -39,9 +41,9 @@ export class AudioFileModel extends UploadableModel {
     if (template) {
       this.set('position', template['position']);
       this.set('label', template['label']);
-      this.VALIDATORS['self'] = [FILE_TEMPLATED(template)];
+      this.VALIDATORS['self'] = [FILE_TEMPLATED(this.versionTemplate, template)];
     } else {
-      this.VALIDATORS['self'] = [FILE_TEMPLATED()];
+      this.VALIDATORS['self'] = [FILE_TEMPLATED(this.versionTemplate)];
     }
   }
 

--- a/src/app/shared/model/audio-version-template-model.spec.ts
+++ b/src/app/shared/model/audio-version-template-model.spec.ts
@@ -1,0 +1,56 @@
+import { cms } from '../../../testing';
+import { AudioVersionTemplateModel } from './audio-version-template.model';
+import { AudioFileTemplateModel } from './audio-file-template.model';
+
+describe('AudioVersionTemplateModel', () => {
+
+  beforeEach(() => window.localStorage.clear());
+
+  it('loads unsaved files', () => {
+    new AudioFileTemplateModel(null, 0, 1).set('label', 'file 1');
+    new AudioFileTemplateModel(null, 0, 2).set('label', 'file 2');
+    new AudioFileTemplateModel(null, 0, 4).set('label', 'file 4');
+    let version = new AudioVersionTemplateModel(null, 0);
+    expect(version.fileTemplates.length).toEqual(2);
+    expect(version.fileTemplates[0].label).toEqual('file 1');
+    expect(version.fileTemplates[1].label).toEqual('file 2');
+  });
+
+  it('concats unsaved files to existing ones', () => {
+    let vdoc = cms.mock('prx:vdoc', {id: 123, label: 'My Version Template'});
+    vdoc.mockItems('prx:audio-file-templates', [{label: 'saved 1', position: 1}]);
+    new AudioFileTemplateModel(null, vdoc, 1).set('label', 'file 1');
+    new AudioFileTemplateModel(null, vdoc, 2).set('label', 'file 2');
+    new AudioFileTemplateModel(null, vdoc, 4).set('label', 'file 4');
+
+    let version = new AudioVersionTemplateModel(null, vdoc);
+    expect(version.fileTemplates.length).toEqual(2);
+    expect(version.fileTemplates[0].label).toEqual('saved 1');
+    expect(version.fileTemplates[1].label).toEqual('file 2');
+  });
+
+  describe('addFile', () => {
+
+    it('sets labels based on position', () => {
+      let version = new AudioVersionTemplateModel();
+      let file1 = version.addFile();
+      let file2 = version.addFile(null, true);
+      expect(file1.label).toEqual('Segment A');
+      expect(file2.label).toEqual('Segment B');
+      expect(file1.changed('label')).toEqual(true);
+      expect(file2.changed('label')).toEqual(false);
+    });
+
+    it('sets file keys based on version index', () => {
+      let version = new AudioVersionTemplateModel(null, 3);
+      let file1 = version.addFile();
+      let file2 = version.addFile();
+      expect(file1.position).toEqual(1);
+      expect(file2.position).toEqual(2);
+      expect(file1.key()).toMatch(/series\.new\.3\.1/);
+      expect(file2.key()).toMatch(/series\.new\.3\.2/);
+    });
+
+  });
+
+});

--- a/src/app/shared/model/audio-version-template.model.ts
+++ b/src/app/shared/model/audio-version-template.model.ts
@@ -101,8 +101,20 @@ export class AudioVersionTemplateModel extends BaseModel {
     }
   }
 
+  addFile(label?: string, forceOriginal = false): AudioFileTemplateModel {
+    let count = this.fileTemplates.length;
+    if (!label) {
+      let segLetter = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'[count % 26];
+      label = `Segment ${segLetter}`;
+    }
+    let file = new AudioFileTemplateModel(this.parent, this.doc || this.newIndex, count + 1);
+    file.set('label', label, forceOriginal);
+    this.fileTemplates.push(file);
+    return file;
+  }
+
   findUnsavedFiles(position, found: AudioFileTemplateModel[] = []) {
-    let file = new AudioFileTemplateModel(this.parent, this.doc, position);
+    let file = new AudioFileTemplateModel(this.parent, this.doc || this.newIndex, position);
     if (file.isStored() && !file.isDestroy) {
       found.push(file);
       return this.findUnsavedFiles(position + 1, found);

--- a/src/app/shared/model/audio-version-template.model.ts
+++ b/src/app/shared/model/audio-version-template.model.ts
@@ -10,15 +10,17 @@ export class AudioVersionTemplateModel extends BaseModel {
 
   public id: number;
   public label: string = null;
+  public contentType = 'audio/mpeg';
   public lengthMinimum: number = null;
   public lengthMaximum: number = null;
   public fileTemplates: AudioFileTemplateModel[];
   private newIndex: number = null;
 
-  SETABLE = ['label', 'lengthMinimum', 'lengthMaximum'];
+  SETABLE = ['label', 'contentType', 'lengthMinimum', 'lengthMaximum'];
 
   VALIDATORS = {
     label: [REQUIRED(), LENGTH(1, 255)],
+    contentType: [REQUIRED(), IN(['audio/mpeg', 'audio/mp2', 'video/mpeg', 'video/x-mpeg'])],
     lengthMinimum: [VERSION_LENGTH(this)],
     lengthMaximum: [VERSION_LENGTH(this)]
   };
@@ -62,6 +64,7 @@ export class AudioVersionTemplateModel extends BaseModel {
   decode() {
     this.id = this.doc['id'];
     this.label = this.doc['label'] || '';
+    this.contentType = this.doc['contentType'] || 'audio/mpeg';
     this.lengthMinimum = this.doc['lengthMinimum'] || null;
     this.lengthMaximum = this.doc['lengthMaximum'] || null;
   }
@@ -69,6 +72,7 @@ export class AudioVersionTemplateModel extends BaseModel {
   encode(): {} {
     let data = <any> {};
     data.label = this.label;
+    data.contentType = this.contentType;
     data.lengthMinimum = this.lengthMinimum || 0;
     data.lengthMaximum = this.lengthMaximum || 0;
     return data;
@@ -94,6 +98,10 @@ export class AudioVersionTemplateModel extends BaseModel {
     } else {
       return found;
     }
+  }
+
+  get isAudio(): boolean {
+    return !!this.contentType.match(/^audio\//);
   }
 
 }

--- a/src/app/shared/model/audio-version-template.model.ts
+++ b/src/app/shared/model/audio-version-template.model.ts
@@ -3,7 +3,7 @@ import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/map';
 import { HalDoc } from '../../core';
 import { BaseModel } from 'ngx-prx-styleguide';
-import { REQUIRED, LENGTH, VERSION_LENGTH } from './invalid';
+import { REQUIRED, LENGTH, IN, VERSION_LENGTH } from './invalid';
 import { AudioFileTemplateModel } from './audio-file-template.model';
 
 export class AudioVersionTemplateModel extends BaseModel {
@@ -13,6 +13,7 @@ export class AudioVersionTemplateModel extends BaseModel {
   public lengthMinimum: number = null;
   public lengthMaximum: number = null;
   public fileTemplates: AudioFileTemplateModel[];
+  private newIndex: number = null;
 
   SETABLE = ['label', 'lengthMinimum', 'lengthMaximum'];
 
@@ -22,18 +23,23 @@ export class AudioVersionTemplateModel extends BaseModel {
     lengthMaximum: [VERSION_LENGTH(this)]
   };
 
-  constructor(series?: HalDoc, versionTemplate?: HalDoc, loadRelated = true) {
+  constructor(series?: HalDoc, docOrIndex?: HalDoc | number, loadRelated = true) {
     super();
-    this.init(series, versionTemplate, loadRelated);
+    if (docOrIndex instanceof HalDoc) {
+      this.init(series, docOrIndex, loadRelated);
+    } else {
+      this.newIndex = docOrIndex || 0;
+      this.init(series, null, loadRelated);
+    }
   }
 
   key() {
     if (this.doc) {
       return `prx.audio-version-template.${this.doc.id}`;
     } else if (this.parent) {
-      return `prx.audio-version-template.new.${this.parent.id}`;
+      return `prx.audio-version-template.new.${this.parent.id}.${this.newIndex}`;
     } else {
-      return 'prx.audio-version-template.new.new';
+      return `prx.audio-version-template.new.new.${this.newIndex}`;
     }
   }
 

--- a/src/app/shared/model/audio-version-template.model.ts
+++ b/src/app/shared/model/audio-version-template.model.ts
@@ -8,9 +8,16 @@ import { AudioFileTemplateModel } from './audio-file-template.model';
 
 export class AudioVersionTemplateModel extends BaseModel {
 
+  static CONTENT_TYPES = {
+    MP3: 'audio/mpeg',
+    MP2: 'audio/mp2',
+    VIDEO: 'video/mpeg',
+    VIDEO_ALT: 'video/x-mpeg'
+  };
+
   public id: number;
   public label: string = null;
-  public contentType = 'audio/mpeg';
+  public contentType = AudioVersionTemplateModel.CONTENT_TYPES.MP3;
   public lengthMinimum: number = null;
   public lengthMaximum: number = null;
   public fileTemplates: AudioFileTemplateModel[];
@@ -20,10 +27,14 @@ export class AudioVersionTemplateModel extends BaseModel {
 
   VALIDATORS = {
     label: [REQUIRED(), LENGTH(1, 255)],
-    contentType: [REQUIRED(), IN(['audio/mpeg', 'audio/mp2', 'video/mpeg', 'video/x-mpeg'])],
+    contentType: [REQUIRED(), IN(AudioVersionTemplateModel.ALL_CONTENT_TYPES)],
     lengthMinimum: [VERSION_LENGTH(this)],
     lengthMaximum: [VERSION_LENGTH(this)]
   };
+
+  static get ALL_CONTENT_TYPES(): string[] {
+    return Object.keys(this.CONTENT_TYPES).map(k => this.CONTENT_TYPES[k]);
+  }
 
   constructor(series?: HalDoc, docOrIndex?: HalDoc | number, loadRelated = true) {
     super();
@@ -64,7 +75,7 @@ export class AudioVersionTemplateModel extends BaseModel {
   decode() {
     this.id = this.doc['id'];
     this.label = this.doc['label'] || '';
-    this.contentType = this.doc['contentType'] || 'audio/mpeg';
+    this.contentType = this.doc['contentType'] || AudioVersionTemplateModel.CONTENT_TYPES.MP3;
     this.lengthMinimum = this.doc['lengthMinimum'] || null;
     this.lengthMaximum = this.doc['lengthMaximum'] || null;
   }

--- a/src/app/shared/model/audio-version.model.spec.ts
+++ b/src/app/shared/model/audio-version.model.spec.ts
@@ -59,7 +59,7 @@ describe('AudioVersionModel', () => {
     });
 
     it('uses the audio template id', () => {
-      expect(makeVersion(null).key()).toContain('template.the-template-id');
+      expect(makeVersion(null).key()).toContain('.the-template-id');
     });
 
     it('falls back to the story id', () => {

--- a/src/app/shared/model/audio-version.model.ts
+++ b/src/app/shared/model/audio-version.model.ts
@@ -78,7 +78,7 @@ export class AudioVersionModel extends BaseModel implements HasUpload {
     const fileSort = (f1, f2) => f1.position - f2.position;
 
     let files = this.getUploads('prx:audio').map(audios => {
-      let docs = audios.map(docOrUuid => new AudioFileModel(this.doc, docOrUuid));
+      let docs = audios.map(docOrUuid => new AudioFileModel(this.template, this.doc, docOrUuid));
       this.setUploads('prx:audio', docs.map(d => d.uuid));
       return docs.sort(fileSort);
     });
@@ -155,7 +155,7 @@ export class AudioVersionModel extends BaseModel implements HasUpload {
   }
 
   addUpload(upload: Upload, position?: number): AudioFileModel {
-    let audio = new AudioFileModel(this.doc, upload);
+    let audio = new AudioFileModel(this.template, this.doc, upload);
     if (position) {
       audio.set('position', position);
       this.files = [...this.files]; // trigger change detection

--- a/src/app/shared/model/audio-version.model.ts
+++ b/src/app/shared/model/audio-version.model.ts
@@ -14,7 +14,7 @@ export class AudioVersionModel extends BaseModel implements HasUpload {
 
   public id: number;
   public label: string;
-  public explicit: string;
+  public explicit = '';
   public status: string;
   public statusMessage: string;
 
@@ -109,7 +109,7 @@ export class AudioVersionModel extends BaseModel implements HasUpload {
         this.explicit = 'Clean';
         break;
       default:
-        this.explicit = undefined;
+        this.explicit = '';
         break;
     }
     this.status = this.doc['status'];

--- a/src/app/shared/model/audio-version.model.ts
+++ b/src/app/shared/model/audio-version.model.ts
@@ -14,7 +14,7 @@ export class AudioVersionModel extends BaseModel implements HasUpload {
 
   public id: number;
   public label: string;
-  public explicit = '';
+  public explicit: string;
   public status: string;
   public statusMessage: string;
 
@@ -106,7 +106,7 @@ export class AudioVersionModel extends BaseModel implements HasUpload {
         this.explicit = 'Clean';
         break;
       default:
-        this.explicit = '';
+        this.explicit = undefined;
         break;
     }
     this.status = this.doc['status'];

--- a/src/app/shared/model/distribution.model.spec.ts
+++ b/src/app/shared/model/distribution.model.spec.ts
@@ -10,7 +10,7 @@ describe('DistributionModel', () => {
   let fooDist = series.mock('prx:distributions', {id: 'dist1', kind: 'foo'});
   let podDist = series.mock('prx:distributions', {id: 'dist2', kind: 'podcast', url: podcastUrl});
   let podcast = podDist.mock(podcastUrl, {id: 'pod1'});
-  let tpls = podDist.mockItems('prx:audio-version-templates', [{id: 'template1'}]);
+  let tpls = podDist.mockItems('prx:audio-version-templates', [{id: 'template1', label: 'template1'}]);
   tpls[0].mockItems('prx:audio-file-templates', []);
 
   beforeEach(() => window.localStorage.clear());
@@ -71,6 +71,15 @@ describe('DistributionModel', () => {
     dist.loadRelated('versionTemplates');
     expect(dist.versionTemplates.length).toEqual(1);
     expect(dist.versionTemplates[0].id).toEqual('template1');
+  });
+
+  it('does not try to validate version templates until they load', () => {
+    let dist = new DistributionModel(series, podDist);
+    expect(dist.invalid()).toBeNull();
+    dist.loadRelated('versionTemplates');
+    expect(dist.invalid()).toBeNull();
+    dist.set('versionTemplateUrls', []);
+    expect(dist.invalid()).toMatch(/must pick at least one/i);
   });
 
 });

--- a/src/app/shared/model/distribution.model.spec.ts
+++ b/src/app/shared/model/distribution.model.spec.ts
@@ -10,8 +10,8 @@ describe('DistributionModel', () => {
   let fooDist = series.mock('prx:distributions', {id: 'dist1', kind: 'foo'});
   let podDist = series.mock('prx:distributions', {id: 'dist2', kind: 'podcast', url: podcastUrl});
   let podcast = podDist.mock(podcastUrl, {id: 'pod1'});
-  let podDistTemplate = podDist.mock('prx:audio-version-template', {id: 'template1'});
-  podDistTemplate.mockItems('prx:audio-file-templates', []);
+  let tpls = podDist.mockItems('prx:audio-version-templates', [{id: 'template1'}]);
+  tpls[0].mockItems('prx:audio-file-templates', []);
 
   beforeEach(() => window.localStorage.clear());
 
@@ -66,10 +66,11 @@ describe('DistributionModel', () => {
     expect(dist.podcast.category).toEqual('Education');
   });
 
-  it('loads the version template', () => {
+  it('loads the version templates', () => {
     let dist = new DistributionModel(series, podDist);
-    dist.loadRelated('versionTemplate');
-    expect(dist.versionTemplate.id).toEqual(podDistTemplate.id);
+    dist.loadRelated('versionTemplates');
+    expect(dist.versionTemplates.length).toEqual(1);
+    expect(dist.versionTemplates[0].id).toEqual('template1');
   });
 
 });

--- a/src/app/shared/model/distribution.model.ts
+++ b/src/app/shared/model/distribution.model.ts
@@ -72,10 +72,6 @@ export class DistributionModel extends BaseModel {
         this.set('versionTemplateUrls', currentTemplateUrls, true);
         return tdocs.map(t => new AudioVersionTemplateModel(this.parent, t));
       });
-    } else if (this.doc && this.doc.has('prx:audio-version-template')) {
-      versionTemplates = this.doc.follow('prx:audio-version-template').map(tdoc => {
-        return [new AudioVersionTemplateModel(this.parent, tdoc)];
-      });
     }
 
     return {podcast, versionTemplates};

--- a/src/app/shared/model/distribution.model.ts
+++ b/src/app/shared/model/distribution.model.ts
@@ -12,7 +12,7 @@ export class DistributionModel extends BaseModel {
   id: number;
   kind = '';
   url = '';
-  versionTemplateUrls = [];
+  versionTemplateUrls: string[];
 
   // external related models
   podcast: FeederPodcastModel;
@@ -68,6 +68,8 @@ export class DistributionModel extends BaseModel {
     // load existing version templates
     if (this.doc && this.doc.count('prx:audio-version-templates')) {
       versionTemplates = this.doc.followItems('prx:audio-version-templates').map(tdocs => {
+        let currentTemplateUrls = tdocs.map(tdoc => tdoc.expand('self'));
+        this.set('versionTemplateUrls', currentTemplateUrls, true);
         return tdocs.map(t => new AudioVersionTemplateModel(this.parent, t));
       });
     } else if (this.doc && this.doc.has('prx:audio-version-template')) {
@@ -87,17 +89,6 @@ export class DistributionModel extends BaseModel {
     this.url = this.doc['url'] || '';
     if (this.url && !this.url.match('/authorization/')) {
       this.url = this.url.replace('/podcasts/', '/authorization/podcasts/');
-    }
-
-    // TODO: since a PUT returns no data, underscored key is set on callback
-    if (this.doc['set_audio_version_template_uris']) {
-      this.versionTemplateUrls = this.doc['set_audio_version_template_uris'];
-    } else if (this.doc.count('prx:audio-version-templates')) {
-      this.versionTemplateUrls = []; // TODO: how to get this syncronously???
-    } else if (this.doc.has('prx:audio-version-template')) {
-      this.versionTemplateUrls = [this.doc.expand('prx:audio-version-template')];
-    } else {
-      this.versionTemplateUrls = [];
     }
   }
 

--- a/src/app/shared/model/distribution.model.ts
+++ b/src/app/shared/model/distribution.model.ts
@@ -92,9 +92,11 @@ export class DistributionModel extends BaseModel {
     if (this.url && !this.url.match('/authorization/')) {
       this.url = this.url.replace('/podcasts/', '/authorization/podcasts/');
     }
+  }
 
-    // discard templateurl changes
+  discard() {
     this.resetVersionTemplateUrls(this.versionTemplates);
+    super.discard();
   }
 
   encode(): {} {

--- a/src/app/shared/model/distribution.model.ts
+++ b/src/app/shared/model/distribution.model.ts
@@ -74,9 +74,9 @@ export class DistributionModel extends BaseModel {
     // load existing version templates
     if (this.doc && this.doc.count('prx:audio-version-templates')) {
       versionTemplates = this.doc.followItems('prx:audio-version-templates').map(tdocs => {
-        let currentTemplateUrls = tdocs.map(tdoc => tdoc.expand('self'));
-        this.set('versionTemplateUrls', currentTemplateUrls, true);
-        return tdocs.map(t => new AudioVersionTemplateModel(this.parent, t));
+        let models = tdocs.map(t => new AudioVersionTemplateModel(this.parent, t));
+        this.resetVersionTemplateUrls(models);
+        return models;
       });
     }
 
@@ -92,6 +92,9 @@ export class DistributionModel extends BaseModel {
     if (this.url && !this.url.match('/authorization/')) {
       this.url = this.url.replace('/podcasts/', '/authorization/podcasts/');
     }
+
+    // discard templateurl changes
+    this.resetVersionTemplateUrls(this.versionTemplates);
   }
 
   encode(): {} {
@@ -105,6 +108,14 @@ export class DistributionModel extends BaseModel {
 
   saveNew(data: {}): Observable<HalDoc> {
     return this.parent.create('prx:distributions', {}, data);
+  }
+
+  private resetVersionTemplateUrls(tpls: AudioVersionTemplateModel[]) {
+    if (tpls) {
+      let urls = tpls.filter(t => t.doc).map(t => t.doc.expand('self'));
+      let isFirstSet = !this.versionTemplateUrls;
+      this.set('versionTemplateUrls', urls, isFirstSet);
+    }
   }
 
 }

--- a/src/app/shared/model/distribution.model.ts
+++ b/src/app/shared/model/distribution.model.ts
@@ -2,10 +2,16 @@ import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/map';
 import { HalDoc } from '../../core';
-import { BaseModel } from 'ngx-prx-styleguide';
-import { REQUIRED } from './invalid';
+import { BaseModel, BaseInvalid, REQUIRED } from 'ngx-prx-styleguide';
 import { FeederPodcastModel } from './feeder-podcast.model';
 import { AudioVersionTemplateModel } from './audio-version-template.model';
+
+const REQUIRE_IF_LOADED: BaseInvalid = (key: string, value: any): string => {
+  if (value !== undefined && value.length === 0) {
+    return 'You must pick at least one template';
+  }
+  return null;
+};
 
 export class DistributionModel extends BaseModel {
 
@@ -22,7 +28,7 @@ export class DistributionModel extends BaseModel {
 
   VALIDATORS = {
     kind: [REQUIRED()],
-    versionTemplateUrls: [REQUIRED()]
+    versionTemplateUrls: [REQUIRE_IF_LOADED]
   };
 
   constructor(series: HalDoc, distribution?: HalDoc, loadRelated = false) {

--- a/src/app/shared/model/invalid/audio.invalid.spec.ts
+++ b/src/app/shared/model/invalid/audio.invalid.spec.ts
@@ -64,14 +64,20 @@ describe('AudioInvalid', () => {
   describe('FILE_TEMPLATED', () => {
 
     it('only accepts mp3 files', () => {
-      let invalid = FILE_TEMPLATED();
+      let invalid = FILE_TEMPLATED(<any> {contentType: 'audio/mpeg'});
       expect(invalid('', {format: 'mp2'})).toMatch('not an mp3');
       expect(invalid('', {format: 'm4a'})).toMatch('not an mp3');
       expect(invalid('', {format: 'mp3', duration: 1})).toBeNull();
     });
 
+    it('does not validate video files', () => {
+      let invalid = FILE_TEMPLATED(<any> {contentType: 'video/mpeg'});
+      expect(invalid('', {format: 'whatev'})).toBeNull();
+      expect(invalid('', {contenttype: 'whatev'})).toBeNull();
+    });
+
     it('requires a duration', () => {
-      let invalid = FILE_TEMPLATED();
+      let invalid = FILE_TEMPLATED(<any> {contentType: 'audio/mpeg'});
       expect(invalid('', {})).toMatch('not an audio file');
       expect(invalid('', {duration: null})).toMatch('not an audio file');
       expect(invalid('', {duration: 0})).toBeNull();
@@ -79,13 +85,13 @@ describe('AudioInvalid', () => {
     });
 
     it('checks min duration', () => {
-      let invalid = FILE_TEMPLATED(<any> {lengthMinimum: 7});
+      let invalid = FILE_TEMPLATED(null, <any> {lengthMinimum: 7});
       expect(invalid('', {duration: 2})).toMatch('must be greater than 0:00:07');
       expect(invalid('', {duration: 8})).toBeNull();
     });
 
     it('checks max duration', () => {
-      let invalid = FILE_TEMPLATED(<any> {lengthMaximum: 7});
+      let invalid = FILE_TEMPLATED(null, <any> {lengthMaximum: 7});
       expect(invalid('', {duration: 8})).toMatch('must be less than 0:00:07');
       expect(invalid('', {duration: 6})).toBeNull();
     });

--- a/src/app/shared/model/invalid/audio.invalid.ts
+++ b/src/app/shared/model/invalid/audio.invalid.ts
@@ -70,14 +70,18 @@ export const VERSION_TEMPLATED = (template?: HalDoc): BaseInvalid => {
 /**
  * Audio file template validations
  */
-export const FILE_TEMPLATED = (template?: HalDoc): BaseInvalid => {
+export const FILE_TEMPLATED = (versionTemplate?: HalDoc, template?: HalDoc): BaseInvalid => {
   return <BaseInvalid> (key: string, file: AudioFileModel) => {
 
-    if (file.format && file.format !== 'mp3') {
-      return 'not an mp3 file';
-    }
-    if (file.duration === null || file.duration === undefined) {
-      return 'not an audio file';
+    // loosely match content type
+    if (versionTemplate && versionTemplate['contentType']) {
+      if (versionTemplate['contentType'] === 'audio/mpeg' && file.format && file.format !== 'mp3') {
+        return 'not an mp3 file';
+      } else if (versionTemplate['contentType'].match(/audio/) && (file.duration === null || file.duration === undefined)) {
+        return 'not an audio file';
+      } else if (versionTemplate['contentType'].match(/video/)) {
+        // just bypass for now
+      }
     }
 
     // min duration

--- a/src/app/shared/model/invalid/index.ts
+++ b/src/app/shared/model/invalid/index.ts
@@ -1,3 +1,4 @@
 export { BaseInvalid, UNLESS_NEW, REQUIRED, LENGTH, IN, FALSEY, TOKENY, URL } from 'ngx-prx-styleguide';
 export * from './audio.invalid';
+export * from './relations.invalid';
 export * from './template.invalid';

--- a/src/app/shared/model/invalid/relations.invalid.ts
+++ b/src/app/shared/model/invalid/relations.invalid.ts
@@ -1,0 +1,15 @@
+import { BaseInvalid, BaseModel } from 'ngx-prx-styleguide';
+
+/**
+ * Make sure a relation exists
+ */
+export const RELATIONS = (msg?: string): BaseInvalid => {
+  return <BaseInvalid> (key: string, models: BaseModel[], strict: boolean) => {
+    if (strict) {
+      if (!models || models.length === 0 || models.every(m => m.isDestroy)) {
+        return msg || `${key} is required`;
+      }
+    }
+    return null;
+  };
+};

--- a/src/app/shared/model/series.model.ts
+++ b/src/app/shared/model/series.model.ts
@@ -29,7 +29,8 @@ export class SeriesModel extends BaseModel implements HasUpload {
   VALIDATORS = {
     title:            [REQUIRED(), LENGTH(1, 255)],
     shortDescription: [REQUIRED()],
-    description: [LENGTH(0, 4000)]
+    description:      [LENGTH(0, 4000)],
+    accountId:        [REQUIRED()]
   };
 
   // HasUpload mixin

--- a/src/app/shared/model/series.model.ts
+++ b/src/app/shared/model/series.model.ts
@@ -156,11 +156,9 @@ export class SeriesModel extends BaseModel implements HasUpload {
   }
 
   defaultVersionTemplate() {
-    let tpl = new AudioVersionTemplateModel();
+    let tpl = new AudioVersionTemplateModel(null, 0);
     tpl.set('label', 'Podcast Audio', true);
-    let file = new AudioFileTemplateModel(null, null, 1);
-    file.set('label', 'Main Segment', true);
-    tpl.fileTemplates.push(file);
+    tpl.addFile('Main Segment', true);
     this.versionTemplates = [tpl];
   }
 

--- a/src/app/shared/model/series.model.ts
+++ b/src/app/shared/model/series.model.ts
@@ -74,10 +74,10 @@ export class SeriesModel extends BaseModel implements HasUpload {
     if (this.doc && this.doc.count('prx:audio-version-templates')) {
       templates = this.doc.followItems('prx:audio-version-templates').map(tdocs => {
         return tdocs.map(t => new AudioVersionTemplateModel(this.doc, t))
-                    .concat(this.unsavedVersionTemplate).filter(t => t);
+                    .concat(this.unsavedVersionTemplates).filter(t => t);
       });
-    } else if (this.unsavedVersionTemplate) {
-      templates = Observable.of([this.unsavedVersionTemplate]);
+    } else if (this.unsavedVersionTemplates) {
+      templates = Observable.of(this.unsavedVersionTemplates);
     }
 
     if (this.doc && this.doc.count('prx:distributions')) {
@@ -104,7 +104,7 @@ export class SeriesModel extends BaseModel implements HasUpload {
   }
 
   changed(field?: string | string[], includeRelations = true): boolean {
-    if (this.isNew && this.versionTemplates.length !== 1) {
+    if (!field && this.isNew && this.versionTemplates.length !== 1) {
       return true; // default version template was deleted!
     } else {
       return super.changed(field, includeRelations);
@@ -163,9 +163,15 @@ export class SeriesModel extends BaseModel implements HasUpload {
     this.versionTemplates = [tpl];
   }
 
-  get unsavedVersionTemplate(): AudioVersionTemplateModel {
-    let tpl = new AudioVersionTemplateModel(this.doc);
-    return tpl.isStored() && !tpl.isDestroy ? tpl : null;
+  get unsavedVersionTemplates(): AudioVersionTemplateModel[] {
+    let tpls = [];
+    for (let i = 0; i < 20; i++) {
+      let tpl = new AudioVersionTemplateModel(this.doc, i);
+      if (tpl.isStored() && !tpl.isDestroy) {
+        tpls.push(tpl);
+      }
+    }
+    return tpls.length ? tpls : null;
   }
 
   get unsavedDistribution(): DistributionModel {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -11,7 +11,7 @@ import { TextOverflowEllipsesComponent, TextOverflowFadeComponent, TextOverflowW
 import { FocusDirective, WysiwygComponent } from './wysiwyg';
 import { AuthGuard, DeactivateGuard, UnauthGuard,
   DatepickerModule, FancyFormModule, HeroModule, ImageModule,
-  ModalModule, SpinnerModule, TabModule, TabService } from 'ngx-prx-styleguide';
+  ModalModule, SpinnerModule } from 'ngx-prx-styleguide';
 
 @NgModule({
   declarations: [
@@ -43,7 +43,6 @@ import { AuthGuard, DeactivateGuard, UnauthGuard,
     HeroModule,
     ImageModule,
     ImageUploadComponent,
-    TabModule,
     TimeAgoPipe,
     TextOverflowEllipsesComponent,
     TextOverflowFadeComponent,
@@ -60,14 +59,12 @@ import { AuthGuard, DeactivateGuard, UnauthGuard,
     HeroModule,
     ImageModule,
     ModalModule,
-    SpinnerModule,
-    TabModule
+    SpinnerModule
   ],
   providers: [
     AuthGuard,
     DeactivateGuard,
-    UnauthGuard,
-    TabService
+    UnauthGuard
   ]
 })
 

--- a/src/app/story/directives/basic.component.css
+++ b/src/app/story/directives/basic.component.css
@@ -13,13 +13,6 @@ prx-select {
   top: -4px;
   right: 0;
 }
-/* TODO: move to styleguide */
-/*prx-select.changed >>> .dropdown-toggle {
-  outline: 5px auto #f09b4c;
-}
-prx-select.invalid >>> .dropdown-toggle {
-  outline: 5px auto #e32;
-}*/
 
 publish-upload {
   margin-bottom: 30px;

--- a/src/app/story/directives/basic.component.css
+++ b/src/app/story/directives/basic.component.css
@@ -7,6 +7,20 @@ hr {
   border-bottom: 1px solid #ccc;
   margin: 0 0 30px;
 }
+
+prx-select {
+  position: absolute;
+  top: -4px;
+  right: 0;
+}
+/* TODO: move to styleguide */
+/*prx-select.changed >>> .dropdown-toggle {
+  outline: 5px auto #f09b4c;
+}
+prx-select.invalid >>> .dropdown-toggle {
+  outline: 5px auto #e32;
+}*/
+
 publish-upload {
   margin-bottom: 30px;
 }

--- a/src/app/story/directives/basic.component.spec.ts
+++ b/src/app/story/directives/basic.component.spec.ts
@@ -1,4 +1,6 @@
-import { cit, create, provide, By } from '../../../testing';
+import { cit, create, cms, provide, By } from '../../../testing';
+import { Observable } from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
 import { BasicComponent } from './basic.component';
 import { TabService } from 'ngx-prx-styleguide';
 
@@ -36,6 +38,36 @@ describe('BasicComponent', () => {
     fix.detectChanges();
 
     expect(el).toContainText('You have no audio templates for this episode');
+  });
+
+
+  describe('version select', () => {
+
+    let story, versions, templates;
+    beforeEach(() => {
+      versions = [];
+      templates = [];
+      story = {
+        loadRelated: () => (story.versions = versions) && Observable.of(true),
+        removeRelated: r => story.versions = story.versions.filter(v => v !== r),
+        getSeriesTemplates: () => Observable.of(templates.map(t => cms.mock('prx:tpl', t)))
+      };
+    });
+
+    cit('updates version templates to match the selection', (fix, el, comp) => {
+      comp.story = story;
+      versions = [{label: 'whatev', template: {id: 456}}, {label: 'whatev2', isNew: true, template: {id: 456}}];
+      templates = [{id: 123, label: 'tpl 123'}, {id: 456, label: 'tpl 456'}];
+      comp.loadVersionTemplates();
+      comp.updateVersions([123]);
+      expect(story.versions.length).toEqual(2);
+      expect(story.versions[0].label).toEqual('whatev');
+      expect(story.versions[0].template.id).toEqual(456);
+      expect(story.versions[0].isDestroy).toEqual(true);
+      expect(story.versions[1].label).toEqual('tpl 123');
+      expect(story.versions[1].template.id).toEqual(123);
+    });
+
   });
 
 });

--- a/src/app/story/directives/basic.component.spec.ts
+++ b/src/app/story/directives/basic.component.spec.ts
@@ -37,7 +37,7 @@ describe('BasicComponent', () => {
     comp.story = {versions: [], changed: () => false};
     fix.detectChanges();
 
-    expect(el).toContainText('You have no audio templates for this episode');
+    expect(el).toContainText('Pick at least one version of your audio files to upload for this episode');
   });
 
 

--- a/src/app/story/directives/basic.component.ts
+++ b/src/app/story/directives/basic.component.ts
@@ -139,6 +139,8 @@ export class BasicComponent implements OnDestroy, DoCheck {
           v.isDestroy = false;
         } else if (v.isNew) {
           this.story.removeRelated(v);
+        } else {
+          v.isDestroy = true;
         }
       }
     });
@@ -159,7 +161,7 @@ export class BasicComponent implements OnDestroy, DoCheck {
     }
   }
 
-  private loadVersionTemplates() {
+  loadVersionTemplates() {
     this.story.getSeriesTemplates().subscribe(tdocs => {
       this.versionTemplates = {};
       this.versionTemplateOptions = tdocs.map(tdoc => {
@@ -173,10 +175,9 @@ export class BasicComponent implements OnDestroy, DoCheck {
   private setSelected() {
     let templateIds: any = this.versionTemplateOptions.map(opt => opt[1]);
     let selected = this.story.versions.filter(v => {
-      return v.template && templateIds.indexOf(v.template.id) > -1;
+      return !v.isDestroy && v.template && templateIds.indexOf(v.template.id) > -1;
     }).map(v => v.template.id);
     if (selected.join(',') !== (this.versionTemplatesSelected || []).join(',')) {
-      console.log('change selected:', (this.versionTemplatesSelected || []).join(','), selected.join(','));
       this.versionTemplatesSelected = selected;
     }
   }

--- a/src/app/story/directives/basic.component.ts
+++ b/src/app/story/directives/basic.component.ts
@@ -36,9 +36,9 @@ import { HalDoc, TabService } from 'ngx-prx-styleguide';
           [class.changed]="versionsChanged"></prx-select>
         <prx-spinner *ngIf="!undeletedVersions"></prx-spinner>
         <publish-upload *ngFor="let v of undeletedVersions" [version]="v" [strict]="strict"></publish-upload>
-        <h1 *ngIf="undeletedVersions?.length === 0">
-          You have no audio templates for this episode. How did that happen?
-        </h1>
+        <div *ngIf="undeletedVersions?.length === 0" class="fancy-hint">
+          Pick at least one version of your audio files to upload for this episode.
+        </div>
       </prx-fancy-field>
 
       <prx-fancy-field label="Cover Image">

--- a/src/app/story/directives/podcast.component.html
+++ b/src/app/story/directives/podcast.component.html
@@ -1,6 +1,6 @@
 <prx-spinner *ngIf="!episode"></prx-spinner>
 <form *ngIf="episode">
-  <prx-fancy-field *ngIf="version" label="Explicit">
+  <prx-fancy-field *ngIf="versions?.length" label="Explicit">
     <div class="fancy-hint">
       In accordance with
       <a [href]="itunesRequirementsDoc"
@@ -12,12 +12,12 @@
         Setting this field will override your <strong>{{podcastExplicit}}</strong> podcast global value.
       </ng-container>
     </div>
-    <div class="version">
+    <div *ngFor="let v of versions" class="version">
       <header>
-        <strong>{{version?.label}}</strong>
+        <strong>{{v?.label}}</strong>
       </header>
       <section>
-        <prx-fancy-field [model]="version" [select]="explicitOpts" name="explicit">
+        <prx-fancy-field [model]="v" [select]="explicitOpts" name="explicit">
         </prx-fancy-field>
       </section>
     </div>

--- a/src/app/story/directives/podcast.component.spec.ts
+++ b/src/app/story/directives/podcast.component.spec.ts
@@ -28,7 +28,7 @@ describe('PodcastComponent', () => {
       original: {guid: 'bar'},
       changed: () => false
     };
-    comp.version = 'foo';
+    comp.versions = ['foo'];
     fix.detectChanges();
 
     expect(el.queryAll(By.css('prx-fancy-field')).length).toEqual(8);

--- a/src/app/story/directives/podcast.component.ts
+++ b/src/app/story/directives/podcast.component.ts
@@ -18,7 +18,7 @@ import {
 
 export class PodcastComponent implements OnDestroy {
 
-  explicitOpts = ['', 'Explicit', 'Clean'];
+  explicitOpts = ['Explicit', 'Clean'];
   itunesRequirementsDoc = 'https://help.apple.com/itc/podcasts_connect/#/itc1723472cb';
   itunesExplicitDoc = 'https://support.apple.com/en-us/HT202005';
 

--- a/src/app/story/directives/podcast.component.ts
+++ b/src/app/story/directives/podcast.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnDestroy, ViewChild } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';
+import 'rxjs/add/observable/forkJoin';
 import { TabService } from 'ngx-prx-styleguide';
 import { CmsService } from '../../core';
 import {
@@ -26,7 +28,7 @@ export class PodcastComponent implements OnDestroy {
   storyDistribution: StoryDistributionModel;
   story: StoryModel;
   episode: FeederEpisodeModel;
-  version: AudioVersionModel;
+  versions: AudioVersionModel[];
   podcastExplicit: string;
   podcastAuthorName: string;
   podcastAuthorEmail: string;
@@ -65,19 +67,17 @@ export class PodcastComponent implements OnDestroy {
         this.podcastAuthorName = dist.podcast ? dist.podcast.authorName : null;
         this.podcastAuthorEmail = dist.podcast ? dist.podcast.authorEmail : null;
       });
-      this.findPodcastAudioVersion(story, dist);
+      this.findPodcastAudioVersions(story, dist);
     });
   }
 
-  findPodcastAudioVersion(story: StoryModel, dist: DistributionModel) {
-    dist.loadRelated('versionTemplate').subscribe(() => {
-      if (dist.versionTemplate) {
-        story.loadRelated('versions').subscribe(() => {
-          this.version = story.versions.find(v => v.template && v.template.id === dist.versionTemplate.id);
-        });
-      } else {
-        this.version = null;
-      }
+  findPodcastAudioVersions(story: StoryModel, dist: DistributionModel) {
+    let loadTpls = dist.loadRelated('versionTemplates');
+    let loadVersions = story.loadRelated('versions');
+    Observable.forkJoin(loadTpls, loadVersions).subscribe(() => {
+      this.versions = dist.versionTemplates.map(vt => {
+        return story.versions.find(v => v.template && v.template.id === vt.id);
+      }).filter(v => v);
     });
   }
 

--- a/src/app/story/story.component.ts
+++ b/src/app/story/story.component.ts
@@ -4,11 +4,12 @@ import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 
 import { CmsService } from '../core';
-import { ModalService, ToastrService } from 'ngx-prx-styleguide';
+import { ModalService, TabService, ToastrService } from 'ngx-prx-styleguide';
 import { StoryModel } from '../shared';
 import { Env } from '../core/core.env';
 
 @Component({
+  providers: [TabService],
   selector: 'publish-story',
   styleUrls: ['story.component.css'],
   template: `

--- a/src/app/story/story.module.ts
+++ b/src/app/story/story.module.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 
 import { SharedModule } from '../shared';
 import { UploadModule } from '../upload';
-import { ChartsModule, SelectModule } from 'ngx-prx-styleguide';
+import { ChartsModule, SelectModule, TabModule } from 'ngx-prx-styleguide';
 import { storyRouting, storyProviders, storyComponents } from './story.routing';
 
 @NgModule({
@@ -15,6 +15,7 @@ import { storyRouting, storyProviders, storyComponents } from './story.routing';
     ChartsModule,
     SelectModule,
     SharedModule,
+    TabModule,
     UploadModule,
     storyRouting
   ],

--- a/src/app/story/story.module.ts
+++ b/src/app/story/story.module.ts
@@ -3,7 +3,7 @@ import { CommonModule } from '@angular/common';
 
 import { SharedModule } from '../shared';
 import { UploadModule } from '../upload';
-import { ChartsModule } from 'ngx-prx-styleguide';
+import { ChartsModule, SelectModule } from 'ngx-prx-styleguide';
 import { storyRouting, storyProviders, storyComponents } from './story.routing';
 
 @NgModule({
@@ -13,6 +13,7 @@ import { storyRouting, storyProviders, storyComponents } from './story.routing';
   imports: [
     CommonModule,
     ChartsModule,
+    SelectModule,
     SharedModule,
     UploadModule,
     storyRouting

--- a/src/app/upload/shared/audio-input.component.spec.ts
+++ b/src/app/upload/shared/audio-input.component.spec.ts
@@ -81,4 +81,17 @@ describe('AudioInputComponent', () => {
     expect(el).toQueryAttr('input', 'multiple', 'true');
   });
 
+  cit('accepts different content types', (fix, el, comp) => {
+    comp.accept = undefined;
+    expect(comp.acceptWildcard).toEqual('*');
+    comp.accept = 'audio/mpeg';
+    expect(comp.acceptWildcard).toEqual('audio/*');
+    comp.accept = 'audio/foobar';
+    expect(comp.acceptWildcard).toEqual('audio/*');
+    comp.accept = 'video/mpeg';
+    expect(comp.acceptWildcard).toEqual('video/*');
+    comp.accept = 'foo/bar';
+    expect(comp.acceptWildcard).toEqual('*');
+  });
+
 });

--- a/src/app/upload/shared/audio-input.component.ts
+++ b/src/app/upload/shared/audio-input.component.ts
@@ -6,7 +6,7 @@ import { AudioVersionModel } from '../../shared';
   selector: 'publish-audio-input',
   styleUrls: ['audio-input.component.css'],
   template: `
-    <input type="file" accept="audio/mpeg" publishFileSelect [id]="uuid"
+    <input type="file" [accept]="acceptWildcard" publishFileSelect [id]="uuid"
       [attr.multiple]="multiple" (file)="addFile($event)"/>
     <label *ngIf="multiple" class="button" [htmlFor]="uuid">Upload Files</label>
     <label *ngIf="!multiple" class="button" [htmlFor]="uuid">Upload File</label>
@@ -18,6 +18,7 @@ export class AudioInputComponent {
   @Input() multiple = null;
   @Input() version: AudioVersionModel;
   @Input() position: number;
+  @Input() accept: string;
 
   uuid: string;
 
@@ -27,6 +28,16 @@ export class AudioInputComponent {
     private uploadService: UploadService
   ) {
     this.uuid = UUID.UUID();
+  }
+
+  get acceptWildcard(): string {
+    if (this.accept && this.accept.match(/audio/i)) {
+      return 'audio/*';
+    } else if (this.accept && this.accept.match(/video/i)) {
+      return 'video/*';
+    } else {
+      return '*';
+    }
   }
 
   click() {

--- a/src/app/upload/templated/templated-upload.component.ts
+++ b/src/app/upload/templated/templated-upload.component.ts
@@ -48,7 +48,8 @@ import {
       </div>
 
       <div class="cancel">
-        <publish-audio-input [version]="version" [position]="template.position"></publish-audio-input>
+        <publish-audio-input [version]="version" [position]="template.position"
+          [accept]="accept"></publish-audio-input>
       </div>
 
     </div>
@@ -60,5 +61,6 @@ export class TemplatedUploadComponent {
   @Input() version: AudioVersionModel;
   @Input() template: AudioVersionTemplateModel;
   @Input() file: AudioFileModel;
+  @Input() accept: string;
 
 }

--- a/src/app/upload/upload.component.spec.ts
+++ b/src/app/upload/upload.component.spec.ts
@@ -25,7 +25,14 @@ describe('UploadComponent', () => {
     comp.version = mockVersion({label: 'My Label'});
     fix.detectChanges();
     expect(el).toQueryText('header strong', 'My Label');
-    expect(el).toQueryText('header span', comp.DESCRIPTIONS.DEFAULT);
+    expect(el).toQueryText('header span', comp.DESCRIPTIONS[comp.DESCRIPTIONS.length - 1].desc);
+  });
+
+  cit('bases descriptions on the version label', (fix, el, comp) => {
+    comp.version = mockVersion({label: 'Some Promos or Something'});
+    expect(comp.versionDescription()).toMatch(/promotional version/i);
+    comp.version = mockVersion({label: 'Video episode for my podcast'});
+    expect(comp.versionDescription()).toMatch(/the video file/i);
   });
 
   cit('lists templated uploads', (fix, el, comp) => {

--- a/src/app/upload/upload.component.ts
+++ b/src/app/upload/upload.component.ts
@@ -7,7 +7,7 @@ import { AudioVersionModel } from '../shared';
   template: `
     <header>
       <strong>{{version.label}}</strong>
-      <span>{{versionDescription}}</span>
+      <span>{{versionDescription()}}</span>
     </header>
 
     <section *ngIf="version.hasFileTemplates">
@@ -44,32 +44,23 @@ import { AudioVersionModel } from '../shared';
   `
 })
 
-export class UploadComponent implements OnInit, DoCheck {
+export class UploadComponent implements DoCheck {
 
   @Input() version: AudioVersionModel;
   @Input() strict: boolean;
 
-  versionDescription: string;
-
-  DESCRIPTIONS = {
-    'DEFAULT': 'The audio files for your episode, in mp3 format.',
-    'Piece Audio': 'The standard version of your episode you would most like people to hear and buy',
-    'Promos': 'The promotional version of your audio'
-  };
+  DESCRIPTIONS = [
+    {test: /piece audio/i, desc: 'The standard version of your episode you would most like people to hear and buy'},
+    {test: /promos/i, desc: 'The promotional version of your audio'},
+    {test: /video/i, desc: 'The video file for your episode'},
+    {test: /./, desc: 'The audio files for your episode, in mp3 format.'}
+  ];
 
   @HostBinding('class.changed') changedClass = false;
 
   @HostBinding('class.invalid') invalidClass = false;
 
   invalidMessage: string = null;
-
-  ngOnInit() {
-    if (this.version && this.DESCRIPTIONS[this.version.label]) {
-      this.versionDescription = this.DESCRIPTIONS[this.version.label];
-    } else {
-      this.versionDescription = this.DESCRIPTIONS.DEFAULT;
-    }
-  }
 
   ngDoCheck() {
     this.changedClass = false;
@@ -93,6 +84,15 @@ export class UploadComponent implements OnInit, DoCheck {
         this.invalidMessage = this.version.statusMessage;
       }
     }
+  }
+
+  versionDescription(): string {
+    let label = this.version['label'] || '';
+    let desc = this.DESCRIPTIONS.find(d => d.test.test(label));
+    if (desc) {
+      return desc.desc;
+    }
+    return '';
   }
 
   versionUploadedInvalid(): boolean {

--- a/src/app/upload/upload.component.ts
+++ b/src/app/upload/upload.component.ts
@@ -14,7 +14,8 @@ import { AudioVersionModel } from '../shared';
       <div class="uploads">
         <ng-container *ngFor="let ft of version.filesAndTemplates">
           <publish-templated-upload *ngIf="ft.tpl" [template]="ft.tpl"
-            [file]="ft.file" [version]="version" publishClick></publish-templated-upload>
+            [file]="ft.file" [version]="version" publishClick
+            [accept]="version?.template?.contentType"></publish-templated-upload>
           <publish-illegal-upload *ngIf="!ft.tpl" [file]="ft.file"
             [version]="version"></publish-illegal-upload>
         </ng-container>
@@ -37,8 +38,8 @@ import { AudioVersionModel } from '../shared';
 
       <footer [class.templated]="version.hasFileTemplates">
         <p *ngIf="invalidMessage" class="error">{{invalidMessage | capitalize}}</p>
-        <publish-audio-input *ngIf="!version.hasFileTemplates"
-          multiple=true [version]="version"></publish-audio-input>
+        <publish-audio-input *ngIf="!version.hasFileTemplates" multiple=true
+          [version]="version" [accept]="version?.template?.contentType"></publish-audio-input>
       </footer>
     </section>
   `

--- a/yarn.lock
+++ b/yarn.lock
@@ -265,6 +265,10 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
+angular-2-dropdown-multiselect@^1.5.4:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/angular-2-dropdown-multiselect/-/angular-2-dropdown-multiselect-1.5.4.tgz#d596745ffdb877e4bc80170d64e8b5c52247926e"
+
 angulartics2@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/angulartics2/-/angulartics2-2.2.2.tgz#a4fe1a007b87299b3818811c1f3490756792fd8f"
@@ -3523,10 +3527,11 @@ ng2-dragula@^1.3.1:
   dependencies:
     dragula "^3.7.2"
 
-ngx-prx-styleguide@0.0.15:
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/ngx-prx-styleguide/-/ngx-prx-styleguide-0.0.15.tgz#02f0704939bc8e9038f19ebfca3ff5f5d383a8f1"
+ngx-prx-styleguide@0.0.16:
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/ngx-prx-styleguide/-/ngx-prx-styleguide-0.0.16.tgz#0870701a131180389761192037dc93fb58ddb414"
   dependencies:
+    angular-2-dropdown-multiselect "^1.5.4"
     c3 "^0.4.11"
     pikaday "^1.5.1"
 


### PR DESCRIPTION
See #448.

- [x] Allow adding multiple templates to a series (new or existing)
- [x] Allow adding "video file" templates to a series
- [x] Don't allow setting duration or multiple-segments for video templates (hardcoded 1-segment, but it only shows up on the story pages)

Also made sense to build in #450:

- [x] Allow uploading other mime types for a video-file-version.  (Uses `<input accept="video/*"/>`)
- [x] Don't validate video uploads on the frontend

And #449:

- [x] Allow selecting multiple templates associated with your Series Podcast Distribution
  - Force at least 1 selection
- [x] Allow selecting/unselecting the audio-versions for a story
  - Force at least 1 version per story
  - NOTE: this makes **no attempt** to enforce picking a version associated with your podcast (selected above on the series page).  This is fine for now, since there's only 1 kind of distribution.  But later may allow users to shoot themselves in the foot.  Which is also fine.
  - ALSO NOTE: this doesn't warn users that changing around your story-audio-versions can impact what audio is in your feed.  I assume if you changed a story from "Version w/3 segments" to "Version w/4 segments" ... it's fairly self explanatory of the consequences.
