### PR TITLE
Limit max audio template selection to 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "langmap": "0.0.14",
     "moment": "^2.18.1",
     "ng2-dragula": "^1.3.1",
-    "ngx-prx-styleguide": "2.1.2",
+    "ngx-prx-styleguide": "2.3.1",
     "prosemirror-commands": "0.18.0",
     "prosemirror-inputrules": "0.18.0",
     "prosemirror-keymap": "0.18.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "langmap": "0.0.14",
     "moment": "^2.18.1",
     "ng2-dragula": "^1.3.1",
-    "ngx-prx-styleguide": "2.1.1",
+    "ngx-prx-styleguide": "2.1.2",
     "prosemirror-commands": "0.18.0",
     "prosemirror-inputrules": "0.18.0",
     "prosemirror-keymap": "0.18.0",

--- a/src/app/story/directives/basic.component.spec.ts
+++ b/src/app/story/directives/basic.component.spec.ts
@@ -45,7 +45,7 @@ describe('BasicComponent', () => {
     comp.story = {versions: [], changed: () => false, invalid: () => false};
     fix.detectChanges();
 
-    expect(el).toContainText('Pick at least one version of your audio files to upload for this episode');
+    expect(el).toContainText('Pick a version of your audio files to upload for this episode');
   });
 
   cit('shows tip if audio version is selected', (fix, el, comp) => {

--- a/src/app/story/directives/basic.component.spec.ts
+++ b/src/app/story/directives/basic.component.spec.ts
@@ -48,6 +48,12 @@ describe('BasicComponent', () => {
     expect(el).toContainText('Pick at least one version of your audio files to upload for this episode');
   });
 
+  cit('shows tip if audio version is selected', (fix, el, comp) => {
+    comp.story = {versions: [{label: 'whatev', template: {id: 456}}], changed: () => false, invalid: () => false};
+    fix.detectChanges();
+
+    expect(el).toContainText('Clear your selection to select another template');
+  });
 
   describe('version select', () => {
 

--- a/src/app/story/directives/basic.component.ts
+++ b/src/app/story/directives/basic.component.ts
@@ -38,18 +38,18 @@ import { HalDoc, ModalService, TabService } from 'ngx-prx-styleguide';
       <prx-fancy-field required label="Audio Files">
         
         <prx-select
-          *ngIf="versionTemplateOptions" class="file-select"  placeholder="Select Templates..."
+          *ngIf="versionTemplateOptions" class="file-select" placeholder="Select Template..."
           [selected]="versionTemplatesSelected" [options]="versionTemplateOptions"
-          (onSelect)="updateVersions($event)" [maxSelectedItems]="1"
-          [class.invalid]="versionsInvalid"
-          [class.changed]="versionsChanged"></prx-select>
+          (onSelect)="updateVersions($event)" [maxSelectedItems]="1" [closeOnSelect]="true"
+          [class.invalid]="versionsInvalid" [class.changed]="versionsChanged">
+        </prx-select>
         <prx-spinner *ngIf="!undeletedVersions"></prx-spinner>
         <publish-upload *ngFor="let v of undeletedVersions" [version]="v" [strict]="strict"></publish-upload>
         <div *ngIf="undeletedVersions?.length === 0" class="fancy-hint">
-          Pick at least one version of your audio files to upload for this episode.
+          Pick a version of your audio files to upload for this episode.
         </div>
         <div *ngIf="undeletedVersions?.length > 0" class="fancy-hint">
-          Clear your selection to select another template
+          Clear your selection to select another template.
         </div>
       </prx-fancy-field>
 

--- a/src/app/story/directives/basic.component.ts
+++ b/src/app/story/directives/basic.component.ts
@@ -36,15 +36,20 @@ import { HalDoc, ModalService, TabService } from 'ngx-prx-styleguide';
       <hr/>
 
       <prx-fancy-field required label="Audio Files">
-        <prx-select *ngIf="versionTemplateOptions" class="file-select"  placeholder="Select Templates..."
+        
+        <prx-select
+          *ngIf="versionTemplateOptions" class="file-select"  placeholder="Select Templates..."
           [selected]="versionTemplatesSelected" [options]="versionTemplateOptions"
-          (onSelect)="updateVersions($event)"
+          (onSelect)="updateVersions($event)" [maxSelectedItems]="1"
           [class.invalid]="versionsInvalid"
           [class.changed]="versionsChanged"></prx-select>
         <prx-spinner *ngIf="!undeletedVersions"></prx-spinner>
         <publish-upload *ngFor="let v of undeletedVersions" [version]="v" [strict]="strict"></publish-upload>
         <div *ngIf="undeletedVersions?.length === 0" class="fancy-hint">
           Pick at least one version of your audio files to upload for this episode.
+        </div>
+        <div *ngIf="undeletedVersions?.length > 0" class="fancy-hint">
+          Clear your selection to select another template
         </div>
       </prx-fancy-field>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4931,10 +4931,10 @@ ng2-dragula@^1.3.1:
   dependencies:
     dragula "^3.7.2"
 
-ngx-prx-styleguide@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ngx-prx-styleguide/-/ngx-prx-styleguide-2.1.1.tgz#440de2b7bf16aabfd39ecbf0678e2b79e6668345"
-  integrity sha512-DM7Hi7pOspE8u2AQHoAfCSfU1sTW3e+BVBco4DUncKkx/45LxBOaOpc7ic9i5sJwZLz/3NfqFO3ywmIUg/1Gug==
+ngx-prx-styleguide@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ngx-prx-styleguide/-/ngx-prx-styleguide-2.1.2.tgz#d447893481b54e02afe9d5a88571bd3b86b820f0"
+  integrity sha512-USadGPKt4ekcgDIxQB5SWspnTAlEf9nN9Alt+NzX3YqxnHlqDRQoa1ckACu01JpwsyEfltxYXbUsbaXBWTQVkA==
   dependencies:
     "@ng-select/ng-select" "^2.15.3"
     c3 "^0.4.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4931,15 +4931,21 @@ ng2-dragula@^1.3.1:
   dependencies:
     dragula "^3.7.2"
 
-ngx-prx-styleguide@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/ngx-prx-styleguide/-/ngx-prx-styleguide-2.1.2.tgz#d447893481b54e02afe9d5a88571bd3b86b820f0"
-  integrity sha512-USadGPKt4ekcgDIxQB5SWspnTAlEf9nN9Alt+NzX3YqxnHlqDRQoa1ckACu01JpwsyEfltxYXbUsbaXBWTQVkA==
+ngx-prx-styleguide@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/ngx-prx-styleguide/-/ngx-prx-styleguide-2.3.1.tgz#e407d3f6ec6693670648b105a4efb3729fc638d1"
+  integrity sha512-urgMEOYmxYyqD89Buw0ybXaCfU+h/FFI8o7Drb8jubT3LMHnsLDmiQLFrdE7fDm/wYxL9Cb1IgVmbwv7jXm8Lw==
   dependencies:
     "@ng-select/ng-select" "^2.15.3"
     c3 "^0.4.11"
+    ngx-tooltip "0.0.9"
     pikaday "^1.5.1"
     tslib "^1.9.0"
+
+ngx-tooltip@0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/ngx-tooltip/-/ngx-tooltip-0.0.9.tgz#9821693e7d91c57dae8189c5d6a810526890b6f6"
+  integrity sha1-mCFpPn2RxX2ugYnF1qgQUmiQtvY=
 
 nice-try@^1.0.4:
   version "1.0.5"


### PR DESCRIPTION
Rather than moving to a single select, which changes the underlying datatype to a `number` rather than an `number[]`, I've limited max selection to one. Since we're still planning to re-enable multiple templates in the future, it doesn't make sense to change the underlying Angular model.