### PR TITLE
improves performance by eliminating feeder requests for ids

### DIFF
--- a/src/app/dashboard/dashboard-series.component.ts
+++ b/src/app/dashboard/dashboard-series.component.ts
@@ -1,5 +1,5 @@
 
-import { filter, mergeMap, map } from 'rxjs/operators';
+import { mergeMap, map } from 'rxjs/operators';
 
 import { Component, Input, OnInit } from '@angular/core';
 
@@ -114,19 +114,6 @@ export class DashboardSeriesComponent implements OnInit {
       }),
       mergeMap((stories: StoryModel[]) => {
         return stories.map(story => story.loadRelated('distributions'))
-      }),
-      map(() => {
-        const distributions = this.stories.filter((story, i) => {
-          const episodeDistribution = story.distributions.find(d => d.kind === 'episode');
-          if (!episodeDistribution) {
-            this.episodeLoaders[i] = false;
-          }
-          return episodeDistribution;
-        });
-        return distributions;
-      }),
-      mergeMap((stories: StoryModel[]) => {
-        return stories.map(story => story.distributions.find(d => d.kind === 'episode').loadRelated('episode'))
       })
     ).subscribe(() => {
       this.episodeLoaders.fill(false);
@@ -134,18 +121,8 @@ export class DashboardSeriesComponent implements OnInit {
   }
 
   loadSeriesDistribution() {
-    let podcastDistribution;
     this.podcastLoader = true;
-    this.series.loadRelated('distributions').pipe(
-      filter(() => {
-        podcastDistribution = this.series.distributions.find(d => d.kind === 'podcast');
-        if (!podcastDistribution) {
-          this.podcastLoader = false;
-        }
-        return this.podcastLoader;
-      }),
-      mergeMap(() => podcastDistribution.loadRelated('podcast'))
-    ).subscribe(() => {
+    this.series.loadRelated('distributions').subscribe(() => {
       this.podcastLoader = false;
     });
   }

--- a/src/app/dashboard/dashboard-story.component.spec.ts
+++ b/src/app/dashboard/dashboard-story.component.spec.ts
@@ -1,6 +1,8 @@
 import { cit, create, stubPipe } from '../../testing';
 import { DashboardStoryComponent } from './dashboard-story.component';
 import { By } from '@angular/platform-browser';
+import { SeriesModel, StoryModel, DistributionModel, StoryDistributionModel } from 'app/shared';
+import { MockHalDoc } from 'ngx-prx-styleguide';
 
 
 describe('DashboardStoryComponent', () => {
@@ -33,15 +35,12 @@ describe('DashboardStoryComponent', () => {
 
   cit('has metrics link for published stories', (fix, el, comp) => {
     comp.status = 'published';
-    comp.series = {id: 1, distributions: [{kind: 'podcast', podcast: {id: 14}}]};
-    comp.story = {
-      isNew: false,
-      parent: {id: 1},
-      publishedAt: new Date(),
-      isPublished: () => true,
-      changed: () => true,
-      distributions: [{kind: 'episode', episode: {id: 'abcdefg'}}]
-    };
+    comp.series = new SeriesModel(null, new MockHalDoc({id: 1}));
+    comp.series.distributions = [new DistributionModel(comp.series.doc,
+      new MockHalDoc({kind: 'podcast', url: 'anywhere.com/that/ends/with/14'}))];
+    comp.story = new StoryModel(comp.series.doc, new MockHalDoc({id: '1234', publishedAt: new Date()}));
+    comp.story.distributions = [new StoryDistributionModel(comp.series.doc, comp.story.doc,
+      new MockHalDoc({kind: 'episode', url: 'anywhere.com/that/ends/with/abcdefg'}))]
     fix.detectChanges();
     const statusText = el.query(By.css('.status.text.published')).nativeElement;
     expect(statusText.innerText.toLowerCase()).toEqual('published');

--- a/src/app/dashboard/dashboard-story.component.ts
+++ b/src/app/dashboard/dashboard-story.component.ts
@@ -89,9 +89,9 @@ export class DashboardStoryComponent implements OnInit {
         && this.series && this.series.distributions) {
       const seriesDistribution = this.series.distributions.find(d => d.kind === 'podcast')
       const storyDistribution = this.story.distributions.find(d => d.kind === 'episode');
-      if (seriesDistribution && seriesDistribution.podcast && storyDistribution && storyDistribution.episode) {
-        const podcastId = seriesDistribution.podcast.id;
-        const episodeGuid = encodeURIComponent(storyDistribution.episode.id);
+      const podcastId = seriesDistribution && seriesDistribution.feederPodcastId;
+      const episodeGuid = storyDistribution && encodeURIComponent(storyDistribution.feederEpisodeId);
+      if (podcastId && episodeGuid) {
         return `${Env.METRICS_HOST}/${podcastId}/reach/episodes/daily;episodePage=1;guids=${episodeGuid}${this.metricsUrlParams}`;
       }
     }

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { Observable, forkJoin } from 'rxjs';
-import { mergeMap, map } from 'rxjs/operators';
+import { mergeMap } from 'rxjs/operators';
 import { CmsService, HalDoc } from '../core';
 import { SeriesModel } from '../shared';
 
@@ -22,8 +21,6 @@ export class DashboardComponent implements OnInit {
   constructor(private cms: CmsService) {}
 
   ngOnInit() {
-    let seriesDocs: HalDoc[];
-
     this.cms.auth.pipe(
       mergeMap((auth: HalDoc) => {
         this.auth = auth;
@@ -33,18 +30,11 @@ export class DashboardComponent implements OnInit {
         this.defaultAccount = defaultAccount;
         return this.auth.followItems('prx:series', {filters: 'v4', zoom: 'prx:image'});
       }),
-      mergeMap((series: HalDoc[]) => {
-        seriesDocs = series;
-        this.totalCount = series.length ? series[0].total() : 0;
-        this.noSeries = (series.length < 1) ? true : null;
-        return series.map(s => s.follow('prx:account'));
-      }),
-      mergeMap((account: Observable<HalDoc>) => {
-        return account;
-      })
-    ).subscribe((account: HalDoc) => {
+    ).subscribe((series: HalDoc[]) => {
       this.isLoaded = true;
-      this.series = seriesDocs.map(s => new SeriesModel(account, s));
+      this.totalCount = series.length ? series[0].total() : 0;
+      this.noSeries = (series.length < 1) ? true : null;
+      this.series = series.map(s => new SeriesModel(null, s, false));
     });
   }
 

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -28,7 +28,7 @@ export class DashboardComponent implements OnInit {
       }),
       mergeMap((defaultAccount: HalDoc) => {
         this.defaultAccount = defaultAccount;
-        return this.auth.followItems('prx:series', {filters: 'v4', zoom: 'prx:image'});
+        return this.auth.followItems('prx:series', {filters: 'v4', zoom: 'prx:image,prx:distributions'});
       }),
     ).subscribe((series: HalDoc[]) => {
       this.isLoaded = true;

--- a/src/app/shared/model/distribution.model.spec.ts
+++ b/src/app/shared/model/distribution.model.spec.ts
@@ -82,4 +82,9 @@ describe('DistributionModel', () => {
     expect(dist.invalid()).toMatch(/must pick at least one/i);
   });
 
+  it('hacks the distribution url for podcast distributions to get at the podcast id', () => {
+    const dist = new DistributionModel(series, podDist);
+    expect(dist.feederPodcastId).toEqual('1234');
+  });
+
 });

--- a/src/app/shared/model/distribution.model.ts
+++ b/src/app/shared/model/distribution.model.ts
@@ -88,8 +88,7 @@ export class DistributionModel extends BaseModel {
 
   get feederPodcastId(): string {
     if (this.kind === 'podcast' && this.url) {
-      const parts = this.url.match(/\/(.[^\/]*)$/);
-      return parts && parts.length > 1 && parts[1];
+      return this.url.split('/').pop();
     }
   }
 

--- a/src/app/shared/model/distribution.model.ts
+++ b/src/app/shared/model/distribution.model.ts
@@ -86,6 +86,13 @@ export class DistributionModel extends BaseModel {
     return {podcast, versionTemplates};
   }
 
+  get feederPodcastId(): string {
+    if (this.kind === 'podcast' && this.url) {
+      const parts = this.url.match(/\/(.[^\/]*)$/);
+      return parts && parts.length > 1 && parts[1];
+    }
+  }
+
   decode() {
     this.id = this.doc['id'];
     this.kind = this.doc['kind'] || '';

--- a/src/app/shared/model/story-distribution.model.spec.ts
+++ b/src/app/shared/model/story-distribution.model.spec.ts
@@ -54,4 +54,9 @@ describe('StoryDistributionModel', () => {
     expect(dist.episode.guid).toEqual('some-guid');
   });
 
+  it('hacks the distribution url for podcast distributions to get at the podcast id', () => {
+    const dist = new StoryDistributionModel(series, story, episodeDist);
+    expect(dist.feederEpisodeId).toEqual('1234');
+  });
+
 });

--- a/src/app/shared/model/story-distribution.model.ts
+++ b/src/app/shared/model/story-distribution.model.ts
@@ -51,6 +51,13 @@ export class StoryDistributionModel extends BaseModel {
     return {episode: episode};
   }
 
+  get feederEpisodeId(): string {
+    if (this.kind === 'episode' && this.url) {
+      const parts = this.url.match(/\/(.[^\/]*)$/);
+      return parts && parts.length > 1 && parts[1];
+    }
+  }
+
   decode() {
     this.id = this.doc['id'];
     this.kind = this.doc['kind'] || '';

--- a/src/app/shared/model/story-distribution.model.ts
+++ b/src/app/shared/model/story-distribution.model.ts
@@ -53,8 +53,7 @@ export class StoryDistributionModel extends BaseModel {
 
   get feederEpisodeId(): string {
     if (this.kind === 'episode' && this.url) {
-      const parts = this.url.match(/\/(.[^\/]*)$/);
-      return parts && parts.length > 1 && parts[1];
+      return this.url.split('/').pop();
     }
   }
 


### PR DESCRIPTION
addresses #624 

I started to go the generic route with the guess id in the haldoc, but then I realized these actually weren't even hal links, they are url properties on a resource that we're treating like a link, and it was really looking like a static function in haldoc that didn't feel right, so I chose to go the specific route in the distribution models. Hopefully that's more of a guiding factor for future developers as well as guessing a link is not the recommended path (except in special cases I suppose.)