### PR TITLE
Use new CMS search endpoints

### DIFF
--- a/src/app/search/directives/search-series-form.component.ts
+++ b/src/app/search/directives/search-series-form.component.ts
@@ -43,7 +43,7 @@ export class SearchSeriesFormComponent implements OnInit {
 
   ngOnInit() {
     this.searchTextStream
-      .debounceTime(300)
+      .debounceTime(500)
       .distinctUntilChanged()
       .subscribe((text: string) => {
         this.modelChange.emit(this.model);

--- a/src/app/search/directives/search-story-form.component.ts
+++ b/src/app/search/directives/search-story-form.component.ts
@@ -57,7 +57,7 @@ export class SearchStoryFormComponent implements OnInit {
 
   ngOnInit() {
     this.searchTextStream
-      .debounceTime(300)
+      .debounceTime(500)
       .distinctUntilChanged()
       .subscribe((text: string) => {
         this.modelChange.emit(this.model);

--- a/src/app/search/directives/series-card.component.ts
+++ b/src/app/search/directives/series-card.component.ts
@@ -1,12 +1,12 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { SeriesModel } from '../../shared';
+import { HalDoc } from '../../core';
 
 @Component({
   selector: 'publish-series-card',
   styleUrls: ['series-card.component.css'],
   template: `
     <section class="series-image">
-      <a [routerLink]="seriesLink"><prx-image [imageDoc]="series.doc"></prx-image></a>
+      <a [routerLink]="seriesLink"><prx-image [imageDoc]="series"></prx-image></a>
       <div class="stack stk-one"></div>
       <div class="stack stk-two"></div>
       <div class="stack stk-three"></div>
@@ -28,7 +28,7 @@ import { SeriesModel } from '../../shared';
 
 export class SeriesCardComponent implements OnInit {
 
-  @Input() series: SeriesModel;
+  @Input() series: HalDoc;
 
   seriesLink: any[];
 
@@ -40,10 +40,10 @@ export class SeriesCardComponent implements OnInit {
 
   ngOnInit() {
     this.seriesId = this.series.id;
-    this.seriesTitle = this.series.title;
-    this.seriesEpisodeCount = this.series.doc.count('prx:stories') || 0;
-    this.seriesUpdatedAt = this.series.updatedAt;
-    this.seriesDescription = this.series.shortDescription;
+    this.seriesTitle = this.series['title'];
+    this.seriesEpisodeCount = this.series.count('prx:stories') || 0;
+    this.seriesUpdatedAt = this.series['updatedAt'];
+    this.seriesDescription = this.series['shortDescription'];
     this.seriesLink = ['/series', this.series.id];
   }
 }

--- a/src/app/search/directives/series-list.component.ts
+++ b/src/app/search/directives/series-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { SeriesModel } from '../../shared';
+import { HalDoc } from '../../core';
 
 @Component({
   selector: 'publish-series-list',
@@ -20,6 +20,6 @@ import { SeriesModel } from '../../shared';
 
 export class SeriesListComponent {
   @Input() noSeries: boolean;
-  @Input() series: SeriesModel[];
+  @Input() series: HalDoc[];
   @Input() isLoaded: boolean;
 }

--- a/src/app/search/directives/story-list.component.ts
+++ b/src/app/search/directives/story-list.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { StoryModel } from '../../shared';
+import { HalDoc } from '../../core';
 
 @Component({
   selector: 'publish-story-list',
@@ -20,7 +20,7 @@ import { StoryModel } from '../../shared';
 
 export class StoryListComponent {
   @Input() noStories: boolean;
-  @Input() stories: StoryModel[];
+  @Input() stories: HalDoc[];
   @Input() isLoaded: boolean;
 
   emptyCards: number[] = [1, 2]; // These are fillers for cheating the flexbox "grid"

--- a/src/app/search/search.component.css
+++ b/src/app/search/search.component.css
@@ -34,3 +34,7 @@ header .pages > button {
   margin-left: 4px;
 }
 
+.error h1 {
+  color: #e32;
+  font-weight: 400;
+}

--- a/src/app/search/search.component.html
+++ b/src/app/search/search.component.html
@@ -40,6 +40,10 @@
       </div>
     </header>
 
+    <div *ngIf="searchError" class="error">
+      <h1>Your search query contains a syntax error - please update it and try again</h1>
+    </div>
+
     <publish-story-list
       *ngIf="isOnStoriesTab()"
       [noStories]="noResults"

--- a/src/app/search/search.component.spec.ts
+++ b/src/app/search/search.component.spec.ts
@@ -18,7 +18,8 @@ describe('SearchComponent', () => {
     auth = cms.mock('prx:authorization', {});
     auth.mock('prx:default-account', {});
     auth.mockItems('prx:series', []);
-    auth.mockItems('prx:stories', []);
+    auth.mockItems('prx:series-search', []);
+    auth.mockItems('prx:stories-search', []);
   });
 
   cit('detects no results', (fix, el, comp) => {
@@ -38,7 +39,7 @@ describe('SearchComponent', () => {
     let storiesResults = [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}];
     beforeEach(() => {
       activatedRoute.testParams = {tab: 'stories'};
-      auth.mockItems('prx:stories', storiesResults);
+      auth.mockItems('prx:stories-search', storiesResults);
     });
 
     cit('loads a list of stories', (fix, el, comp) => {
@@ -59,7 +60,7 @@ describe('SearchComponent', () => {
     let seriesResults = [{}, {}, {}, {}, {}, {}, {}, {}, {}, {}];
     beforeEach(() => {
       activatedRoute.testParams = {tab: 'series'};
-      auth.mockItems('prx:series', seriesResults);
+      auth.mockItems('prx:series-search', seriesResults);
     });
 
     cit('loads a list of series', (fix, el, comp) => {
@@ -68,6 +69,32 @@ describe('SearchComponent', () => {
       expect(comp.seriesResults.length).toEqual(seriesResults.length);
     });
 
+  });
+
+  describe('with remote errors', () => {
+
+    beforeEach(() => {
+      auth.count = () => 999;
+      auth.mockError('prx:stories-search', new Error('Something went terribly awry'));
+      activatedRoute.testParams = {tab: 'stories'};
+    });
+
+    cit('catches and displays a search errors', (fix, el, comp) => {
+      expect(comp.noResults).toBe(false);
+      expect(comp.isLoaded).toBe(true);
+      expect(comp.searchError).toBe(true);
+      expect(el).toContainText('Your search query contains a syntax error');
+    });
+
+  });
+
+  cit('adds wildcards to the end of searches', (fix, el, comp) => {
+    expect(comp.addWildcard(null)).toEqual(null);
+    expect(comp.addWildcard('')).toEqual('');
+    expect(comp.addWildcard('a')).toEqual('a*');
+    expect(comp.addWildcard('hello worl')).toEqual('hello worl*');
+    expect(comp.addWildcard('hello worl*')).toEqual('hello worl*');
+    expect(comp.addWildcard('hello worl ')).toEqual('hello worl ');
   });
 
 });


### PR DESCRIPTION
For #540 and #422.

Requires PRX/cms.prx.org#453.

- [x] Use the new `prx:stories-search` and `prx-series-search` endpoints, and the new `q` param
- [x] Simplify a bit by converting models into plain HalDocs (search pages are read-only anyways)
- [x] Add wildcards to the end of the `?q=` string, for a better search-as-you-type experience
- [x] Catch any CMS 500 errors, and display a nice message _(since I started sanitizing the `?q=` param in CMS, this is less of an issue... but you never know)_