### PR TITLE
adds Intl polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "evaporate": "^1.6.3",
     "express": "^4.15.2",
     "express-http-proxy": "^1.0.1",
+    "intl": "^1.2.5",
     "langmap": "0.0.14",
     "moment": "^2.18.1",
     "morgan": "^1.8.1",

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -65,4 +65,4 @@ import 'zone.js/dist/zone';  // Included with Angular CLI.
  * Date, currency, decimal and percent pipes.
  * Needed for: All but Chrome, Firefox, Edge, IE11 and Safari 10
  */
-// import 'intl';  // Run `npm install --save intl`.
+import 'intl';  // Run `npm install --save intl`.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2587,6 +2587,10 @@ interpret@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.3.tgz#cbc35c62eeee73f19ab7b10a801511401afc0f90"
 
+intl@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"
+
 invariant@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"


### PR DESCRIPTION
resolves PhantomJS error `Can't find variable: Intl` by adding polyfill