### PR TITLE
Upstream fix for url validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "langmap": "0.0.14",
     "moment": "^2.18.1",
     "ng2-dragula": "^1.3.1",
-    "ngx-prx-styleguide": "0.0.16",
+    "ngx-prx-styleguide": "0.0.32",
     "prosemirror-commands": "0.18.0",
     "prosemirror-inputrules": "0.18.0",
     "prosemirror-keymap": "0.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3651,9 +3651,9 @@ ng2-dragula@^1.3.1:
   dependencies:
     dragula "^3.7.2"
 
-ngx-prx-styleguide@0.0.16:
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/ngx-prx-styleguide/-/ngx-prx-styleguide-0.0.16.tgz#0870701a131180389761192037dc93fb58ddb414"
+ngx-prx-styleguide@0.0.32:
+  version "0.0.32"
+  resolved "https://registry.yarnpkg.com/ngx-prx-styleguide/-/ngx-prx-styleguide-0.0.32.tgz#c27a6e6b1ef3305c5ff40629065a8b42466d58ce"
   dependencies:
     angular-2-dropdown-multiselect "^1.5.4"
     c3 "^0.4.11"


### PR DESCRIPTION
Doesn't actually solve #496, but at least fixes the URL-validations so you can't save your messed up URL.

Still has the issue where "strange things" can happen if you type in a leading space, or delete part of "http://".