### PR TITLE
Show extraneous audio files

### DIFF
--- a/src/app/shared/model/audio-version.model.spec.ts
+++ b/src/app/shared/model/audio-version.model.spec.ts
@@ -116,6 +116,23 @@ describe('AudioVersionModel', () => {
       expect(version.filesAndTemplates[3].tpl).toBeNull();
     });
 
+    it('includes duplicate positions when assigning templates to files', () => {
+      templateMock.mockItems('prx:audio-file-templates', [{position: 1, label: 'at1'}, {position: 2, label: 'at2'}]);
+      let files = [{position: 1, label: 'f1'}, {position: 1, label: 'f2'}, {position: 2, label: 'f3'}];
+      let version = makeVersion({}, files);
+      expect(version.filesAndTemplates.length).toEqual(3);
+
+      // files assigned a template will have their label overwritten
+      expect(version.filesAndTemplates[0].file.label).toEqual('at1');
+      expect(version.filesAndTemplates[0].tpl).not.toBeNull();
+      expect(version.filesAndTemplates[1].file.label).toEqual('at2');
+      expect(version.filesAndTemplates[1].tpl).not.toBeNull();
+
+      // oldest file (1st in the files[]) doesn't get a template
+      expect(version.filesAndTemplates[2].file.label).toEqual('f1');
+      expect(version.filesAndTemplates[2].tpl).toBeNull();
+    });
+
   });
 
   describe('encode', () => {

--- a/src/app/shared/model/audio-version.model.ts
+++ b/src/app/shared/model/audio-version.model.ts
@@ -227,9 +227,12 @@ export class AudioVersionModel extends BaseModel implements HasUpload {
       for (let t of this.fileTemplates) {
         this.filesAndTemplates.push({file: null, tpl: t});
       }
-      for (let f of this.files.filter(file => !file.isDestroy)) {
+
+      // fill templates in reverse order - newest files first
+      let files = this.files.filter(file => !file.isDestroy).reverse();
+      for (let f of files) {
         let ft = this.filesAndTemplates.find(ftmp => ftmp.tpl && ftmp.tpl['position'] === f.position);
-        if (ft) {
+        if (ft && !ft.file) {
           f.setTemplate(ft.tpl);
           ft.file = f;
         } else {


### PR DESCRIPTION
For #643.  

If you somehow get > 1 audio_file with the same `position`, we were hiding the old ones.  Which would result in an error you can't fix.

This displays the extraneous files, at the bottom of the list.  (Meaning the oldest audio files with a duplicated `position` get this "Segment not in template" error message. 

![image](https://user-images.githubusercontent.com/1410587/57811382-b710a380-772f-11e9-9f54-5288c397f37f.png)

Note there's another slight bug in how CMS [detects missing segments](https://github.com/PRX/cms.prx.org/blob/master/app/models/audio_version.rb#L80), which causes that 2nd "You must upload 2 segments (got 3)" error.  It doesn't handle > 1 file in the same position.
