### PR TITLE
Audio version delete fixes

### DIFF
--- a/src/app/story/directives/basic.component.spec.ts
+++ b/src/app/story/directives/basic.component.spec.ts
@@ -71,6 +71,15 @@ describe('BasicComponent', () => {
       expect(story.versions[1].template.id).toEqual(123);
     });
 
+    cit('refuses to select an unknown template id', (fix, el, comp) => {
+      comp.story = story;
+      versions = [{label: 'whatev', template: {id: 456}}, {label: 'whatev2', isNew: true, template: {id: 456}}];
+      templates = [{id: 123, label: 'tpl 123'}, {id: 456, label: 'tpl 456'}];
+      comp.loadVersionTemplates();
+      comp.updateVersions([456, 99999]);
+      expect(story.versions.length).toEqual(1);
+    });
+
   });
 
 });

--- a/src/app/story/directives/basic.component.spec.ts
+++ b/src/app/story/directives/basic.component.spec.ts
@@ -48,8 +48,8 @@ describe('BasicComponent', () => {
 
     let story, versions, templates;
     beforeEach(() => {
-      versions = [];
-      templates = [];
+      versions = [{label: 'whatev', template: {id: 456}}];
+      templates = [{id: 123, label: 'tpl 123'}, {id: 456, label: 'tpl 456'}];
       story = {
         loadRelated: () => (story.versions = versions) && Observable.of(true),
         removeRelated: r => story.versions = story.versions.filter(v => v !== r),
@@ -59,8 +59,6 @@ describe('BasicComponent', () => {
 
     cit('updates version templates to match the selection', (fix, el, comp) => {
       comp.story = story;
-      versions = [{label: 'whatev', template: {id: 456}}, {label: 'whatev2', isNew: true, template: {id: 456}}];
-      templates = [{id: 123, label: 'tpl 123'}, {id: 456, label: 'tpl 456'}];
       comp.loadVersionTemplates();
       comp.updateVersions([123]);
       expect(story.versions.length).toEqual(2);
@@ -73,11 +71,20 @@ describe('BasicComponent', () => {
 
     cit('refuses to select an unknown template id', (fix, el, comp) => {
       comp.story = story;
-      versions = [{label: 'whatev', template: {id: 456}}, {label: 'whatev2', isNew: true, template: {id: 456}}];
-      templates = [{id: 123, label: 'tpl 123'}, {id: 456, label: 'tpl 456'}];
       comp.loadVersionTemplates();
       comp.updateVersions([456, 99999]);
       expect(story.versions.length).toEqual(1);
+    });
+
+    cit('undestroys audio files when their version is destroyed', (fix, el, comp) => {
+      versions[0].files = [{isDestroy: true}, {isDestroy: false}];
+      comp.story = story;
+      comp.loadVersionTemplates();
+      comp.updateVersions([123]);
+      expect(story.versions.length).toEqual(2);
+      expect(story.versions[0].isDestroy).toEqual(true);
+      expect(story.versions[0].files[0].isDestroy).toEqual(false);
+      expect(story.versions[0].files[1].isDestroy).toEqual(false);
     });
 
   });

--- a/src/app/story/directives/basic.component.ts
+++ b/src/app/story/directives/basic.component.ts
@@ -168,7 +168,7 @@ export class BasicComponent implements OnDestroy, DoCheck {
       }
     });
     templateIds.forEach(id => {
-      if (!used[id]) {
+      if (!used[id] && this.versionTemplates[id]) {
         this.story.versions.push(new AudioVersionModel({
           series: this.story.parent,
           template: this.versionTemplates[id]

--- a/src/app/story/directives/basic.component.ts
+++ b/src/app/story/directives/basic.component.ts
@@ -164,6 +164,7 @@ export class BasicComponent implements OnDestroy, DoCheck {
           this.story.removeRelated(v);
         } else {
           v.isDestroy = true;
+          (v.files || []).forEach(f => f.isDestroy = false);
         }
       }
     });


### PR DESCRIPTION
Issues:

1. Delete an audio-file, then delete the audio-version, then save ... Publish fires off 2 DELETEs to CMS.  But CMS already destroys the child audio-files when the version is destroyed, so we end up getting a 404 for the 2nd DELETE.
2. Start with a saved story with 0 audio-versions.  When you go to add an audio-version from the dropdown, you get 2 (the 2nd that default "Main Audio").

Fixes:

- [x] Whenever you delete an audio-version, iterate through version.files and set all their `isDestroy = false`
- [x] Checkbox component was returning a null when you start with a blank selection (like `[1234, null]` when you select template-id 1234).  May be a bug in the styleguide component, but it doesn't hurt to just always validate that each id in that array actually exists.