### PR TITLE
Prevent accidental unpublish

### DIFF
--- a/src/app/story/directives/status-control.component.spec.ts
+++ b/src/app/story/directives/status-control.component.spec.ts
@@ -58,22 +58,22 @@ describe('StatusControlComponent', () => {
     expectDisabled(el, 'Save & Publish', true);
   });
 
-  cit('strictly toggles to published (after audio processing)', (fix, el, comp) => {
+  cit('strictly sets to published (after audio processing)', (fix, el, comp) => {
     comp.nextStatus = 'published';
     mockStory({ publishedAt: null, invalid: () => 'bad', setPublished: () => null }, comp, fix);
     spyOn(comp.story, 'setPublished').and.returnValue(new Subject());
 
-    comp.togglePublish('should not be able to publish this');
+    comp.setPublished('should not be able to publish this');
     expect(comp.story.setPublished).not.toHaveBeenCalled();
     expect(toastErrorMsg).toEqual('Unable to publish - check validation errors');
   });
 
-  cit('unstrictly toggles to unpublished (after audio processing)', (fix, el, comp) => {
+  cit('unstrictly sets to unpublished (after audio processing)', (fix, el, comp) => {
     comp.nextStatus = 'unpublished';
     mockStory({ publishedAt: new Date(), invalid: () => 'bad', setPublished: () => null }, comp, fix);
     spyOn(comp.story, 'setPublished').and.returnValue(new Subject());
 
-    comp.togglePublish('should be able to unpublish this');
+    comp.setUnpublished('should be able to unpublish this');
     expect(comp.story.setPublished).toHaveBeenCalledWith(false);
     expect(toastErrorMsg).toEqual(null);
   });

--- a/src/app/story/directives/status-control.component.spec.ts
+++ b/src/app/story/directives/status-control.component.spec.ts
@@ -11,14 +11,14 @@ describe('StatusControlComponent', () => {
 
   provide(Router, RouterStub);
   provide(ModalService);
-  provide(Angulartics2, {trackLocation: () => {}, eventTrack: new Subject<any>()});
+  provide(Angulartics2, { trackLocation: () => {}, eventTrack: new Subject<any>() });
 
   let toastErrorMsg: string;
-  beforeEach(() => toastErrorMsg = null);
-  provide(ToastrService, { error: (m: string) => toastErrorMsg = m });
+  beforeEach(() => (toastErrorMsg = null));
+  provide(ToastrService, { error: (m: string) => (toastErrorMsg = m) });
 
   const expectDisabled = (el, text, shouldBeDisabled) => {
-    let button = el.queryAll(By.css('prx-button')).find(btn => {
+    let button = el.queryAll(By.css('prx-button')).find((btn) => {
       return btn.nativeElement.firstChild.data.trim() === text;
     });
     if (!button) {
@@ -47,11 +47,11 @@ describe('StatusControlComponent', () => {
 
   cit('strictly allows publishing', (fix, el, comp) => {
     comp.nextStatus = 'published';
-    mockStory({invalid: () => 'bad'}, comp, fix);
+    mockStory({ invalid: () => 'bad' }, comp, fix);
     expect(el).toContainText('Found 1 Problem');
-    mockStory({invalid: (f, strict) => strict ? 'bad,stuff' : null}, comp, fix);
+    mockStory({ invalid: (f, strict) => (strict ? 'bad,stuff' : null) }, comp, fix);
     expect(el).toContainText('Found 2 Problems');
-    mockStory({invalid: () => null}, comp, fix);
+    mockStory({ invalid: () => null }, comp, fix);
     expectDisabled(el, 'Publish Now', false);
     comp.currentStatus = 'published';
     fix.detectChanges();
@@ -60,7 +60,7 @@ describe('StatusControlComponent', () => {
 
   cit('strictly toggles to published (after audio processing)', (fix, el, comp) => {
     comp.nextStatus = 'published';
-    mockStory({publishedAt: null, invalid: () => 'bad', setPublished: () => null}, comp, fix);
+    mockStory({ publishedAt: null, invalid: () => 'bad', setPublished: () => null }, comp, fix);
     spyOn(comp.story, 'setPublished').and.returnValue(new Subject());
 
     comp.togglePublish('should not be able to publish this');
@@ -70,7 +70,7 @@ describe('StatusControlComponent', () => {
 
   cit('unstrictly toggles to unpublished (after audio processing)', (fix, el, comp) => {
     comp.nextStatus = 'unpublished';
-    mockStory({publishedAt: new Date(), invalid: () => 'bad', setPublished: () => null}, comp, fix);
+    mockStory({ publishedAt: new Date(), invalid: () => 'bad', setPublished: () => null }, comp, fix);
     spyOn(comp.story, 'setPublished').and.returnValue(new Subject());
 
     comp.togglePublish('should be able to unpublish this');
@@ -80,27 +80,27 @@ describe('StatusControlComponent', () => {
 
   cit('shows remote status messages', (fix, el, comp) => {
     comp.nextStatus = comp.currentStatus = 'scheduled';
-    mockStory({status: 'invalid', statusMessage: 'Remote invalid'}, comp, fix);
+    mockStory({ status: 'invalid', statusMessage: 'Remote invalid' }, comp, fix);
     expect(el).toContainText('Found 1 Problem');
-    mockStory({status: 'any', statusMessage: 'Remote invalid'}, comp, fix);
+    mockStory({ status: 'any', statusMessage: 'Remote invalid' }, comp, fix);
     expectDisabled(el, 'Save', true);
   });
 
   cit('unstrictly saves new stories', (fix, el, comp) => {
     comp.nextStatus = comp.currentStatus = 'draft';
-    mockStory({isNew: true, invalid: () => 'bad'}, comp, fix);
+    mockStory({ isNew: true, invalid: () => 'bad' }, comp, fix);
     expect(el).toContainText('Save');
     expectDisabled(el, 'Save', true);
-    mockStory({isNew: true, invalid: (f, strict) => strict ? 'bad' : null, changed: () => true}, comp, fix);
+    mockStory({ isNew: true, invalid: (f, strict) => (strict ? 'bad' : null), changed: () => true }, comp, fix);
     expectDisabled(el, 'Save', false);
   });
 
   cit('unstrictly saves unpublished stories', (fix, el, comp) => {
     comp.nextStatus = comp.currentStatus = 'draft';
-    mockStory({invalid: () => 'bad'}, comp, fix);
+    mockStory({ invalid: () => 'bad' }, comp, fix);
     expect(el).toContainText('Save');
     expectDisabled(el, 'Save', true);
-    comp.story.invalid = (f, strict) => strict ? 'bad' : null;
+    comp.story.invalid = (f, strict) => (strict ? 'bad' : null);
     comp.story.changed = () => true;
     fix.detectChanges();
     expectDisabled(el, 'Save', false);
@@ -108,10 +108,10 @@ describe('StatusControlComponent', () => {
 
   cit('strictly saves published stories', (fix, el, comp) => {
     comp.nextStatus = comp.currentStatus = 'published';
-    mockStory({publishedAt: new Date(), isPublished: () => true, invalid: () => null}, comp, fix);
+    mockStory({ publishedAt: new Date(), isPublished: () => true, invalid: () => null }, comp, fix);
     expect(el).toContainText('Save & Publish');
     expectDisabled(el, 'Save & Publish', true);
-    comp.story.invalid = (f, strict) => strict ? 'bad' : null;
+    comp.story.invalid = (f, strict) => (strict ? 'bad' : null);
     fix.detectChanges();
     expectDisabled(el, 'Found 1 Problem', false);
     comp.story.invalid = (f, strict) => null;
@@ -123,26 +123,26 @@ describe('StatusControlComponent', () => {
   cit('it correctly determines the next step', (fix, el, comp: StatusControlComponent) => {
     comp.nextStatus = comp.currentStatus = 'draft';
     // If it's going to draft and fails normal validation, it can't be saved
-    mockStory({isNew: true, invalid: () => 'bad', changed: () => true}, comp, fix);
+    mockStory({ isNew: true, invalid: () => 'bad', changed: () => true }, comp, fix);
     expect(comp.buttons.primary.text).toEqual('Found 1 Problem');
     // If it's going to draft and passes normal validation, it can be saved
-    mockStory({isNew: true, invalid: (f, strict) => strict ? 'bad' : null, changed: () => true}, comp, fix);
+    mockStory({ isNew: true, invalid: (f, strict) => (strict ? 'bad' : null), changed: () => true }, comp, fix);
     expectDisabled(el, 'Save', false);
     // If it's going to scheduled and fails strict validation, it can't be scheduled
     comp.nextStatus = 'scheduled';
-    mockStory({releasedAt: new Date(), invalid: (f, strict) => strict ? 'bad' : null, changed: () => true}, comp, fix);
+    mockStory({ releasedAt: new Date(), invalid: (f, strict) => (strict ? 'bad' : null), changed: () => true }, comp, fix);
     expect(comp.buttons.primary.text).toEqual('Found 1 Problem');
     // If it's going to scheduled and passes strict validation, it can be scheduled
-    mockStory({releasedAt: new Date(), invalid: () => null, changed: () => true}, comp, fix);
+    mockStory({ releasedAt: new Date(), invalid: () => null, changed: () => true }, comp, fix);
     expectDisabled(el, 'Schedule', false);
     // If it's going to published and fails strict validation, it can't be published
     comp.nextStatus = 'published';
-    comp.story.invalid = (f, strict) => strict ? 'bad' : null;
+    comp.story.invalid = (f, strict) => (strict ? 'bad' : null);
     fix.detectChanges();
     expect(comp.buttons.primary.text).toEqual('Found 1 Problem');
     // If it's going to published and passes strict validation, it can be published
     comp.story.invalid = (f, strict) => null;
     fix.detectChanges();
     expect(comp.buttons.primary.text).toEqual('Publish Now');
-  })
+  });
 });


### PR DESCRIPTION
Closes #698 (again).

Belt and suspenders - an upstream bug in HalRemote fixed some token retrying.  But just in case that doesn't fix it ... also break up the `togglePublish()` method.  So if there's a stray observable somewhere, it doesn't accidentally toggle-to-unpublished.