### PR TITLE
Fixes series owner discard

### DIFF
--- a/src/app/shared/model/feeder-episode.model.ts
+++ b/src/app/shared/model/feeder-episode.model.ts
@@ -24,7 +24,7 @@ export class FeederEpisodeModel extends BaseModel {
 
   VALIDATORS = {
     guid: [UNLESS_NEW(REQUIRED())],
-    episodeUrl: [REQUIRED(), URL('Not a valid URL')],
+    episodeUrl: [URL('Not a valid URL')],
     summary: [LENGTH(0, 4000)],
     itunesType: [IN(['full', 'trailer', 'bonus', '', null])]
   };

--- a/src/app/shared/model/series.model.spec.ts
+++ b/src/app/shared/model/series.model.spec.ts
@@ -36,6 +36,18 @@ describe('SeriesModel', () => {
     expect(data['set_account_uri']).not.toMatch(/series-account-id/);
   });
 
+  it('restores account id on discard', () => {
+    const series = makeSeries(false);
+    const originalAccountId = series.accountId;
+    series.set('accountId', 200);
+    series.discard();
+    expect(originalAccountId).not.toBeNull();
+    expect(series.accountId).toEqual(originalAccountId);
+    series.set('accountId', null);
+    series.discard();
+    expect(series.accountId).toEqual(originalAccountId);
+  });
+
   it('allows clearing version templates on new series', () => {
     let series = makeSeries(true);
     expect(series.versionTemplates.length).toEqual(1);

--- a/src/app/shared/model/series.model.ts
+++ b/src/app/shared/model/series.model.ts
@@ -120,6 +120,9 @@ export class SeriesModel extends BaseModel implements HasUpload {
   }
 
   discard(): any {
+    if (this.changed('accountId')) {
+      this.set('accountId', this.original['accountId']);
+    }
     super.discard();
     if (this.isNew) {
       this.defaultVersionTemplate();

--- a/src/app/story/directives/podcast.component.html
+++ b/src/app/story/directives/podcast.component.html
@@ -47,7 +47,7 @@
     </div>
   </prx-fancy-field>
 
-  <prx-fancy-field label="Episode URL" textinput [model]="episode" name="episodeUrl" required>
+  <prx-fancy-field label="Episode URL" textinput [model]="episode" name="episodeUrl">
     <div class="fancy-hint">
       If you have a public URL for this podcast episode, enter it here.
     </div>


### PR DESCRIPTION
#598 Fixes series owner/accountId discard bug. The series owner field was not getting restored on discard because it's a sort of pseudo field that actually comes from the parent account.

#436 Also removes feeder episode url from required fields