### PR TITLE
Prevent publishing remote audio errors

### DIFF
--- a/src/app/story/directives/status-control.component.spec.ts
+++ b/src/app/story/directives/status-control.component.spec.ts
@@ -10,8 +10,11 @@ describe('StatusControlComponent', () => {
 
   provide(Router, RouterStub);
   provide(ModalService);
-  provide(ToastrService);
   provide(Angulartics2, {trackLocation: () => {}});
+
+  let toastSuccessMsg: string, toastErrorMsg: string;
+  beforeEach(() => toastSuccessMsg = toastErrorMsg = null);
+  provide(ToastrService, { success: (m: string) => toastSuccessMsg = m, error: (m: string) => toastErrorMsg = m });
 
   const expectDisabled = (el, text, shouldBeDisabled) => {
     let button = el.queryAll(By.css('prx-button')).find(btn => {
@@ -52,6 +55,15 @@ describe('StatusControlComponent', () => {
     comp.currentStatus = 'published';
     fix.detectChanges();
     expectDisabled(el, 'Save & Publish', true);
+  });
+
+  cit('strictly toggles to published (after audio processing)', (fix, el, comp) => {
+    comp.nextStatus = 'published';
+    mockStory({invalid: () => 'bad'}, comp, fix);
+    comp.togglePublish('should not be able to publish this');
+    expect(comp.story.publishedAt).toEqual(undefined);
+    expect(toastSuccessMsg).toEqual(null);
+    expect(toastErrorMsg).toEqual('Unable to publish - check validation errors');
   });
 
   cit('shows remote status messages', (fix, el, comp) => {

--- a/src/app/story/directives/status-control.component.ts
+++ b/src/app/story/directives/status-control.component.ts
@@ -282,6 +282,11 @@ export class StatusControlComponent implements DoCheck {
   }
 
   togglePublish(toast: string) {
+    // prevent publishing invalid (usually audio-files mismatching after processing)
+    if (this.story.invalid() && !this.story.publishedAt) {
+      return this.toastr.error(`Unable to publish - check validation errors`);
+    }
+
     this.isPublishing = true;
     this.story.setPublished(!this.story.publishedAt).subscribe(() => {
       this.angulartics2.eventTrack.next({ action: this.story.publishedAt ? 'publish' : 'unpublish',


### PR DESCRIPTION
For #704.  Turns out you could publish an episode with invalid audio (mismatching bitrates will do it ... but really any remote-detected audio error).

1) Create a new (or existing saved) episode.
2) Upload audio files _and_ set status dropdown to "Published" in a single step.  Click save.
3) Audio processes, completes and displays error message down in the "audio file uploader" box.
4) Publish POSTs to `/publish` the story, even though there were remote errors.
5) Feeder sees the `story.status` is invalid, but allows it through because of [this logic](https://github.com/PRX/feeder.prx.org/blob/master/app/jobs/story_update_job.rb#L17).  The bad audio could even end up in the public RSS feed!