### PR TITLE
Small fixes of shared audio CSS 

### DIFF
--- a/src/app/upload/shared/audio.css
+++ b/src/app/upload/shared/audio.css
@@ -78,7 +78,6 @@
 .main .info span, .main .info publish-audio-duration {
   margin-right: 6px;
   max-width: 60%;
-  vertical-align: middle;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/app/upload/shared/audio.css
+++ b/src/app/upload/shared/audio.css
@@ -73,9 +73,15 @@
   border: 1px solid #DDDDDD;
   border-left: 0 none;
   padding: 6px 10px;
+  max-width: calc(100% - 160px);
 }
 .main .info span, .main .info publish-audio-duration {
   margin-right: 6px;
+  max-width: 60%;
+  vertical-align: middle;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .main .info publish-audio-player {
   flex-grow: 1;


### PR DESCRIPTION
looks like this currently: 
not playing:
![image](https://user-images.githubusercontent.com/16007382/35064499-43c0d224-fb98-11e7-952d-b3ef5563b117.png)

playing:
![image](https://user-images.githubusercontent.com/16007382/35064504-4c62c144-fb98-11e7-8e64-f522af5c55ed.png)

with this PR, will look like:
not playing:
![image](https://user-images.githubusercontent.com/16007382/35064474-2d9471ae-fb98-11e7-8a25-840e840b24f6.png)
playing:
![image](https://user-images.githubusercontent.com/16007382/35064446-1810a1fe-fb98-11e7-9693-a150167b4984.png)
