### PR TITLE
Update layout of Publish Feed URL input elements

### DIFF
--- a/src/app/series/directives/series-podcast.component.css
+++ b/src/app/series/directives/series-podcast.component.css
@@ -3,7 +3,7 @@
   width: 250px;
   margin-right: 40px;
 }
-.prx-feed-url input, .feed-url input {
+.prx-feed-url input {
   padding: 10px 8px;
   margin-bottom: 4px;
 }
@@ -13,16 +13,27 @@
 input.changed {
   outline: 5px auto #f09b4c;
 }
-.feed-url input {
-  min-width: 400px;
-}
-.feed-url button, .feed-url .button {
-  padding-top: 9px;
-  padding-bottom: 8px;
-}
 .feed-url button {
   background-color: #ff9600;
 }
 .feed-url button:hover, .feed-url button:focus {
   background-color: #ec8200;
+}
+.feed-url_checkbox {
+  text-indent: -1.35em;
+  padding-left: 1.35em;
+}
+.feed-url_checkbox > input {
+  margin-right: 0.35em;
+}
+.feed-url_input-group {
+  display: grid;
+  grid-template-columns: 1fr max-content max-content;
+  align-content: center;
+  margin-top: 0.5rem;
+  line-height: 2.5rem;
+}
+.feed-url_input-group > * {
+  line-height: inherit;
+  padding: 0 0.75rem;
 }

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -129,15 +129,17 @@
       <div class="fancy-hint">
         The public URL for your podcast feed. Feel free to share this URL with listeners. If you need to alter this URL once you have subscribers, set the <a target="_blank" rel="noopener" [href]="this.itunesNewFeedURLDoc">New Feed URL</a> as well.
       </div>
-      <p>
+      <div class="feed-url_checkbox">
         <input type="checkbox" (change)="setNewFeedToPublicFeed($event)" [checked]="podcast.publicFeedUrl === podcast.newFeedUrl" id="matchFeeds">
         <label for="matchFeeds">Check to set your podcast's New Feed URL to this URL as well.</label>
-      </p>
-      <input type="text" [ngModel]="podcast?.publicFeedUrl" name="publicFeedUrl" #pubFeed
-       [prxAdvancedConfirm]="publicFeedChangeConfirm" [prxModel]="podcast" prxName="publicFeedUrl" (ngModelChange)="podcast.set('publicFeedUrl', $event)"
-       [class.changed]="podcast.changed('publicFeedUrl', false)"/>
-      <button [publishCopyInput]="pubFeed">Copy</button>
-      <a class="button" target="_blank" rel="noopener" [href]="podcast?.publicFeedUrl">Open Link</a>
+      </div>
+      <div class="feed-url_input-group">
+        <input type="text" [ngModel]="podcast?.publicFeedUrl" name="publicFeedUrl" #pubFeed
+        [prxAdvancedConfirm]="publicFeedChangeConfirm" [prxModel]="podcast" prxName="publicFeedUrl" (ngModelChange)="podcast.set('publicFeedUrl', $event)"
+        [class.changed]="podcast.changed('publicFeedUrl', false)" />
+        <button [publishCopyInput]="pubFeed">Copy</button>
+        <a class="button" target="_blank" rel="noopener" [href]="podcast?.publicFeedUrl">Open Link</a>
+      </div>
     </prx-fancy-field>
 
     <prx-fancy-field *ngIf="!podcast?.hasPublicFeed" label="Public Feed Url" textinput [model]="podcast" name="publicFeedUrl">

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -125,7 +125,7 @@
       <input type="text" readonly [ngModel]="podcast?.publishedUrl" name="publishedUrl"/>
     </prx-fancy-field>
 
-    <prx-fancy-field *ngIf="podcast?.hasPublicFeed" label="Public Feed Url" class="feed-url">
+    <prx-fancy-field *ngIf="podcast?.hasPublicFeed" label="Public Feed URL" class="feed-url">
       <div class="fancy-hint">
         The public URL for your podcast feed. Feel free to share this URL with listeners. If you need to alter this URL once you have subscribers, set the <a target="_blank" rel="noopener" [href]="this.itunesNewFeedURLDoc">New Feed URL</a> as well.
       </div>
@@ -142,7 +142,7 @@
       </div>
     </prx-fancy-field>
 
-    <prx-fancy-field *ngIf="!podcast?.hasPublicFeed" label="Public Feed Url" textinput [model]="podcast" name="publicFeedUrl">
+    <prx-fancy-field *ngIf="!podcast?.hasPublicFeed" label="Public Feed URL" textinput [model]="podcast" name="publicFeedUrl">
       <div class="fancy-hint">
         If you already have a public URL for your podcast feed (e.g., feedburner), enter it here.
       </div>


### PR DESCRIPTION
Edit an Episode's Podcast Info. Ensure input elements and labels layout consistently in Chrome and Firefox. Wasn't able to test in Safari due to not being able to log into publish.prx.docker in Safari (weird?).