### PR TITLE
Don't create version templates via publish when importing

### DIFF
--- a/src/app/series-import/series-import.component.spec.ts
+++ b/src/app/series-import/series-import.component.spec.ts
@@ -88,4 +88,20 @@ describe('SeriesImportComponent', () => {
     expect(router.navigate).toHaveBeenCalledWith(['/series', comp.series.id, 'import-status']);
   });
 
+  cit('flushes unsaved audio version templates before save', (fix, el, comp) => {
+    activatedRoute.testParams = {};
+    auth.mock('prx:default-account', {id: 100});
+    auth.mock('prx:verify-rss', {});
+    fix.detectChanges();
+
+    let btn = el.queryAll(By.css('prx-button')).find(e => {
+      return e.nativeElement.textContent === 'Import Podcast';
+    });
+    expect(btn).not.toBeNull();
+
+    spyOn(comp.series, 'flushVersionTemplates');
+    btn.triggerEventHandler('click', null);
+    expect(comp.series.flushVersionTemplates).toHaveBeenCalled();
+  });
+
 });

--- a/src/app/series-import/series-import.component.ts
+++ b/src/app/series-import/series-import.component.ts
@@ -32,6 +32,8 @@ export class SeriesImportComponent implements OnInit {
   }
 
   save() {
+    // assume the import process builds any needed audio templates
+    this.series.flushVersionTemplates();
     this.series.save().subscribe(() => {
       this.toastr.success(`Series created`);
       this.router.navigate(this.afterSaveNavigateParams());

--- a/src/app/shared/model/series.model.spec.ts
+++ b/src/app/shared/model/series.model.spec.ts
@@ -36,4 +36,11 @@ describe('SeriesModel', () => {
     expect(data['set_account_uri']).not.toMatch(/series-account-id/);
   });
 
+  it('allows clearing version templates on new series', () => {
+    let series = makeSeries(true);
+    expect(series.versionTemplates.length).toEqual(1);
+    series.flushVersionTemplates();
+    expect(series.versionTemplates.length).toEqual(0);
+  });
+
 });

--- a/src/app/shared/model/series.model.ts
+++ b/src/app/shared/model/series.model.ts
@@ -177,6 +177,10 @@ export class SeriesModel extends BaseModel implements HasUpload {
     this.setUploads('prx:images', this.images.map(i => i.uuid));
   }
 
+  flushVersionTemplates() {
+    this.versionTemplates = [];
+  }
+
   defaultVersionTemplate() {
     let tpl = new AudioVersionTemplateModel(null, 0);
     tpl.set('label', 'Podcast Audio', true);


### PR DESCRIPTION
This PR prevents the podcast import component from creating an audio version template as part of creating the series.  The audio version templates will be created separately as part of the import process.

