### PR TITLE
Episode type can't be blank

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "langmap": "0.0.14",
     "moment": "^2.18.1",
     "ng2-dragula": "^1.3.1",
-    "ngx-prx-styleguide": "2.3.1",
+    "ngx-prx-styleguide": "2.3.3",
     "prosemirror-commands": "0.18.0",
     "prosemirror-inputrules": "0.18.0",
     "prosemirror-keymap": "0.18.0",

--- a/src/app/story/directives/podcast.component.html
+++ b/src/app/story/directives/podcast.component.html
@@ -23,7 +23,7 @@
     </div>
   </prx-fancy-field>
 
-  <prx-fancy-field label="Episode Type" [model]="episode" [select]="episodeTypeOptions" name="itunesType">
+  <prx-fancy-field label="Episode Type" [model]="episode" [select]="episodeTypeOptions" name="itunesType" required>
     <div class="fancy-hint">Select the type of episode: <strong>full</strong> (default and most common); <strong>trailer</strong> (a short, promotional piece of content that represents a preview of a show); or <strong>bonus</strong> (extra content like behind-the-scenes information or interviews).</div>
   </prx-fancy-field>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4931,10 +4931,10 @@ ng2-dragula@^1.3.1:
   dependencies:
     dragula "^3.7.2"
 
-ngx-prx-styleguide@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/ngx-prx-styleguide/-/ngx-prx-styleguide-2.3.1.tgz#e407d3f6ec6693670648b105a4efb3729fc638d1"
-  integrity sha512-urgMEOYmxYyqD89Buw0ybXaCfU+h/FFI8o7Drb8jubT3LMHnsLDmiQLFrdE7fDm/wYxL9Cb1IgVmbwv7jXm8Lw==
+ngx-prx-styleguide@2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/ngx-prx-styleguide/-/ngx-prx-styleguide-2.3.3.tgz#310f257877855c69beea742e3c804641571a9457"
+  integrity sha512-caUsd9cARfWTDPd9kx/F+wZxUeC/ytZryO04OFsxtZo2GCHZPPdDGUtaTge7zVGvaK+3u8xknNucIArNLZrF9Q==
   dependencies:
     "@ng-select/ng-select" "^2.15.3"
     c3 "^0.4.11"


### PR DESCRIPTION
Marks `itunesType` as required and pulls in styleguide change which disables clearing selects when a field is marked as required.