### PR TITLE
Remove broken link

### DIFF
--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -40,9 +40,7 @@
         In accordance with
         <a [href]="itunesRequirementsDoc"
            title="Requirements - Podcasts Connect Help">the requirements for iTunes podcast content</a>,
-        do any of your podcast episodes contain
-        <a [href]="itunesExplicitDoc"
-           title="About iTunes Store Parental Advisories - Apple Support">explicit material?</a>
+        do any of your podcast episodes contain explicit material?
       </div>
     </prx-fancy-field>
 

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -16,7 +16,6 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
   subCategories: string[] = [];
   explicitOpts = ['Explicit', 'Clean'];
   itunesRequirementsDoc = 'https://help.apple.com/itc/podcasts_connect/#/itc1723472cb';
-  itunesExplicitDoc = 'https://support.apple.com/en-us/HT202005';
   itunesCategoryDoc = 'https://help.apple.com/itc/podcasts_connect/#/itc9267a2f12';
   itunesNewFeedURLDoc = 'https://help.apple.com/itc/podcasts_connect/#/itca489031e0';
   podcastTypeOptions = [['Episodic', false], ['Serial', true]];

--- a/src/app/story/directives/podcast.component.html
+++ b/src/app/story/directives/podcast.component.html
@@ -5,9 +5,7 @@
       In accordance with
       <a [href]="itunesRequirementsDoc"
          title="Requirements - Podcasts Connect Help">the requirements for iTunes podcast content</a>,
-      does any of your podcast audio contain
-      <a [href]="itunesExplicitDoc"
-         title="About iTunes Store Parental Advisories - Apple Support">explicit material?</a>
+      does any of your podcast audio contain explicit material?
       <ng-container *ngIf="podcastExplicit">
         Setting this field will override your <strong>{{podcastExplicit}}</strong> podcast global value.
       </ng-container>

--- a/src/app/story/directives/podcast.component.ts
+++ b/src/app/story/directives/podcast.component.ts
@@ -22,7 +22,6 @@ export class PodcastComponent implements OnDestroy {
 
   explicitOpts = ['Explicit', 'Clean'];
   itunesRequirementsDoc = 'https://help.apple.com/itc/podcasts_connect/#/itc1723472cb';
-  itunesExplicitDoc = 'https://support.apple.com/en-us/HT202005';
   episodeTypeOptions = ['full', 'trailer', 'bonus'];
 
   tabSub: Subscription;


### PR DESCRIPTION
Removes a broken link from the Series and Piece podcast tabs:

![image](https://user-images.githubusercontent.com/1410587/70659753-f3e93e00-1c1d-11ea-85bb-4f431858f0e7.png)

[This page](https://web.archive.org/web/20190505212417/https://support.apple.com/en-us/HT202005) in the apple docs apparently disappeared recently.  And I can't find anything similar in the Apple docs, so may as well remove it.  There is _some_ info under the [Content Requirements here](https://help.apple.com/itc/podcasts_connect/#/itc1723472cb) - which is where the 1st link in that sentence goes to.

If users end up needing more guidance, we'll probably have to create our own support page for this.