### PR TITLE
Episode mp3 link

### DIFF
--- a/src/app/story/directives/player.component.css
+++ b/src/app/story/directives/player.component.css
@@ -13,8 +13,9 @@ input {
   margin-bottom: 4px;
 }
 button, .button {
-  padding-top: 9px;
-  padding-bottom: 8px;
+  padding-top: 10px;
+  padding-bottom: 9px;
+  vertical-align: top;
 }
 button {
   background-color: #ff9600;

--- a/src/app/story/directives/player.component.html
+++ b/src/app/story/directives/player.component.html
@@ -13,7 +13,7 @@
       <p *ngIf="previewingUnpublished" class="error">
         <b>WARNING:</b> It looks like your episode is not yet published, or very recently
         published. The player below is only a preview of how it will appear after
-        your feed is updated with the new episode. Your copyable link/iframe will begin
+        your feed is updated with the new episode. Your copyable iframe/links will begin
         to function as expected within a few minutes of publishing.
       </p>
 
@@ -26,6 +26,11 @@
       <p class="embed-iframe">An embeddable iframe</p>
       <input type="text" readonly [ngModel]="copyIframe" #iframeInput/>
       <button [publishCopyInput]="iframeInput">Copy</button>
+      <ng-container *ngIf="shouldUseFeeder">
+        <p>Direct link to your episode mp3</p>
+        <input type="text" readonly [ngModel]="enclosureUrl" #enclosureInput/>
+        <button [publishCopyInput]="enclosureInput">Copy</button>
+      </ng-container>
     </div>
 
   </prx-fancy-field>

--- a/src/app/story/directives/player.component.spec.ts
+++ b/src/app/story/directives/player.component.spec.ts
@@ -117,4 +117,22 @@ describe('PlayerComponent', () => {
     expect(comp.copyIframe.search(/height="200"/)).not.toEqual(-1);
   });
 
+  cit('shows the episode mp3 url for podcast distributions', (fix, el, comp) => {
+    const dists = series.mockItems('prx:distributions', [{kind: 'podcast', url: 'http://some-where'}]);
+    dists[0].mock('http://some-where', {publishedUrl: 'http://published-url'});
+
+    const storyDists = story.mockItems('prx:distributions', [{kind: 'episode', url: 'http://some-where/episode'}]);
+    storyDists[0].mock('http://some-where/episode', {guid: 'episode1',
+      _links: {enclosure: {href: 'http://prefix/some-where/enclosure.mp3'}}});
+
+    tabModel.next(new StoryModel(series, story));
+    fix.detectChanges();
+    expect(el).toContainText('Direct link to your episode');
+
+    series.mockItems('prx:distributions', []);
+    tabModel.next(new StoryModel(series, story));
+    fix.detectChanges();
+    expect(el).not.toContainText('Direct link to your episode');
+  });
+
 });


### PR DESCRIPTION
For #610.  Adds a copyable link to the dovetail mp3.

- Field only shows up for stories with a "podcast distribution"
- Will be blank until you upload at least 1 audio file
- Dovetail returns a 404 until you actually publish the story

![image](https://user-images.githubusercontent.com/1410587/55363403-2c832600-549a-11e9-9480-f4fa4fbfdad9.png)
