### PR TITLE
Audio version explicit

### DIFF
--- a/src/app/series/directives/series-podcast.component.ts
+++ b/src/app/series/directives/series-podcast.component.ts
@@ -11,7 +11,7 @@ import * as languageMappingList from 'langmap';
 export class SeriesPodcastComponent implements OnDestroy, DoCheck {
   categories = CATEGORIES;
   subCategories: string[] = [];
-  explicitOpts = ['Explicit', 'Clean'];
+  explicitOpts = [['Explicit', 'true'], ['Clean', 'false']];
   itunesRequirementsDoc = 'https://help.apple.com/itc/podcasts_connect/#/itc1723472cb';
   itunesCategoryDoc = 'https://help.apple.com/itc/podcasts_connect/#/itc9267a2f12';
   itunesNewFeedURLDoc = 'https://help.apple.com/itc/podcasts_connect/#/itca489031e0';

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -120,10 +120,7 @@ export class FeederPodcastModel extends BaseModel {
       this.subCategory = '';
     }
 
-    this.explicit = this.doc['explicit'] || '';
-    if (this.explicit) {
-      this.explicit = this.explicit.charAt(0).toUpperCase() + this.explicit.slice(1);
-    }
+    this.explicit = this.doc['explicit'] || null;
 
     this.language = this.doc['language'] || '';
     if (this.language) {
@@ -172,10 +169,6 @@ export class FeederPodcastModel extends BaseModel {
     }
 
     data.explicit = this.explicit || null;
-    if (data.explicit) {
-      data.explicit = data.explicit.toLowerCase();
-    }
-
     data.summary = this.summary || null;
     data.serialOrder = this.serialOrder || null;
     data.displayEpisodesCount = parseInt(this.displayEpisodesCount, 10) || null;

--- a/src/app/story/directives/podcast.component.ts
+++ b/src/app/story/directives/podcast.component.ts
@@ -11,7 +11,7 @@ import { AudioVersionModel } from 'ngx-prx-styleguide';
   templateUrl: 'podcast.component.html'
 })
 export class PodcastComponent implements OnDestroy {
-  explicitOpts = ['Explicit', 'Clean'];
+  explicitOpts = [['Explicit', 'true'], ['Clean', 'false']];
   itunesRequirementsDoc = 'https://help.apple.com/itc/podcasts_connect/#/itc1723472cb';
   episodeTypeOptions = ['full', 'trailer', 'bonus'];
 
@@ -54,7 +54,11 @@ export class PodcastComponent implements OnDestroy {
     story.getSeriesDistribution('podcast').subscribe((ddoc) => {
       let dist = new DistributionModel(null, ddoc);
       dist.loadRelated('podcast').subscribe(() => {
-        this.podcastExplicit = dist.podcast ? dist.podcast.explicit : null;
+        if (dist.podcast) {
+          this.podcastExplicit = dist.podcast.explicit === 'true' ? 'Explicit' : 'Clean';
+        } else {
+          this.podcastExplicit = null;
+        }
         this.podcastAuthorName = dist.podcast ? dist.podcast.authorName : null;
         this.podcastAuthorEmail = dist.podcast ? dist.podcast.authorEmail : null;
       });


### PR DESCRIPTION
Deploy along with Feeder/CMS changes.

Use newest "true/false" strings for itunes:explicit.  But keeps displaying them as "Explicit" vs "Clean".