### PR TITLE
Add timepicker to series planner

### DIFF
--- a/src/app/series/directives/series-plan.component.html
+++ b/src/app/series/directives/series-plan.component.html
@@ -15,12 +15,10 @@
     publish once the state is changed to scheduled. This will prevent you from
     resetting the value on each individual episode.
   </p>
-  <div class="horizontal-checkboxes">
-    <prx-timepicker
-      [date]="planTime"
-      (timeChange)="onTimeChange($event)"
-    ></prx-timepicker>
-  </div>
+  <prx-timepicker
+    [date]="planTime"
+    (timeChange)="onTimeChange($event)"
+  ></prx-timepicker>
 </section>
 
 <section>

--- a/src/app/series/directives/series-plan.component.html
+++ b/src/app/series/directives/series-plan.component.html
@@ -9,6 +9,21 @@
 </header>
 
 <section>
+  <h2>What time of day do you plan to publish your episodes?</h2>
+  <p>
+    Select the time of day in which episodes would automatically be set to
+    publish once the state is changed to scheduled. This will prevent you from
+    resetting the value on each individual episode.
+  </p>
+  <div class="horizontal-checkboxes">
+    <prx-timepicker
+      [date]="planTime"
+      (timeChange)="onTimeChange($event)"
+    ></prx-timepicker>
+  </div>
+</section>
+
+<section>
   <h2>Which day of the week do you plan to publish your episodes?</h2>
   <p>
     Publish will automatically create an episode draft for each day selected

--- a/src/app/series/directives/series-plan.component.spec.ts
+++ b/src/app/series/directives/series-plan.component.spec.ts
@@ -66,6 +66,19 @@ describe('SeriesPlanComponent', () => {
     expect(comp.generateMax).not.toEqual(null);
   });
 
+  cit('creates episodes with a different time', (_fix, _el, comp) => {
+    const [planHours, planMinutes] = [10, 30];
+    comp.series = series;
+    comp.templateLink = '/some/link';
+    comp.planned = [new SimpleDate('2019-02-01')];
+    comp.planTime = new Date(2019, 1, 1, planHours, planMinutes);
+
+    comp.createEpisodes().subscribe(d => {
+      expect(d[0].releasedAt.getHours()).toEqual(planHours);
+      expect(d[0].releasedAt.getMinutes()).toEqual(planMinutes);
+    });
+  });
+
   cit('plans episodes with a max number', (_fix, _el, comp) => {
     comp.generateStartingAt = new Date(2019, 1, 1);
     comp.days[2] = true;

--- a/src/app/series/directives/series-plan.component.ts
+++ b/src/app/series/directives/series-plan.component.ts
@@ -24,6 +24,7 @@ export class SeriesPlanComponent implements OnDestroy {
 
   planMinDate: SimpleDate;
   planDefaultDate: SimpleDate;
+  planTime: Date;
   planned: SimpleDate[] = [];
 
   objectKeys = Object.keys;
@@ -47,11 +48,18 @@ export class SeriesPlanComponent implements OnDestroy {
     this.tabSub = tab.model.subscribe((s: SeriesModel) => this.setSeries(s));
     this.planMinDate = new SimpleDate(this.tomorrow, true);
     this.planDefaultDate = this.planMinDate;
+    this.planTime = new Date(
+      this.planDefaultDate.toLocaleDate().setHours(12)
+    );
     this.generateStartingAt = this.planMinDate.toLocaleDate();
   }
 
   ngOnDestroy() {
     this.tabSub.unsubscribe();
+  }
+
+  onTimeChange($event) {
+    this.planTime = $event;
   }
 
   setSeries(s: SeriesModel) {
@@ -145,7 +153,7 @@ export class SeriesPlanComponent implements OnDestroy {
   }
 
   private createStory(date: SimpleDate): Observable<HalDoc[]> {
-    const releasedAt = date.toLocaleDate(12);
+    const releasedAt = date.toLocaleDate(this.planTime.getHours(), this.planTime.getMinutes());
     const title = releasedAt.toLocaleDateString('en-US', {year: 'numeric', month: 'long', day: 'numeric'});
     return this.series.create('prx:stories', {}, {title, releasedAt})
       .pipe(mergeMap(story => this.createVersion(story)));


### PR DESCRIPTION
Allows users to set the publish time for planned episodes.