### PR TITLE
Feeder episode limits

### DIFF
--- a/src/app/series/directives/series-podcast.component.css
+++ b/src/app/series/directives/series-podcast.component.css
@@ -2,6 +2,7 @@
   display: inline-block;
   width: 250px;
   margin-right: 40px;
+  vertical-align: top;
 }
 .prx-feed-url input {
   padding: 10px 8px;
@@ -16,7 +17,8 @@ input.changed {
 .feed-url button {
   background-color: #ff9600;
 }
-.feed-url button:hover, .feed-url button:focus {
+.feed-url button:hover,
+.feed-url button:focus {
   background-color: #ec8200;
 }
 .feed-url_checkbox {

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -1,13 +1,10 @@
 <form [ngSwitch]="state">
-
   <prx-fancy-field label="Series Podcast" *ngSwitchCase="'new'">
-    <div class="fancy-hint">The series itself must be created before a podcast distribution
-      can be created for it.</div>
+    <div class="fancy-hint">The series itself must be created before a podcast distribution can be created for it.</div>
   </prx-fancy-field>
 
   <prx-fancy-field label="Series Podcast" *ngSwitchCase="'missing'">
-    <div class="fancy-hint">This series must have audio templates before a podcast distribution
-      can be created for it.</div>
+    <div class="fancy-hint">This series must have audio templates before a podcast distribution can be created for it.</div>
   </prx-fancy-field>
 
   <prx-fancy-field label="Series Podcast" *ngSwitchCase="'creating'">
@@ -16,44 +13,56 @@
   </prx-fancy-field>
 
   <div *ngSwitchCase="'editing'">
-
-    <prx-fancy-field label="iTunes Categories" required=1>
-      <div class="fancy-hint">Select the
-        <a [href]="itunesCategoryDoc"
-           title="Podcasts Connect categories - Podcasts Connect Help">
-           iTunes category and subcategory, if applicable,
+    <prx-fancy-field label="iTunes Categories" required="1">
+      <div class="fancy-hint">
+        Select the
+        <a [href]="itunesCategoryDoc" title="Podcasts Connect categories - Podcasts Connect Help">
+          iTunes category and subcategory, if applicable,
         </a>
         that best describe this podcast.
       </div>
       <div class="span-fields">
-        <prx-fancy-field label="Category" [model]="podcast" name="category"
-          [select]="categories" (change)="setSubCategories()" small=1>
+        <prx-fancy-field label="Category" [model]="podcast" name="category" [select]="categories" (change)="setSubCategories()" small="1">
         </prx-fancy-field>
-        <prx-fancy-field *ngIf="subCategories.length" label="Sub-Category"
-          [model]="podcast" name="subCategory" [select]="subCategories" small=1>
+        <prx-fancy-field
+          *ngIf="subCategories.length"
+          label="Sub-Category"
+          [model]="podcast"
+          name="subCategory"
+          [select]="subCategories"
+          small="1"
+        >
         </prx-fancy-field>
       </div>
     </prx-fancy-field>
 
-    <prx-fancy-field label="Explicit" required=1 [model]="podcast" name="explicit" [select]="explicitOpts">
+    <prx-fancy-field label="Explicit" required="1" [model]="podcast" name="explicit" [select]="explicitOpts">
       <div class="fancy-hint">
         In accordance with
-        <a [href]="itunesRequirementsDoc"
-           title="Requirements - Podcasts Connect Help">the requirements for iTunes podcast content</a>,
-        do any of your podcast episodes contain explicit material?
+        <a [href]="itunesRequirementsDoc" title="Requirements - Podcasts Connect Help">the requirements for iTunes podcast content</a>, do
+        any of your podcast episodes contain explicit material?
       </div>
     </prx-fancy-field>
 
     <prx-fancy-field label="Podcast Type" [model]="podcast" name="serialOrder" [select]="podcastTypeOptions">
-      <div class="fancy-hint">Select how your episodes should be ordered: <strong>episodic</strong> (when you want your episodes to be presented and recommended last-to-first; this is the default and most common order for podcasts), or <strong>serial</strong> (when you want your episodes presented and recommended first-to-last).</div>
+      <div class="fancy-hint">
+        Select how your episodes should be ordered: <strong>episodic</strong> (when you want your episodes to be presented and recommended
+        last-to-first; this is the default and most common order for podcasts), or <strong>serial</strong> (when you want your episodes
+        presented and recommended first-to-last).
+      </div>
     </prx-fancy-field>
 
-    <prx-fancy-field required label="Podcast Audio" name="versionTemplateUrls"
-      [multiselect]="audioVersionOptions" [model]="distribution" [advancedConfirm]="versionTemplateConfirm">
+    <prx-fancy-field
+      required
+      label="Podcast Audio"
+      name="versionTemplateUrls"
+      [multiselect]="audioVersionOptions"
+      [model]="distribution"
+      [advancedConfirm]="versionTemplateConfirm"
+    >
       <div class="fancy-hint">
-        Select which template(s) should be used with your podcast. If an episode
-        of your podcast provides more than one of these, the first one in this
-        list will be used.
+        Select which template(s) should be used with your podcast. If an episode of your podcast provides more than one of these, the first
+        one in this list will be used.
       </div>
     </prx-fancy-field>
 
@@ -64,77 +73,98 @@
     <prx-fancy-field label="Owner Information">
       <div class="fancy-hint">Set the iTunes owner name and email for this podcast.</div>
       <div class="span-fields">
-        <prx-fancy-field label="Name" textinput [model]="podcast" name="ownerName" small=1>
-        </prx-fancy-field>
-        <prx-fancy-field label="Email" textinput [model]="podcast" name="ownerEmail" small=1>
-        </prx-fancy-field>
+        <prx-fancy-field label="Name" textinput [model]="podcast" name="ownerName" small="1"> </prx-fancy-field>
+        <prx-fancy-field label="Email" textinput [model]="podcast" name="ownerEmail" small="1"> </prx-fancy-field>
       </div>
     </prx-fancy-field>
 
     <prx-fancy-field label="Author Information">
       <div class="fancy-hint">Set the author name and email for this podcast.</div>
       <div class="span-fields">
-        <prx-fancy-field label="Name" textinput [model]="podcast" name="authorName" small=1>
-        </prx-fancy-field>
-        <prx-fancy-field label="Email" textinput [model]="podcast" name="authorEmail" small=1>
-        </prx-fancy-field>
+        <prx-fancy-field label="Name" textinput [model]="podcast" name="authorName" small="1"> </prx-fancy-field>
+        <prx-fancy-field label="Email" textinput [model]="podcast" name="authorEmail" small="1"> </prx-fancy-field>
       </div>
     </prx-fancy-field>
 
     <prx-fancy-field label="Managing Editor Information">
       <div class="fancy-hint">Set the managing editor name and email for this podcast.</div>
       <div class="span-fields">
-        <prx-fancy-field label="Name" textinput [model]="podcast" name="managingEditorName" small=1>
-        </prx-fancy-field>
-        <prx-fancy-field label="Email" textinput [model]="podcast" name="managingEditorEmail" small=1>
-        </prx-fancy-field>
+        <prx-fancy-field label="Name" textinput [model]="podcast" name="managingEditorName" small="1"> </prx-fancy-field>
+        <prx-fancy-field label="Email" textinput [model]="podcast" name="managingEditorEmail" small="1"> </prx-fancy-field>
       </div>
     </prx-fancy-field>
 
     <prx-fancy-field label="Summary" *ngIf="podcast && podcast.summary">
       <div class="fancy-hint">The iTunes summary for this podcast. You may create links, but other formatting is not supported.</div>
-      <publish-wysiwyg [model]="podcast" name="summary" [content]="podcast.summary"
-                       inputFormat="HTML" outputFormat="HTML" [changed]="podcast && podcast.changed('summary', false)"></publish-wysiwyg>
+      <publish-wysiwyg
+        [model]="podcast"
+        name="summary"
+        [content]="podcast.summary"
+        inputFormat="HTML"
+        outputFormat="HTML"
+        [changed]="podcast && podcast.changed('summary', false)"
+      ></publish-wysiwyg>
     </prx-fancy-field>
 
     <prx-fancy-field label="Summary" *ngIf="podcast && !podcast.summary">
       <div class="fancy-hint">
-        Unless otherwise specified, the summary is created from the description of your series as shown in the preview below.
-        The iTunes summary only allows for links, so all other formatting has been removed.
+        Unless otherwise specified, the summary is created from the description of your series as shown in the preview below. The iTunes
+        summary only allows for links, so all other formatting has been removed.
         <p>
-          <input type="checkbox" (click)="toggleAlternateSummary()" name="alternateSummary" id="alternateSummary">
+          <input type="checkbox" (click)="toggleAlternateSummary()" name="alternateSummary" id="alternateSummary" />
           <label for="alternateSummary">Enter an alternate summary</label>
         </p>
       </div>
-      <publish-wysiwyg #readonlyEditor [content]="series.description" [changed]="false" [editable]="false"
-                       inputFormat="MARKDOWN" outputFormat="HTML">
+      <publish-wysiwyg
+        #readonlyEditor
+        [content]="series.description"
+        [changed]="false"
+        [editable]="false"
+        inputFormat="MARKDOWN"
+        outputFormat="HTML"
+      >
       </publish-wysiwyg>
     </prx-fancy-field>
 
     <prx-fancy-field label="PRX Feed" class="prx-feed-url" *ngIf="!distribution.isNew">
       <div class="fancy-hint" *ngIf="podcast?.hasPublicFeed">
-        The private URL for your PRX podcast feed, providing the content for <a href="{{podcast.publicFeedUrl}}">your public feed</a>.
+        The private URL for your PRX podcast feed, providing the content for <a href="{{ podcast.publicFeedUrl }}">your public feed</a>.
       </div>
       <div class="fancy-hint" *ngIf="!podcast?.hasPublicFeed">
-        The URL for your PRX podcast feed. It's encouraged for podcasters to use a  public proxy like feedburner (potentially with a custom domain)
-        for sharing with listeners. If you already have a public URL for your podcast feed, enter it in the next field, or feel free to
+        The URL for your PRX podcast feed. It's encouraged for podcasters to use a public proxy like feedburner (potentially with a custom
+        domain) for sharing with listeners. If you already have a public URL for your podcast feed, enter it in the next field, or feel free
+        to
         <a href="https://support.google.com/feedburner/answer/78475?hl=en" title="Feedburner Help">create one.</a>
       </div>
-      <input type="text" readonly [ngModel]="podcast?.publishedUrl" name="publishedUrl"/>
+      <input type="text" readonly [ngModel]="podcast?.publishedUrl" name="publishedUrl" />
     </prx-fancy-field>
 
     <prx-fancy-field *ngIf="podcast?.hasPublicFeed" label="Public Feed URL" class="feed-url">
       <div class="fancy-hint">
-        The public URL for your podcast feed. Feel free to share this URL with listeners. If you need to alter this URL once you have subscribers, set the <a target="_blank" rel="noopener" [href]="this.itunesNewFeedURLDoc">New Feed URL</a> as well.
+        The public URL for your podcast feed. Feel free to share this URL with listeners. If you need to alter this URL once you have
+        subscribers, set the <a target="_blank" rel="noopener" [href]="this.itunesNewFeedURLDoc">New Feed URL</a> as well.
       </div>
       <div class="feed-url_checkbox">
-        <input type="checkbox" (change)="setNewFeedToPublicFeed($event)" [checked]="podcast.publicFeedUrl === podcast.newFeedUrl" id="matchFeeds">
+        <input
+          type="checkbox"
+          (change)="setNewFeedToPublicFeed($event)"
+          [checked]="podcast.publicFeedUrl === podcast.newFeedUrl"
+          id="matchFeeds"
+        />
         <label for="matchFeeds">Check to set your podcast's New Feed URL to this URL as well.</label>
       </div>
       <div class="feed-url_input-group">
-        <input type="text" [ngModel]="podcast?.publicFeedUrl" name="publicFeedUrl" #pubFeed
-        [prxAdvancedConfirm]="publicFeedChangeConfirm" [prxModel]="podcast" prxName="publicFeedUrl" (ngModelChange)="podcast.set('publicFeedUrl', $event)"
-        [class.changed]="podcast.changed('publicFeedUrl', false)" />
+        <input
+          type="text"
+          [ngModel]="podcast?.publicFeedUrl"
+          name="publicFeedUrl"
+          #pubFeed
+          [prxAdvancedConfirm]="publicFeedChangeConfirm"
+          [prxModel]="podcast"
+          prxName="publicFeedUrl"
+          (ngModelChange)="podcast.set('publicFeedUrl', $event)"
+          [class.changed]="podcast.changed('publicFeedUrl', false)"
+        />
         <button [publishCopyInput]="pubFeed">Copy</button>
         <a class="button" target="_blank" rel="noopener" [href]="podcast?.publicFeedUrl">Open Link</a>
       </div>
@@ -148,8 +178,8 @@
 
     <prx-fancy-field label="Enclosure Prefix Url" textinput [model]="podcast" name="enclosurePrefix">
       <div class="fancy-hint">
-        If you have an enclosure prefix URL to set a redirect on audio requests for your podcast
-        feed (e.g., podtrac or blubrry), enter it here.
+        If you have an enclosure prefix URL to set a redirect on audio requests for your podcast feed (e.g., podtrac or blubrry), enter it
+        here.
       </div>
     </prx-fancy-field>
 
@@ -166,18 +196,23 @@
     <publish-advanced-section>
       <prx-fancy-field label="New Feed Url" textinput [model]="podcast" name="newFeedUrl" [advancedConfirm]="newFeedUrlConfirm">
         <div class="fancy-hint">
-          If your podcast feed is moving, use this field to point to the new URL where your podcast is located.
-          The current feed should be maintained until all of your subscribers have migrated.
+          If your podcast feed is moving, use this field to point to the new URL where your podcast is located. The current feed should be
+          maintained until all of your subscribers have migrated.
         </div>
       </prx-fancy-field>
 
-      <prx-fancy-field label="Complete" checkbox [model]="podcast" name="complete" [advancedConfirm]="completeConfirm" prompt="The podcast is complete.">
+      <prx-fancy-field
+        label="Complete"
+        checkbox
+        [model]="podcast"
+        name="complete"
+        [advancedConfirm]="completeConfirm"
+        prompt="The podcast is complete."
+      >
         <div class="fancy-hint">
           Checking the box indicates that the podcast is complete and you will not post any more episodes in the future.
         </div>
       </prx-fancy-field>
     </publish-advanced-section>
-
   </div>
-
 </form>

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -126,6 +126,18 @@
       </publish-wysiwyg>
     </prx-fancy-field>
 
+    <prx-fancy-field label="Episode Limits">
+      <div class="fancy-hint">
+        You can optionally limit the number of episodes that will appear in your feed. Or reduce the amount of metadata included for your
+        oldest episodes to trim down your RSS file size. Leave blank to include all episodes and metadata.
+      </div>
+      <div class="span-fields">
+        <prx-fancy-field label="Limit Episodes" textinput [model]="podcast" name="displayEpisodesCount" small="1"> </prx-fancy-field>
+        <prx-fancy-field label="Limit Episode Metadata" textinput [model]="podcast" name="displayFullEpisodesCount" small="1">
+        </prx-fancy-field>
+      </div>
+    </prx-fancy-field>
+
     <prx-fancy-field label="PRX Feed" class="prx-feed-url" *ngIf="!distribution.isNew">
       <div class="fancy-hint" *ngIf="podcast?.hasPublicFeed">
         The private URL for your PRX podcast feed, providing the content for <a href="{{ podcast.publicFeedUrl }}">your public feed</a>.

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -126,15 +126,19 @@
       </publish-wysiwyg>
     </prx-fancy-field>
 
-    <prx-fancy-field label="Episode Limits">
+    <prx-fancy-field label="Feed Episode Limit" textinput [model]="podcast" name="displayEpisodesCount">
       <div class="fancy-hint">
-        You can optionally limit the number of episodes that will appear in your feed. Or reduce the amount of metadata included for your
-        oldest episodes to trim down your RSS file size. Leave blank to include all episodes and metadata.
+        You can optionally limit the number of episodes that will be publicly available in your feed. Your oldest episodes will disappear as
+        you publish newer ones. Leave this field blank to include all.
       </div>
-      <div class="span-fields">
-        <prx-fancy-field label="Limit Episodes" textinput [model]="podcast" name="displayEpisodesCount" small="1"> </prx-fancy-field>
-        <prx-fancy-field label="Limit Episode Metadata" textinput [model]="podcast" name="displayFullEpisodesCount" small="1">
-        </prx-fancy-field>
+    </prx-fancy-field>
+
+    <prx-fancy-field label="Feed Metadata Limit" textinput [model]="podcast" name="displayFullEpisodesCount">
+      <div class="fancy-hint">
+        You can optionally
+        <a target="_blank" rel="noopener" title="Limiting Episode Metadata" [href]="metadataLimitDoc">reduce the size of your RSS feed</a>
+        by trimming metadata from your oldest feed episodes. This many of your newest episodes will include <i>all</i> metadata, and older
+        episodes will omit certain RSS fields. Leave this field blank to include all metadata on every episode.
       </div>
     </prx-fancy-field>
 

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -126,22 +126,6 @@
       </publish-wysiwyg>
     </prx-fancy-field>
 
-    <prx-fancy-field label="Feed Episode Limit" textinput [model]="podcast" name="displayEpisodesCount">
-      <div class="fancy-hint">
-        You can optionally limit the number of episodes that will be publicly available in your feed. Your oldest episodes will disappear as
-        you publish newer ones. Leave this field blank to include all.
-      </div>
-    </prx-fancy-field>
-
-    <prx-fancy-field label="Feed Metadata Limit" textinput [model]="podcast" name="displayFullEpisodesCount">
-      <div class="fancy-hint">
-        You can optionally
-        <a target="_blank" rel="noopener" title="Limiting Episode Metadata" [href]="metadataLimitDoc">reduce the size of your RSS feed</a>
-        by trimming metadata from your oldest feed episodes. This many of your newest episodes will include <i>all</i> metadata, and older
-        episodes will omit certain RSS fields. Leave this field blank to include all metadata on every episode.
-      </div>
-    </prx-fancy-field>
-
     <prx-fancy-field label="PRX Feed" class="prx-feed-url" *ngIf="!distribution.isNew">
       <div class="fancy-hint" *ngIf="podcast?.hasPublicFeed">
         The private URL for your PRX podcast feed, providing the content for <a href="{{ podcast.publicFeedUrl }}">your public feed</a>.
@@ -210,6 +194,22 @@
     </prx-fancy-field>
 
     <publish-advanced-section>
+      <prx-fancy-field label="Feed Episode Limit" textinput [model]="podcast" name="displayEpisodesCount">
+        <div class="fancy-hint">
+          You can optionally limit the number of episodes that will be publicly available in your feed. Your oldest episodes will disappear
+          as you publish newer ones. Leave this field blank to include all.
+        </div>
+      </prx-fancy-field>
+
+      <prx-fancy-field label="Feed Metadata Limit" textinput [model]="podcast" name="displayFullEpisodesCount">
+        <div class="fancy-hint">
+          You can optionally
+          <a target="_blank" rel="noopener" title="Limiting Episode Metadata" [href]="metadataLimitDoc">reduce the size of your RSS feed</a>
+          by trimming metadata from your oldest feed episodes. This many of your newest episodes will include <i>all</i> metadata, and older
+          episodes will omit certain RSS fields. Leave this field blank to include all metadata on every episode.
+        </div>
+      </prx-fancy-field>
+
       <prx-fancy-field label="New Feed Url" textinput [model]="podcast" name="newFeedUrl" [advancedConfirm]="newFeedUrlConfirm">
         <div class="fancy-hint">
           If your podcast feed is moving, use this field to point to the new URL where your podcast is located. The current feed should be

--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -15,6 +15,7 @@ export class SeriesPodcastComponent implements OnDestroy, DoCheck {
   itunesRequirementsDoc = 'https://help.apple.com/itc/podcasts_connect/#/itc1723472cb';
   itunesCategoryDoc = 'https://help.apple.com/itc/podcasts_connect/#/itc9267a2f12';
   itunesNewFeedURLDoc = 'https://help.apple.com/itc/podcasts_connect/#/itca489031e0';
+  metadataLimitDoc = 'https://help.prx.org/hc/en-us/articles/360055869313-Limiting-Episode-Metadata';
   podcastTypeOptions = [
     ['Episodic', false],
     ['Serial', true]

--- a/src/app/shared/model/feeder-podcast.model.spec.ts
+++ b/src/app/shared/model/feeder-podcast.model.spec.ts
@@ -90,4 +90,26 @@ describe('FeederPodcastModel', () => {
     const podcast = new FeederPodcastModel(series, dist, doc);
     expect(podcast.language).toEqual('en-us');
   });
+
+  it('treats feeder episode limits as strings', () => {
+    const doc = dist.mock('some-feeder', { displayEpisodesCount: 123, displayFullEpisodesCount: 456 });
+    const podcast = new FeederPodcastModel(series, dist, doc);
+    expect(podcast.displayEpisodesCount).toEqual('123');
+    expect(podcast.displayFullEpisodesCount).toEqual('456');
+    expect(podcast.encode()['displayEpisodesCount']).toEqual(123);
+    expect(podcast.encode()['displayFullEpisodesCount']).toEqual(456);
+  });
+
+  it('validates feeder episode limits', () => {
+    const podcast = new FeederPodcastModel(series, dist);
+    podcast.set('displayEpisodesCount', '-1');
+    podcast.set('displayFullEpisodesCount', 'abc');
+    expect(podcast.invalid('displayEpisodesCount')).toMatch(/enter a positive number/i);
+    expect(podcast.invalid('displayFullEpisodesCount')).toMatch(/enter a positive number/i);
+
+    podcast.set('displayEpisodesCount', '');
+    podcast.set('displayFullEpisodesCount', '1');
+    expect(podcast.invalid('displayEpisodesCount')).toBeFalsy();
+    expect(podcast.invalid('displayFullEpisodesCount')).toBeFalsy();
+  });
 });

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -1,7 +1,13 @@
 import { throwError as observableThrowError, Observable } from 'rxjs';
-
 import { HalDoc } from '../../core';
-import { BaseModel, REQUIRED, URL, LENGTH } from 'ngx-prx-styleguide';
+import { BaseModel, BaseInvalid, REQUIRED, URL, LENGTH } from 'ngx-prx-styleguide';
+
+const POSITIVE_INT_OR_BLANK: BaseInvalid = (_key: string, value: any): string => {
+  if (value && !value.match(/^[1-9][0-9]*$/)) {
+    return 'Enter a positive number';
+  }
+  return null;
+};
 
 export class FeederPodcastModel extends BaseModel {
   // read-only
@@ -57,7 +63,9 @@ export class FeederPodcastModel extends BaseModel {
     newFeedUrl: [URL('Not a valid URL')],
     publicFeedUrl: [URL('Not a valid URL')],
     enclosurePrefix: [URL('Not a valid URL')],
-    summary: [LENGTH(0, 4000)]
+    summary: [LENGTH(0, 4000)],
+    displayEpisodesCount: [POSITIVE_INT_OR_BLANK],
+    displayFullEpisodesCount: [POSITIVE_INT_OR_BLANK]
   };
 
   constructor(private series: HalDoc, distrib: HalDoc, podcast?: HalDoc, loadRelated = true) {
@@ -129,8 +137,8 @@ export class FeederPodcastModel extends BaseModel {
     }
     this.summary = this.doc['summary'];
     this.serialOrder = this.doc['serialOrder'] || false;
-    this.displayEpisodesCount = this.doc['displayEpisodesCount'] || '';
-    this.displayFullEpisodesCount = this.doc['displayFullEpisodesCount'] || '';
+    this.displayEpisodesCount = this.doc['displayEpisodesCount'] ? this.doc['displayEpisodesCount'].toString() : '';
+    this.displayFullEpisodesCount = this.doc['displayFullEpisodesCount'] ? this.doc['displayFullEpisodesCount'].toString() : '';
   }
 
   encode(): {} {
@@ -170,8 +178,8 @@ export class FeederPodcastModel extends BaseModel {
 
     data.summary = this.summary || null;
     data.serialOrder = this.serialOrder || null;
-    data.displayEpisodesCount = this.displayEpisodesCount || null;
-    data.displayFullEpisodesCount = this.displayFullEpisodesCount || null;
+    data.displayEpisodesCount = parseInt(this.displayEpisodesCount, 10) || null;
+    data.displayFullEpisodesCount = parseInt(this.displayFullEpisodesCount, 10) || null;
 
     return data;
   }

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -1,20 +1,36 @@
-
-import {throwError as observableThrowError,  Observable } from 'rxjs';
+import { throwError as observableThrowError, Observable } from 'rxjs';
 
 import { HalDoc } from '../../core';
 import { BaseModel, REQUIRED, URL, LENGTH } from 'ngx-prx-styleguide';
 
 export class FeederPodcastModel extends BaseModel {
-
   // read-only
   id: number;
   publishedUrl: string;
 
   // writeable
-  SETABLE = ['category', 'subCategory', 'explicit', 'link', 'newFeedUrl', 'publicFeedUrl',
-             'enclosurePrefix', 'copyright', 'complete', 'language', 'summary', 'authorName',
-             'authorEmail', 'ownerName', 'ownerEmail', 'managingEditorName',
-             'managingEditorEmail', 'serialOrder'];
+  SETABLE = [
+    'category',
+    'subCategory',
+    'explicit',
+    'link',
+    'newFeedUrl',
+    'publicFeedUrl',
+    'enclosurePrefix',
+    'copyright',
+    'complete',
+    'language',
+    'summary',
+    'authorName',
+    'authorEmail',
+    'ownerName',
+    'ownerEmail',
+    'managingEditorName',
+    'managingEditorEmail',
+    'serialOrder',
+    'displayEpisodesCount',
+    'displayFullEpisodesCount'
+  ];
   URLS = ['link', 'newFeedUrl', 'publicFeedUrl', 'enclosurePrefix'];
   category = '';
   subCategory = '';
@@ -31,6 +47,8 @@ export class FeederPodcastModel extends BaseModel {
   summary = '';
   hasPublicFeed = false;
   serialOrder = false;
+  displayEpisodesCount = '';
+  displayFullEpisodesCount = '';
 
   VALIDATORS = {
     category: [REQUIRED()],
@@ -111,10 +129,12 @@ export class FeederPodcastModel extends BaseModel {
     }
     this.summary = this.doc['summary'];
     this.serialOrder = this.doc['serialOrder'] || false;
+    this.displayEpisodesCount = this.doc['displayEpisodesCount'] || '';
+    this.displayFullEpisodesCount = this.doc['displayFullEpisodesCount'] || '';
   }
 
   encode(): {} {
-    let data = <any> {};
+    let data = <any>{};
 
     // unset with nulls instead of blank strings
     data.complete = this.complete;
@@ -135,7 +155,7 @@ export class FeederPodcastModel extends BaseModel {
     // we can always send a categories array
     data.itunesCategories = [];
     if (this.category) {
-      data.itunesCategories = [{name: this.category, subcategories: []}];
+      data.itunesCategories = [{ name: this.category, subcategories: [] }];
       if (this.subCategory) {
         data.itunesCategories[0].subcategories.push(this.subCategory);
       }
@@ -150,6 +170,8 @@ export class FeederPodcastModel extends BaseModel {
 
     data.summary = this.summary || null;
     data.serialOrder = this.serialOrder || null;
+    data.displayEpisodesCount = this.displayEpisodesCount || null;
+    data.displayFullEpisodesCount = this.displayFullEpisodesCount || null;
 
     return data;
   }


### PR DESCRIPTION
Closes #724.

Adds feeder episode limits to the Publish; on the Series -> Podcast info tab.  A bit down the form.

I opted to use plain text fields here, so you can easily clear them out.  And we validate whatever you enter is an integer > 0 or blank.

![image](https://user-images.githubusercontent.com/1410587/94062361-cda72000-fda3-11ea-8b19-4d15740338bd.png)

