### PR TITLE
Warn when adding audio templates to existing series

### DIFF
--- a/src/app/series/directives/series-templates.component.css
+++ b/src/app/series/directives/series-templates.component.css
@@ -5,7 +5,7 @@
   width: 100%;
 }
 .version header {
-  background-color: #B8B8B8;
+  background-color: #b8b8b8;
   padding: 16px 14px;
   position: relative;
 }
@@ -23,8 +23,8 @@
 }
 .version section {
   background: #fff;
-  border-bottom: 1px solid #DDD;
-  border-top: 1px solid #DDD;
+  border-bottom: 1px solid #ddd;
+  border-top: 1px solid #ddd;
   margin-top: -1px;
   margin-bottom: 30px;
   padding: 18px 22px 0;
@@ -55,6 +55,10 @@
 .add-segment {
   margin-top: 20px;
 }
-.add-version i, .add-segment i {
+.add-version {
+  margin-right: 10px;
+}
+.add-version i,
+.add-segment i {
   vertical-align: bottom;
 }

--- a/src/app/series/directives/series-templates.component.html
+++ b/src/app/series/directives/series-templates.component.html
@@ -1,19 +1,17 @@
 <form *ngIf="series">
   <prx-fancy-field label="Audio Templates">
     <div class="fancy-hint">
-      When you add episodes, you may want to have different versions of the audio (e.g., clean v. explicit).
-      This page lets you define templates for the versions each episode in this series should have, including
-      specific segment requirements (note: don't include ads here). Every episode using these templates will
-      be checked against them for validity.
+      When you add episodes, you may want to have different versions of the audio (e.g., clean v. explicit). This page lets you define
+      templates for the versions each episode in this series should have, including specific segment requirements (note: don't include ads
+      here). Every episode using these templates will be checked against them for validity.
     </div>
   </prx-fancy-field>
 
   <ng-container *ngFor="let v of series.versionTemplates">
     <div *ngIf="!v.isDestroy" class="version">
       <header>
-        <strong>{{v?.label}}</strong>
-        <button type="button" class="btn-icon icon-cancel grey-dove"
-          aria-label="Remove" (click)="confirmRemoveVersion(v)"></button>
+        <strong>{{ v?.label }}</strong>
+        <button type="button" class="btn-icon icon-cancel grey-dove" aria-label="Remove" (click)="confirmRemoveVersion(v)"></button>
       </header>
       <section>
         <prx-fancy-field required textinput [model]="v" name="label" label="Template Label">
@@ -22,35 +20,41 @@
 
         <prx-fancy-field *ngIf="v.isAudio" class="length" [model]="v" label="Total length" invalid="lengthAny">
           <div class="fancy-hint">
-            The minimum and maximum HH:MM:SS durations for all the audio files. Used to ensure that each
-            of your episodes is the desired approximate length, and to prevent uploading bad audio.
+            The minimum and maximum HH:MM:SS durations for all the audio files. Used to ensure that each of your episodes is the desired
+            approximate length, and to prevent uploading bad audio.
           </div>
-          <prx-fancy-duration [model]="v" name="lengthMinimum" label="Minimum"
-            [advancedConfirm]="lengthConfirm(v, v['lengthMinimum'] | duration, 'minimum')"></prx-fancy-duration>
-          <prx-fancy-duration [model]="v" name="lengthMaximum" label="Maximum"
-            [advancedConfirm]="lengthConfirm(v, v['lengthMaximum'] | duration, 'maximum')"></prx-fancy-duration>
+          <prx-fancy-duration
+            [model]="v"
+            name="lengthMinimum"
+            label="Minimum"
+            [advancedConfirm]="lengthConfirm(v, v['lengthMinimum'] | duration, 'minimum')"
+          ></prx-fancy-duration>
+          <prx-fancy-duration
+            [model]="v"
+            name="lengthMaximum"
+            label="Maximum"
+            [advancedConfirm]="lengthConfirm(v, v['lengthMaximum'] | duration, 'maximum')"
+          ></prx-fancy-duration>
         </prx-fancy-field>
 
         <prx-fancy-field *ngIf="v.isAudio" label="Segments">
           <div class="fancy-hint">
-            Describe the individual segment audio files required in this template. Give
-            them a label such as "Billboard" or "Part A", and an optional min/max length
-            to validate the specific file.
+            Describe the individual segment audio files required in this template. Give them a label such as "Billboard" or "Part A", and an
+            optional min/max length to validate the specific file.
           </div>
           <publish-file-template *ngFor="let t of v.fileTemplates" [file]="t" [version]="v"></publish-file-template>
-          <button tabindex=-1 class="add-segment" *ngIf="canAddFile(v)" type="button"
-            (click)="confirmAddFile($event, v)"><i class="icon-plus white" aria-hidden="true"></i> Add Segment</button>
+          <button tabindex="-1" class="add-segment" *ngIf="canAddFile(v)" type="button" (click)="confirmAddFile($event, v)">
+            <i class="icon-plus white" aria-hidden="true"></i> Add Segment
+          </button>
         </prx-fancy-field>
       </section>
     </div>
   </ng-container>
 
   <section>
-    <button class="add-version" (click)="addAudioVersion()">
+    <button class="add-version" (click)="confirmAddAudioVersion()">
       <i class="icon-plus white" aria-hidden="true"></i> Add audio template
     </button>
-    <button class="add-version" (click)="addVideoVersion()">
-      <i class="icon-plus white" aria-hidden="true"></i> Add video template
-    </button>
+    <button class="add-version" (click)="addVideoVersion()"><i class="icon-plus white" aria-hidden="true"></i> Add video template</button>
   </section>
 </form>

--- a/src/app/series/directives/series-templates.component.ts
+++ b/src/app/series/directives/series-templates.component.ts
@@ -37,15 +37,12 @@ export class SeriesTemplatesComponent implements OnDestroy {
 
   confirmAddAudioVersion() {
     if (this.hasStories()) {
-      this.modal.confirm(
-        '',
-        'WHATTT??? why would you do that??? do you just hate dovetail? [frowny face paloma here]',
-        (confirm: boolean) => {
-          if (confirm) {
-            this.addAudioVersion();
-          }
-        }
-      );
+      const msg = `
+        It looks like you’re trying to add a new audio template to your series.
+        Before you do that, please confirm the show structure for this audio template
+        with the support team at <a href="mailto:podcast-support@prx.org">podcast-support@prx.org</a>.
+      `;
+      this.modal.confirm(null, msg, (confirm: boolean) => confirm && this.addAudioVersion(), 'Add audio template');
     } else {
       this.addAudioVersion();
     }

--- a/src/app/series/directives/series-templates.component.ts
+++ b/src/app/series/directives/series-templates.component.ts
@@ -1,18 +1,14 @@
 import { Component, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { ModalService, TabService } from 'ngx-prx-styleguide';
-import {
-  SeriesModel
-} from '../../shared';
+import { SeriesModel } from '../../shared';
 import { AudioVersionTemplateModel, AudioFileTemplateModel } from 'ngx-prx-styleguide';
 
 @Component({
   styleUrls: ['series-templates.component.css'],
   templateUrl: 'series-templates.component.html'
 })
-
 export class SeriesTemplatesComponent implements OnDestroy {
-
   series: SeriesModel;
   tabSub: Subscription;
 
@@ -31,12 +27,28 @@ export class SeriesTemplatesComponent implements OnDestroy {
   }
 
   hasVersions(): boolean {
-    return !!this.series.versionTemplates.some(f => !f.isDestroy);
+    return !!this.series.versionTemplates.some((f) => !f.isDestroy);
   }
 
   hasDefaultVersion(): boolean {
     let t = this.series.versionTemplates[0];
     return t && t.isNew && !t.changed();
+  }
+
+  confirmAddAudioVersion() {
+    if (this.hasStories()) {
+      this.modal.confirm(
+        '',
+        'WHATTT??? why would you do that??? do you just hate dovetail? [frowny face paloma here]',
+        (confirm: boolean) => {
+          if (confirm) {
+            this.addAudioVersion();
+          }
+        }
+      );
+    } else {
+      this.addAudioVersion();
+    }
   }
 
   addAudioVersion(): AudioVersionTemplateModel {
@@ -87,7 +99,7 @@ export class SeriesTemplatesComponent implements OnDestroy {
   }
 
   canAddFile(version: AudioVersionTemplateModel): boolean {
-    return version.fileTemplates.filter(f => !f.isDestroy).length < 10;
+    return version.fileTemplates.filter((f) => !f.isDestroy).length < 10;
   }
 
   confirmAddFile(event: MouseEvent, version: AudioVersionTemplateModel) {
@@ -108,7 +120,7 @@ export class SeriesTemplatesComponent implements OnDestroy {
   }
 
   addFile(version: AudioVersionTemplateModel) {
-    let existing = version.fileTemplates.find(f => f.isDestroy);
+    let existing = version.fileTemplates.find((f) => f.isDestroy);
     if (existing) {
       existing.isDestroy = false;
     } else {
@@ -117,8 +129,10 @@ export class SeriesTemplatesComponent implements OnDestroy {
   }
 
   isLengthMoreStrict(version: AudioVersionTemplateModel) {
-    return (version.lengthMinimum > version.original['lengthMinimum'] ||
-    (version.lengthMaximum !== 0 && version.lengthMaximum < version.original['lengthMaximum']));
+    return (
+      version.lengthMinimum > version.original['lengthMinimum'] ||
+      (version.lengthMaximum !== 0 && version.lengthMaximum < version.original['lengthMaximum'])
+    );
   }
 
   lengthConfirm(version: AudioVersionTemplateModel, value: string, label: string): string {
@@ -127,5 +141,4 @@ export class SeriesTemplatesComponent implements OnDestroy {
         This change could invalidate your already published episodes.`;
     }
   }
-
 }


### PR DESCRIPTION
Adds a confirmation modal when you add a new audio template to a series with > 0 stories.

![image](https://user-images.githubusercontent.com/1410587/85612712-5af89e00-b616-11ea-98a3-d7c49c7f4211.png)
