### PR TITLE
Multiple feeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "evaporate": "^2.1.4",
     "js-sha256": "^0.9.0",
     "langmap": "0.0.14",
-    "ngx-prx-styleguide": "5.1.1",
+    "ngx-prx-styleguide": "5.1.3",
     "prosemirror-commands": "^1.1.4",
     "prosemirror-inputrules": "^1.1.2",
     "prosemirror-keymap": "^1.1.4",

--- a/src/app/series/directives/series-feeds.component.css
+++ b/src/app/series/directives/series-feeds.component.css
@@ -6,7 +6,7 @@
 }
 .feed {
   width: 100%;
-  margin-top: 30px;
+  margin-top: 2px;
 }
 .feed:first-child {
   margin-top: 0;

--- a/src/app/series/directives/series-feeds.component.css
+++ b/src/app/series/directives/series-feeds.component.css
@@ -14,8 +14,8 @@
 .add-feed {
   margin-top: 30px;
 }
-.add-feed i {
-  vertical-align: bottom;
+.remove-feed {
+  margin-bottom: 15px;
 }
 
 /* header for each feed */
@@ -69,8 +69,8 @@
   transform: rotate(-45deg);
 }
 
-/* external link icon */
-.feed .external-link {
+/* icons */
+.external-icon {
   display: inline-block;
   transform: scale(1);
   width: 12px;
@@ -79,27 +79,57 @@
   margin-left: 6px;
   margin-top: 1px;
 }
-.feed .external-link::after,
-.feed .external-link::before {
+.external-icon::after,
+.external-icon::before {
   content: '';
   display: block;
   box-sizing: border-box;
   position: absolute;
   right: -4px;
 }
-.feed .external-link::before {
+.external-icon::before {
   background: currentColor;
   transform: rotate(-45deg);
   width: 12px;
   height: 2px;
   top: 1px;
 }
-.feed .external-link::after {
+.external-icon::after {
   width: 8px;
   height: 8px;
   border-right: 2px solid;
   border-top: 2px solid;
   top: -4px;
+}
+.add-icon,
+.remove-icon {
+  display: inline-block;
+  transform: scale(1);
+  width: 12px;
+  height: 12px;
+  margin-right: 2px;
+}
+.add-icon::before,
+.add-icon::after,
+.remove-icon::before,
+.remove-icon::after {
+  content: '';
+  position: absolute;
+  width: 14px;
+  height: 2px;
+  background: currentColor;
+  border-radius: 1px;
+  top: 6px;
+  left: 0;
+}
+.add-icon::after {
+  transform: rotate(90deg);
+}
+.remove-icon::before {
+  transform: rotate(45deg);
+}
+.remove-icon::after {
+  transform: rotate(-45deg);
 }
 
 /* main forms */
@@ -124,13 +154,12 @@
 .feed section .auth-token input.invalid {
   outline: 5px auto #e32;
 }
-.feed section .auth-token .external-link {
+.feed section .auth-token .external-icon {
   margin: 15px 0;
 }
-.feed section .auth-token button {
+.feed section .auth-token .remove-icon {
   flex: 0 0 20px;
-  margin-left: 0;
-  margin-right: 0;
+  margin: 13px 0;
 }
 .feed section .ad-zones {
   display: flex;

--- a/src/app/series/directives/series-feeds.component.css
+++ b/src/app/series/directives/series-feeds.component.css
@@ -11,6 +11,14 @@
 .feed:first-child {
   margin-top: 0;
 }
+.add-feed {
+  margin-top: 30px;
+}
+.add-feed i {
+  vertical-align: bottom;
+}
+
+/* header for each feed */
 .feed header {
   background-color: #b8b8b8;
   padding: 16px 14px;
@@ -26,41 +34,11 @@
   flex: 1;
 }
 .feed header .feed-url {
+  /*TODO: how to limit this width?*/
   /*white-space: nowrap;*/
   /*overflow: hidden;*/
   /*text-overflow: ellipsis;*/
   /*min-width: 0;*/
-}
-.feed header .feed-url a {
-  display: inline-block;
-  transform: scale(1);
-  width: 12px;
-  height: 12px;
-  box-shadow: -2px 2px 0 0, -4px -4px 0 -2px, 4px 4px 0 -2px;
-  margin-left: 6px;
-  margin-top: 1px;
-}
-.feed header .feed-url .external::after,
-.feed header .feed-url .external::before {
-  content: '';
-  display: block;
-  box-sizing: border-box;
-  position: absolute;
-  right: -4px;
-}
-.feed header .feed-url .external::before {
-  background: currentColor;
-  transform: rotate(-45deg);
-  width: 12px;
-  height: 2px;
-  top: 1px;
-}
-.feed header .feed-url .external::after {
-  width: 8px;
-  height: 8px;
-  border-right: 2px solid;
-  border-top: 2px solid;
-  top: -4px;
 }
 .feed header button {
   width: 24px;
@@ -90,6 +68,41 @@
   border-right: 2px solid;
   transform: rotate(-45deg);
 }
+
+/* external link icon */
+.feed .external-link {
+  display: inline-block;
+  transform: scale(1);
+  width: 12px;
+  height: 12px;
+  box-shadow: -2px 2px 0 0, -4px -4px 0 -2px, 4px 4px 0 -2px;
+  margin-left: 6px;
+  margin-top: 1px;
+}
+.feed .external-link::after,
+.feed .external-link::before {
+  content: '';
+  display: block;
+  box-sizing: border-box;
+  position: absolute;
+  right: -4px;
+}
+.feed .external-link::before {
+  background: currentColor;
+  transform: rotate(-45deg);
+  width: 12px;
+  height: 2px;
+  top: 1px;
+}
+.feed .external-link::after {
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid;
+  border-top: 2px solid;
+  top: -4px;
+}
+
+/* main forms */
 .feed section {
   background: #fff;
   border-bottom: 1px solid #ddd;
@@ -97,9 +110,32 @@
   margin-top: -1px;
   padding: 18px 22px 0;
 }
-.add-feed {
-  margin-top: 30px;
+.feed section .auth-token {
+  display: flex;
+  gap: 15px;
+  margin: 15px 0;
 }
-.add-feed i {
-  vertical-align: bottom;
+.feed section .auth-token input::placeholder {
+  opacity: 0.5;
+}
+.feed section .auth-token input.changed {
+  outline: 5px auto #f09b4c;
+}
+.feed section .auth-token input.invalid {
+  outline: 5px auto #e32;
+}
+.feed section .auth-token .external-link {
+  margin: 15px 0;
+}
+.feed section .auth-token button {
+  flex: 0 0 20px;
+  margin-left: 0;
+  margin-right: 0;
+}
+.feed section .ad-zones {
+  display: flex;
+  gap: 15px;
+}
+.feed section .ad-zones prx-fancy-field {
+  width: auto;
 }

--- a/src/app/series/directives/series-feeds.component.css
+++ b/src/app/series/directives/series-feeds.component.css
@@ -1,0 +1,105 @@
+/**
+ * Series version/file templates
+ */
+.feeds {
+  width: 100%;
+}
+.feed {
+  width: 100%;
+  margin-top: 30px;
+}
+.feed:first-child {
+  margin-top: 0;
+}
+.feed header {
+  background-color: #b8b8b8;
+  padding: 16px 14px;
+  display: flex;
+  position: relative;
+}
+.feed header strong {
+  white-space: nowrap;
+  color: #222;
+  font-size: 17px;
+  font-weight: 600;
+  margin-right: 14px;
+  flex: 1;
+}
+.feed header .feed-url {
+  /*white-space: nowrap;*/
+  /*overflow: hidden;*/
+  /*text-overflow: ellipsis;*/
+  /*min-width: 0;*/
+}
+.feed header .feed-url a {
+  display: inline-block;
+  transform: scale(1);
+  width: 12px;
+  height: 12px;
+  box-shadow: -2px 2px 0 0, -4px -4px 0 -2px, 4px 4px 0 -2px;
+  margin-left: 6px;
+  margin-top: 1px;
+}
+.feed header .feed-url .external::after,
+.feed header .feed-url .external::before {
+  content: '';
+  display: block;
+  box-sizing: border-box;
+  position: absolute;
+  right: -4px;
+}
+.feed header .feed-url .external::before {
+  background: currentColor;
+  transform: rotate(-45deg);
+  width: 12px;
+  height: 2px;
+  top: 1px;
+}
+.feed header .feed-url .external::after {
+  width: 8px;
+  height: 8px;
+  border-right: 2px solid;
+  border-top: 2px solid;
+  top: -4px;
+}
+.feed header button {
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
+  margin-left: 10px;
+  transform: scale(1);
+  border: 2px solid transparent;
+  background-color: transparent;
+  color: #222;
+}
+.feed header button::after {
+  content: '';
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  left: 6px;
+  bottom: 6px;
+}
+.feed header button.expand::after {
+  border-bottom: 2px solid;
+  border-right: 2px solid;
+  transform: rotate(45deg);
+}
+.feed header button.collapse::after {
+  border-top: 2px solid;
+  border-right: 2px solid;
+  transform: rotate(-45deg);
+}
+.feed section {
+  background: #fff;
+  border-bottom: 1px solid #ddd;
+  border-top: 1px solid #ddd;
+  margin-top: -1px;
+  padding: 18px 22px 0;
+}
+.add-feed {
+  margin-top: 30px;
+}
+.add-feed i {
+  vertical-align: bottom;
+}

--- a/src/app/series/directives/series-feeds.component.html
+++ b/src/app/series/directives/series-feeds.component.html
@@ -1,0 +1,74 @@
+<div *ngIf="!loading">
+  <prx-fancy-field label="Feeds">
+    <div class="fancy-hint">
+      Create and configure RSS feeds to meet your distribution needs. Add new feeds as you need. A public feed is created by default.
+    </div>
+  </prx-fancy-field>
+
+  <div class="feeds">
+    <ng-container *ngFor="let f of podcast.feeds; index as i">
+      <div *ngIf="!f.isDestroy" class="feed">
+        <header>
+          <strong *ngIf="f.isDefault">Default Feed</strong>
+          <strong *ngIf="!f.isDefault">{{ f.title || '(New Feed)' }}</strong>
+          <div class="feed-url">
+            {{ f.privateFeedUrl }}
+            <a [href]="f.privateFeedUrl" target="_blank" rel="noopener" class="external"></a>
+          </div>
+          <button *ngIf="expanded[i]" type="button" class="collapse" aria-label="Collapse" (click)="collapse(i)"></button>
+          <button *ngIf="!expanded[i]" type="button" class="expand" aria-label="Expand" (click)="expand(i)"></button>
+        </header>
+        <section *ngIf="expanded[i]">
+          <prx-fancy-field *ngIf="!f.isDefault" required textinput [model]="f" name="title" id="title{{ i }}" label="Feed Label">
+            <div class="fancy-hint">A label for this feed, such as "Limited Items" or "Apple Subscription"</div>
+          </prx-fancy-field>
+
+          <prx-fancy-field
+            *ngIf="!f.isDefault"
+            required
+            textinput
+            [model]="f"
+            name="slug"
+            id="slug{{ i }}"
+            label="Feed Slug"
+            advancedConfirm="Woh there! Changing your private feed url could break things for your subscribers - are you sure?"
+          >
+            <div class="fancy-hint">An alphanumeric slug used to identify your feed. Also used in the private feed RSS url.</div>
+          </prx-fancy-field>
+
+          <prx-fancy-field
+            required
+            textinput
+            [model]="f"
+            name="fileName"
+            id="fileName{{ i }}"
+            label="File Name"
+            advancedConfirm="Woh there! Changing your private feed url could break things for your subscribers - are you sure?"
+          >
+            <div class="fancy-hint">The file name used for your private RSS feed.</div>
+          </prx-fancy-field>
+
+          <prx-fancy-field
+            *ngIf="!f.isDefault"
+            checkbox
+            [model]="f"
+            name="private"
+            id="private{{ i }}"
+            label="Feed Visibility"
+            prompt="Private (Unlisted)"
+          >
+            <div class="fancy-hint">
+              Your feed can be public or private. Leave unchecked to keep it a Public Feed. If you check this box this feed becomes Private
+              and you'll need to generate an authorization token. Be careful who you share your private link with -
+              <strong>anyone who has access to the link will be able to use it</strong>.
+            </div>
+          </prx-fancy-field>
+        </section>
+      </div>
+    </ng-container>
+  </div>
+
+  <section>
+    <button class="add-feed" (click)="addFeed()"><i class="icon-plus white" aria-hidden="true"></i> Add feed</button>
+  </section>
+</div>

--- a/src/app/series/directives/series-feeds.component.html
+++ b/src/app/series/directives/series-feeds.component.html
@@ -13,7 +13,7 @@
           <strong *ngIf="!f.isDefault">{{ f.title || '(New Feed)' }}</strong>
           <div *ngIf="!f.isNew" class="feed-url">
             {{ f.privateFeedUrl() }}
-            <a [href]="f.privateFeedUrl()" target="_blank" rel="noopener" class="external-link"></a>
+            <a [href]="f.privateFeedUrl()" target="_blank" rel="noopener" class="external-icon"></a>
           </div>
           <button *ngIf="expanded[i]" type="button" class="collapse" aria-label="Collapse" (click)="collapse(i)"></button>
           <button *ngIf="!expanded[i]" type="button" class="expand" aria-label="Expand" (click)="expand(i)"></button>
@@ -87,8 +87,8 @@
                 [class.changed]="f.tokenChanged(j)"
                 [class.invalid]="f.tokenInvalid(j)"
               />
-              <a [href]="f.privateFeedUrl(t.token)" target="_blank" rel="noopener" class="external-link"></a>
-              <button type="button" aria-label="Remove" class="btn-icon icon-cancel grey-dove" (click)="f.removeToken(j)"></button>
+              <a [href]="f.privateFeedUrl(t.token)" target="_blank" rel="noopener" class="external-icon"></a>
+              <button type="button" aria-label="Remove" class="btn-link remove-icon" (click)="f.removeToken(j)"></button>
             </div>
 
             <button type="button" class="btn-link" (click)="f.addToken()">Add token</button>
@@ -103,12 +103,16 @@
               <prx-fancy-field checkbox [model]="f" name="sonicAds" id="sonicAds{{ i }}" prompt="Sonic IDs"> </prx-fancy-field>
             </div>
           </prx-fancy-field>
+
+          <button *ngIf="!f.isDefault" class="delete remove-feed" (click)="removeFeed(i)">
+            <i class="remove-icon" aria-hidden="true"></i> Remove feed
+          </button>
         </section>
       </div>
     </ng-container>
   </div>
 
   <section>
-    <button class="add-feed" (click)="addFeed()"><i class="icon-plus white" aria-hidden="true"></i> Add feed</button>
+    <button class="add-feed" (click)="addFeed()"><i class="add-icon" aria-hidden="true"></i> Add feed</button>
   </section>
 </div>

--- a/src/app/series/directives/series-feeds.component.html
+++ b/src/app/series/directives/series-feeds.component.html
@@ -11,9 +11,9 @@
         <header>
           <strong *ngIf="f.isDefault">Default Feed</strong>
           <strong *ngIf="!f.isDefault">{{ f.title || '(New Feed)' }}</strong>
-          <div class="feed-url">
-            {{ f.privateFeedUrl }}
-            <a [href]="f.privateFeedUrl" target="_blank" rel="noopener" class="external"></a>
+          <div *ngIf="!f.isNew" class="feed-url">
+            {{ f.privateFeedUrl() }}
+            <a [href]="f.privateFeedUrl()" target="_blank" rel="noopener" class="external-link"></a>
           </div>
           <button *ngIf="expanded[i]" type="button" class="collapse" aria-label="Collapse" (click)="collapse(i)"></button>
           <button *ngIf="!expanded[i]" type="button" class="expand" aria-label="Expand" (click)="expand(i)"></button>
@@ -61,6 +61,46 @@
               Your feed can be public or private. Leave unchecked to keep it a Public Feed. If you check this box this feed becomes Private
               and you'll need to generate an authorization token. Be careful who you share your private link with -
               <strong>anyone who has access to the link will be able to use it</strong>.
+            </div>
+          </prx-fancy-field>
+
+          <prx-fancy-field *ngIf="f.private" label="Auth Tokens">
+            <div class="fancy-hint">
+              Auth tokens help ensure your feed stays private. They must be appended to the feed URL for the audio to work. Remove them to
+              revoke access to your feed.
+            </div>
+
+            <div *ngFor="let t of f.tokens; index as j" class="auth-token">
+              <input
+                type="text"
+                placeholder="Label"
+                [(ngModel)]="t.label"
+                (ngModelChange)="f.setTokens()"
+                [class.changed]="f.labelChanged(j)"
+                [class.invalid]="f.labelInvalid(j)"
+              />
+              <input
+                type="text"
+                placeholder="Token"
+                [(ngModel)]="t.token"
+                (ngModelChange)="f.setTokens()"
+                [class.changed]="f.tokenChanged(j)"
+                [class.invalid]="f.tokenInvalid(j)"
+              />
+              <a [href]="f.privateFeedUrl(t.token)" target="_blank" rel="noopener" class="external-link"></a>
+              <button type="button" aria-label="Remove" class="btn-icon icon-cancel grey-dove" (click)="f.removeToken(j)"></button>
+            </div>
+
+            <button type="button" class="btn-link" (click)="f.addToken()">Add token</button>
+          </prx-fancy-field>
+
+          <prx-fancy-field *ngIf="!f.isDefault" label="Ad Zones to include">
+            <div class="fancy-hint">Control the types of ads that should be stitched into episodes in this feed.</div>
+            <div class="ad-zones">
+              <prx-fancy-field checkbox [model]="f" name="billboardAds" id="billboardAds{{ i }}" prompt="Billboards"> </prx-fancy-field>
+              <prx-fancy-field checkbox [model]="f" name="houseAds" id="houseAds{{ i }}" prompt="House Ads"> </prx-fancy-field>
+              <prx-fancy-field checkbox [model]="f" name="paidAds" id="paidAds{{ i }}" prompt="Paid Ads"> </prx-fancy-field>
+              <prx-fancy-field checkbox [model]="f" name="sonicAds" id="sonicAds{{ i }}" prompt="Sonic IDs"> </prx-fancy-field>
             </div>
           </prx-fancy-field>
         </section>

--- a/src/app/series/directives/series-feeds.component.html
+++ b/src/app/series/directives/series-feeds.component.html
@@ -1,7 +1,9 @@
 <div *ngIf="!loading">
   <prx-fancy-field label="Feeds">
     <div class="fancy-hint">
-      Create and configure RSS feeds to meet your distribution needs. Add new feeds as you need. A public feed is created by default.
+      Create and configure RSS feeds to meet your distribution needs. A public feed is created by default. We encourage podcasters to use a
+      proxy like feedburner (potentially with a custom domain) for sharing your default feed. For private feeds, you must use our
+      authorization proxy service to secure access.
     </div>
   </prx-fancy-field>
 
@@ -12,8 +14,8 @@
           <strong *ngIf="f.isDefault">Default Feed</strong>
           <strong *ngIf="!f.isDefault">{{ f.title || '(New Feed)' }}</strong>
           <div *ngIf="!f.isNew" class="feed-url">
-            {{ f.privateFeedUrl() }}
-            <a [href]="f.privateFeedUrl()" target="_blank" rel="noopener" class="external-icon"></a>
+            {{ f.publishedFeedUrl() }}
+            <a [href]="f.publishedFeedUrl()" target="_blank" rel="noopener" class="external-icon"></a>
           </div>
           <button *ngIf="expanded[i]" type="button" class="collapse" aria-label="Collapse" (click)="collapse(i)"></button>
           <button *ngIf="!expanded[i]" type="button" class="expand" aria-label="Expand" (click)="expand(i)"></button>
@@ -92,6 +94,53 @@
             </div>
 
             <button type="button" class="btn-link" (click)="f.addToken()">Add token</button>
+          </prx-fancy-field>
+
+          <prx-fancy-field *ngIf="!f.private" label="Public Feed URL" textinput [model]="f" name="url" [advancedConfirm]="urlConfirm(f)">
+            <div class="fancy-hint">
+              If you already have a public URL for your podcast feed (e.g.,
+              <a [href]="feedburnerHelpUrl" target="_blank" rel="noopener">feedburner</a>), enter it here. It should point to your
+              <a [href]="f.privateFeedUrl()" target="_blank" rel="noopener">private feed URL.</a>
+            </div>
+          </prx-fancy-field>
+
+          <prx-fancy-field
+            *ngIf="!f.private"
+            label="New Feed Url"
+            textinput
+            [model]="f"
+            name="newFeedUrl"
+            [advancedConfirm]="newFeedUrlConfirm(f)"
+          >
+            <div class="fancy-hint">
+              If your podcast feed is moving, use this field to point to the new URL where your podcast is located. The current feed should
+              be maintained until all of your subscribers have migrated.
+            </div>
+          </prx-fancy-field>
+
+          <prx-fancy-field label="Enclosure Prefix Url" textinput [model]="f" name="enclosurePrefix">
+            <div class="fancy-hint">
+              If you have an enclosure prefix URL to set a redirect on audio requests for your podcast feed (e.g., podtrac or blubrry),
+              enter it here.
+            </div>
+          </prx-fancy-field>
+
+          <prx-fancy-field label="Feed Episode Limit" textinput [model]="f" name="displayEpisodesCount">
+            <div class="fancy-hint">
+              You can optionally limit the number of episodes that will be publicly available in your feed. Your oldest episodes will
+              disappear as you publish newer ones. Leave this field blank to include all.
+            </div>
+          </prx-fancy-field>
+
+          <prx-fancy-field label="Feed Metadata Limit" textinput [model]="f" name="displayFullEpisodesCount">
+            <div class="fancy-hint">
+              You can optionally
+              <a target="_blank" rel="noopener" title="Limiting Episode Metadata" [href]="metadataLimitUrl"
+                >reduce the size of your RSS feed</a
+              >
+              by trimming metadata from your oldest feed episodes. This many of your newest episodes will include <i>all</i> metadata, and
+              older episodes will omit certain RSS fields. Leave this field blank to include all metadata on every episode.
+            </div>
           </prx-fancy-field>
 
           <prx-fancy-field *ngIf="!f.isDefault" label="Ad Zones to include">

--- a/src/app/series/directives/series-feeds.component.html
+++ b/src/app/series/directives/series-feeds.component.html
@@ -7,7 +7,11 @@
     </div>
   </prx-fancy-field>
 
-  <div class="feeds">
+  <div class="feeds" *ngIf="!podcast || !podcast.feeds.length">
+    <h2>No feeds found! Please contact support</h2>
+  </div>
+
+  <div class="feeds" *ngIf="podcast">
     <ng-container *ngFor="let f of podcast.feeds; index as i">
       <div *ngIf="!f.isDestroy" class="feed">
         <header>

--- a/src/app/series/directives/series-feeds.component.spec.ts
+++ b/src/app/series/directives/series-feeds.component.spec.ts
@@ -9,8 +9,7 @@ describe('SeriesFeedsComponent', () => {
   provide(TabService);
 
   cit('shows an error message if you have no podcast distribution', (fix, el, comp) => {
-    const podcastUrl = 'http://some.where/your/podcast/1234';
-    const series = cms().mock('prx:series', {});
+    const series = cms().mock('prx:series', { id: 'some-id' });
 
     comp.load(new SeriesModel(null, series, false));
     fix.detectChanges();

--- a/src/app/series/directives/series-feeds.component.spec.ts
+++ b/src/app/series/directives/series-feeds.component.spec.ts
@@ -1,0 +1,65 @@
+import { cit, create, provide, stubPipe, cms } from '../../../testing';
+import { SeriesFeedsComponent } from './series-feeds.component';
+import { SeriesModel, FeederFeedModel } from 'app/shared';
+import { TabService } from 'ngx-prx-styleguide';
+
+describe('SeriesFeedsComponent', () => {
+  create(SeriesFeedsComponent);
+
+  provide(TabService);
+
+  cit('shows an error message if you have no podcast distribution', (fix, el, comp) => {
+    const podcastUrl = 'http://some.where/your/podcast/1234';
+    const series = cms().mock('prx:series', {});
+
+    comp.load(new SeriesModel(null, series, false));
+    fix.detectChanges();
+
+    expect(el).toContainText('No feeds found');
+  });
+
+  cit('displays feeds', (fix, el, comp) => {
+    const podcastUrl = 'http://some.where/your/podcast/1234';
+    const series = cms().mock('prx:series', {});
+    const [dist] = series.mockItems('prx:distributions', [{ kind: 'podcast', url: podcastUrl }]);
+    const podcast = dist.mock(podcastUrl, { title: 'pod1' });
+    podcast.mockItems('prx:feeds', [
+      { id: 1, slug: '', fileName: 'default.xml' },
+      { id: 2, title: 'Some Private Feed', slug: 'private', fileName: 'private.xml' },
+      { id: 3, title: 'Some Public Feed', slug: 'public', fileName: 'public.xml' }
+    ]);
+
+    comp.load(new SeriesModel(null, series, false));
+    fix.detectChanges();
+
+    expect(el).toContainText('Default Feed');
+    expect(el).toContainText('Some Private Feed');
+    expect(el).toContainText('Some Public Feed');
+  });
+
+  cit('confirms urls changing', (fix, el, comp) => {
+    const doc = cms().mock('prx:feed', { id: 1234, url: 'original-url' });
+    const feed = new FeederFeedModel(null, doc);
+
+    feed.set('url', 'updated-url');
+    expect(comp.urlConfirm(feed)).toMatch(/are you sure you want to change/i);
+
+    // pretend the original was blank
+    feed.set('url', '', true);
+    feed.set('url', 'updated-url');
+    expect(comp.urlConfirm(feed)).toBeFalsy();
+  });
+
+  cit('confirms new-feed-urls changing', (fix, el, comp) => {
+    const doc = cms().mock('prx:feed', { id: 1234, url: 'original-url', newFeedUrl: 'original-url' });
+    const feed = new FeederFeedModel(null, doc);
+
+    feed.set('newFeedUrl', 'updated-url');
+    expect(comp.urlConfirm(feed)).toMatch(/are you sure you want to change/i);
+
+    // also shows up if new feed url _was_ blank
+    feed.set('newFeedUrl', '', true);
+    feed.set('newFeedUrl', 'updated-url');
+    expect(comp.urlConfirm(feed)).toMatch(/are you sure you want to change/i);
+  });
+});

--- a/src/app/series/directives/series-feeds.component.ts
+++ b/src/app/series/directives/series-feeds.component.ts
@@ -1,0 +1,57 @@
+import { TabService } from 'ngx-prx-styleguide';
+import { Component, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
+// import { map } from 'rxjs/operators';
+// import { TabService, SimpleDate, HalDoc } from 'ngx-prx-styleguide';
+import { SeriesModel, FeederPodcastModel, FeederFeedModel } from '../../shared';
+
+@Component({
+  styleUrls: ['series-feeds.component.css'],
+  templateUrl: 'series-feeds.component.html'
+})
+export class SeriesFeedsComponent implements OnDestroy {
+  tabSub: Subscription;
+  podcast: FeederPodcastModel;
+  loading = true;
+  expanded = [];
+
+  constructor(tab: TabService) {
+    this.tabSub = tab.model.subscribe((s: SeriesModel) => this.load(s));
+  }
+
+  ngOnDestroy() {
+    this.tabSub.unsubscribe();
+  }
+
+  load(series: SeriesModel) {
+    this.loading = true;
+    series.loadRelated('distributions').subscribe(() => {
+      const distribution = series.distributions.find((d) => d.kind === 'podcast');
+      if (distribution) {
+        distribution.loadRelated('podcast').subscribe(() => {
+          this.podcast = distribution.podcast;
+          this.podcast.loadRelated('feeds').subscribe(() => {
+            this.loading = false;
+            this.expanded = this.podcast.feeds.map((feed, index) => index === 0);
+          });
+        });
+      } else {
+        this.loading = false;
+      }
+    });
+  }
+
+  expand(index: number) {
+    this.expanded[index] = true;
+  }
+
+  collapse(index: number) {
+    this.expanded[index] = false;
+  }
+
+  addFeed() {
+    const feed = new FeederFeedModel(this.podcast.doc);
+    this.podcast.feeds.push(feed);
+    this.expanded.push(true);
+  }
+}

--- a/src/app/series/directives/series-feeds.component.ts
+++ b/src/app/series/directives/series-feeds.component.ts
@@ -1,8 +1,6 @@
 import { TabService } from 'ngx-prx-styleguide';
 import { Component, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
-// import { map } from 'rxjs/operators';
-// import { TabService, SimpleDate, HalDoc } from 'ngx-prx-styleguide';
 import { SeriesModel, FeederPodcastModel, FeederFeedModel } from '../../shared';
 
 @Component({
@@ -32,7 +30,7 @@ export class SeriesFeedsComponent implements OnDestroy {
           this.podcast = distribution.podcast;
           this.podcast.loadRelated('feeds').subscribe(() => {
             this.loading = false;
-            this.expanded = this.podcast.feeds.map((feed, index) => index === 0);
+            this.expanded = this.podcast.feeds.map(() => true);
           });
         });
       } else {

--- a/src/app/series/directives/series-feeds.component.ts
+++ b/src/app/series/directives/series-feeds.component.ts
@@ -13,6 +13,10 @@ export class SeriesFeedsComponent implements OnDestroy {
   loading = true;
   expanded = [];
 
+  feedburnerHelpUrl = 'https://support.google.com/feedburner/answer/78475?hl=en';
+  applePodcastHelpUrl = 'https://help.apple.com/itc/podcasts_connect/#/itcb54353390';
+  metadataLimitUrl = 'https://help.prx.org/hc/en-us/articles/360055869313-Limiting-Episode-Metadata';
+
   constructor(tab: TabService) {
     this.tabSub = tab.model.subscribe((s: SeriesModel) => this.load(s));
   }
@@ -30,7 +34,7 @@ export class SeriesFeedsComponent implements OnDestroy {
           this.podcast = distribution.podcast;
           this.podcast.loadRelated('feeds').subscribe(() => {
             this.loading = false;
-            this.expanded = this.podcast.feeds.map(() => true);
+            this.expanded = this.podcast.feeds.map((_feed, index) => index === 0);
           });
         });
       } else {
@@ -55,5 +59,46 @@ export class SeriesFeedsComponent implements OnDestroy {
 
   removeFeed(index: number) {
     this.podcast.feeds[index].isDestroy = true;
+  }
+
+  urlConfirm(feed: FeederFeedModel): string {
+    if (feed.original['url']) {
+      const setYourNewFeed = `
+        If you have existing subscribers at <strong>${feed.original['url']}</strong>, make sure to
+        set the <a target="_blank" rel="noopener" href="${this.applePodcastHelpUrl}">New Feed URL</a>
+        as well to avoid losing subscribers.
+        <br/><br/>
+      `;
+      if (feed.url) {
+        return `
+          Are you sure you want to change your public feed URL from <strong>${feed.original['url']}</strong>
+          to <strong>${feed.url}</strong>? This will point your subscribers to a new feed location.
+          <br/><br/>
+          ${setYourNewFeed}
+        `;
+      } else {
+        return `
+          Are you sure you want to delete your public feed URL? This will point your subscribers back at
+          your private feed location <strong>${feed.privateFeedUrl()}</strong>.
+          <br/><br/>
+          ${setYourNewFeed}
+        `;
+      }
+    }
+  }
+
+  newFeedUrlConfirm(feed: FeederFeedModel): string {
+    const prevUrl = feed.original['newFeedUrl'] || feed.url;
+    if (prevUrl) {
+      return `
+        Are you sure you want to change your feed URL from <strong>${prevUrl}</strong> to
+        <strong>${feed.newFeedUrl}</strong>? This will point your subscribers to a new feed location.
+      `;
+    } else {
+      return `
+        Are you sure you want to change your feed URL to <strong>${feed.newFeedUrl}</strong>?
+        This will point your subscribers to a new feed location.
+      `;
+    }
   }
 }

--- a/src/app/series/directives/series-feeds.component.ts
+++ b/src/app/series/directives/series-feeds.component.ts
@@ -52,4 +52,8 @@ export class SeriesFeedsComponent implements OnDestroy {
     this.podcast.feeds.push(feed);
     this.expanded.push(true);
   }
+
+  removeFeed(index: number) {
+    this.podcast.feeds[index].isDestroy = true;
+  }
 }

--- a/src/app/series/directives/series-podcast.component.html
+++ b/src/app/series/directives/series-podcast.component.html
@@ -126,6 +126,7 @@
       </publish-wysiwyg>
     </prx-fancy-field>
 
+    <!-- TODO: moved to feed -->
     <prx-fancy-field label="PRX Feed" class="prx-feed-url" *ngIf="!distribution.isNew">
       <div class="fancy-hint" *ngIf="podcast?.hasPublicFeed">
         The private URL for your PRX podcast feed, providing the content for <a href="{{ podcast.publicFeedUrl }}">your public feed</a>.
@@ -139,6 +140,7 @@
       <input type="text" readonly [ngModel]="podcast?.publishedUrl" name="publishedUrl" />
     </prx-fancy-field>
 
+    <!-- TODO: moved to feed -->
     <prx-fancy-field *ngIf="podcast?.hasPublicFeed" label="Public Feed URL" class="feed-url">
       <div class="fancy-hint">
         The public URL for your podcast feed. Feel free to share this URL with listeners. If you need to alter this URL once you have
@@ -170,12 +172,12 @@
       </div>
     </prx-fancy-field>
 
+    <!-- TODO: moved to feed -->
     <prx-fancy-field *ngIf="!podcast?.hasPublicFeed" label="Public Feed URL" textinput [model]="podcast" name="publicFeedUrl">
-      <div class="fancy-hint">
-        If you already have a public URL for your podcast feed (e.g., feedburner), enter it here.
-      </div>
+      <div class="fancy-hint">If you already have a public URL for your podcast feed (e.g., feedburner), enter it here.</div>
     </prx-fancy-field>
 
+    <!-- TODO: moved to feed -->
     <prx-fancy-field label="Enclosure Prefix Url" textinput [model]="podcast" name="enclosurePrefix">
       <div class="fancy-hint">
         If you have an enclosure prefix URL to set a redirect on audio requests for your podcast feed (e.g., podtrac or blubrry), enter it
@@ -184,9 +186,7 @@
     </prx-fancy-field>
 
     <prx-fancy-field label="Copyright" textinput [model]="podcast" name="copyright">
-      <div class="fancy-hint">
-        Copyright notice for content in the podcast.
-      </div>
+      <div class="fancy-hint">Copyright notice for content in the podcast.</div>
     </prx-fancy-field>
 
     <prx-fancy-field label="Language" [model]="podcast" name="language" [select]="languageOptions" searchable>
@@ -194,6 +194,7 @@
     </prx-fancy-field>
 
     <publish-advanced-section>
+      <!-- TODO: moved to feed -->
       <prx-fancy-field label="Feed Episode Limit" textinput [model]="podcast" name="displayEpisodesCount">
         <div class="fancy-hint">
           You can optionally limit the number of episodes that will be publicly available in your feed. Your oldest episodes will disappear
@@ -201,6 +202,7 @@
         </div>
       </prx-fancy-field>
 
+      <!-- TODO: moved to feed -->
       <prx-fancy-field label="Feed Metadata Limit" textinput [model]="podcast" name="displayFullEpisodesCount">
         <div class="fancy-hint">
           You can optionally
@@ -210,6 +212,7 @@
         </div>
       </prx-fancy-field>
 
+      <!-- TODO: moved to feed -->
       <prx-fancy-field label="New Feed Url" textinput [model]="podcast" name="newFeedUrl" [advancedConfirm]="newFeedUrlConfirm">
         <div class="fancy-hint">
           If your podcast feed is moving, use this field to point to the new URL where your podcast is located. The current feed should be

--- a/src/app/series/series.component.html
+++ b/src/app/series/series.component.html
@@ -4,43 +4,39 @@
   </a>
   <prx-status-bar-text bold uppercase>{{ !id ? 'Create' : 'Edit' }} Series</prx-status-bar-text>
   <ng-container *ngIf="series">
-    <prx-status-bar-text italic stretch>{{series.title || '(Untitled)'}}</prx-status-bar-text>
+    <prx-status-bar-text italic stretch>{{ series.title || '(Untitled)' }}</prx-status-bar-text>
 
     <ng-container class="status_bar-actions" *ngIf="series.isNew">
-      <prx-button [model]="series" plain=1 working=0 disabled=0 (click)="discard()">Discard</prx-button>
-      <prx-button [model]="series" visible=1 green=1 (click)="save()">Create</prx-button>
+      <prx-button [model]="series" plain="1" working="0" disabled="0" (click)="discard()">Discard</prx-button>
+      <prx-button [model]="series" visible="1" green="1" (click)="save()">Create</prx-button>
     </ng-container>
 
     <ng-container class="status_bar-actions" *ngIf="!series.isNew">
-      <prx-status-bar-text class="hero-info">Last modified {{series.updatedAt | timeago}}</prx-status-bar-text>
-      <prx-button [model]="series" plain=1 working=0 disabled=0 (click)="discard()">Discard</prx-button>
-      <prx-button [model]="series" (click)="save()">Save
+      <prx-status-bar-text class="hero-info">Last modified {{ series.updatedAt | timeago }}</prx-status-bar-text>
+      <prx-button [model]="series" plain="1" working="0" disabled="0" (click)="discard()">Discard</prx-button>
+      <prx-button [model]="series" (click)="save()"
+        >Save
         <div *ngIf="series.invalid()" class="invalid-tip">
           <h4>Invalid changes</h4>
           <p>Correct them before saving</p>
         </div>
       </prx-button>
-      <prx-button working=0 disabled=1 [visible]="!series.changed()">Saved</prx-button>
+      <prx-button working="0" disabled="1" [visible]="!series.changed()">Saved</prx-button>
     </ng-container>
   </ng-container>
 </prx-status-bar>
 
 <prx-tabs [model]="series">
   <nav>
-    <a routerLinkActive="active" [routerLinkActiveOptions]="{exact:true}" [routerLink]="base">Basic Info</a>
+    <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="base">Basic Info</a>
     <a routerLinkActive="active" [routerLink]="[base, 'templates']">Audio Templates</a>
     <a routerLinkActive="active" [routerLink]="[base, 'podcast']">Podcast Info</a>
-    <a *ngIf="fromImport"
-      routerLinkActive="active"
-      [routerLink]="[base, 'import-status']"
-      >
-      Import Status
-    </a>
+    <a *ngIf="fromImport" routerLinkActive="active" [routerLink]="[base, 'import-status']"> Import Status </a>
     <a *ngIf="series && !series?.isNew" routerLinkActive="active" [routerLink]="[base, 'plan']">Plan Episodes</a>
   </nav>
 
   <div class="links" *ngIf="series && !series?.isNew">
-    <a routerLinkActive="active" [routerLink]="[base, 'list']">{{storyCount}} {{storyNoun}} in Series</a>
+    <a routerLinkActive="active" [routerLink]="[base, 'list']">{{ storyCount }} {{ storyNoun }} in Series</a>
   </div>
   <div class="extras">
     <button *ngIf="id && storyCount == 0" class="delete" (click)="confirmDelete($event)">Delete</button>

--- a/src/app/series/series.component.html
+++ b/src/app/series/series.component.html
@@ -31,6 +31,7 @@
     <a routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" [routerLink]="base">Basic Info</a>
     <a routerLinkActive="active" [routerLink]="[base, 'templates']">Audio Templates</a>
     <a routerLinkActive="active" [routerLink]="[base, 'podcast']">Podcast Info</a>
+    <a *ngIf="tempOnFeeds()" routerLinkActive="active" [routerLink]="[base, 'feeds']">RSS Feeds</a>
     <a *ngIf="fromImport" routerLinkActive="active" [routerLink]="[base, 'import-status']"> Import Status </a>
     <a *ngIf="series && !series?.isNew" routerLinkActive="active" [routerLink]="[base, 'plan']">Plan Episodes</a>
   </nav>

--- a/src/app/series/series.component.spec.ts
+++ b/src/app/series/series.component.spec.ts
@@ -157,6 +157,7 @@ describe('SeriesComponent', () => {
 
   cit('does not show plan episode for new series', (fix, el, comp) => {
     activatedRoute.testParams = {};
+    auth.mock('prx:default-account', { id: 88 });
     fix.detectChanges();
     expect(el).not.toContainText('Plan Episodes');
   });

--- a/src/app/series/series.component.ts
+++ b/src/app/series/series.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Observable,  Subject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 
 import { CmsService } from '../core';
 import { ModalService, TabService, ToastrService } from 'ngx-prx-styleguide';
@@ -16,9 +16,7 @@ import { map, takeUntil } from 'rxjs/operators';
   styleUrls: ['series.component.css'],
   templateUrl: 'series.component.html'
 })
-
 export class SeriesComponent implements OnInit, OnDestroy {
-
   private _onDestroy = new Subject();
 
   id: number;
@@ -40,11 +38,11 @@ export class SeriesComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.route.params.forEach(params => {
-     this.id = +params['id'];
-     this.base = '/series/' + (this.id || 'new');
-     this.loadSeries();
-   });
+    this.route.params.forEach((params) => {
+      this.id = +params['id'];
+      this.base = '/series/' + (this.id || 'new');
+      this.loadSeries();
+    });
   }
 
   ngOnDestroy() {
@@ -53,24 +51,24 @@ export class SeriesComponent implements OnInit, OnDestroy {
 
   loadSeries() {
     if (this.id) {
-      this.cms.auth.follow('prx:series', {id: this.id}).subscribe(
-        s => {
-          s.follow('prx:account').subscribe(a => {
+      this.cms.auth.follow('prx:series', { id: this.id }).subscribe(
+        (s) => {
+          s.follow('prx:account').subscribe((a) => {
             this.setSeries(a, s);
           });
         },
-        err => {
+        (err) => {
           if (err.status === 404 && err.name === 'HalHttpError') {
             this.toastr.error('No series found. Redirecting to new series page');
             console.error(`Series with id ${this.id} not found`);
             setTimeout(() => this.router.navigate(['/series', 'new']), 3000);
           } else {
-            throw(err);
+            throw err;
           }
         }
       );
     } else {
-      this.cms.defaultAccount.subscribe(a => this.setSeries(a, null));
+      this.cms.defaultAccount.subscribe((a) => this.setSeries(a, null));
     }
   }
 
@@ -106,7 +104,9 @@ export class SeriesComponent implements OnInit, OnDestroy {
         'Cannot Edit Series',
         `This series was created in the older PRX.org app, and must be
         edited there. <a target="_blank" href="${oldLink}">Click here</a> to view it.`,
-        () => { window.history.back(); }
+        () => {
+          window.history.back();
+        }
       );
     }
   }
@@ -123,31 +123,28 @@ export class SeriesComponent implements OnInit, OnDestroy {
       return this.series.seriesImports;
     }
 
-    this.series.seriesImports = this.importLoader.fetchImportsForSeries(this.series)
-      .pipe(
-        map((seriesImports) => {
-          return seriesImports.map((si) => {
-            return this.importLoader.pollForChanges(si);
-          });
-        })
-      );
+    this.series.seriesImports = this.importLoader.fetchImportsForSeries(this.series).pipe(
+      map((seriesImports) => {
+        return seriesImports.map((si) => {
+          return this.importLoader.pollForChanges(si);
+        });
+      })
+    );
 
     // start up your pollers!
-    this.series.seriesImports.pipe(
-      takeUntil(this._onDestroy))
-      .subscribe((seriesImports) => {
-        seriesImports.map((siObservable) => {
-          siObservable
-            .pipe(
-              takeUntil(this._onDestroy),
-              // TODO sample the series resource less frequently
-              // auditTime(5000)
-            )
-            .subscribe((si) => {
-              this.seriesImportStateChanged(si);
-            });
-        });
+    this.series.seriesImports.pipe(takeUntil(this._onDestroy)).subscribe((seriesImports) => {
+      seriesImports.map((siObservable) => {
+        siObservable
+          .pipe(
+            takeUntil(this._onDestroy)
+            // TODO sample the series resource less frequently
+            // auditTime(5000)
+          )
+          .subscribe((si) => {
+            this.seriesImportStateChanged(si);
+          });
       });
+    });
 
     return this.series.seriesImports;
   }
@@ -160,7 +157,6 @@ export class SeriesComponent implements OnInit, OnDestroy {
     this.loadSeries();
 
     return si;
-
   }
 
   validationStrategy() {
@@ -233,5 +229,4 @@ export class SeriesComponent implements OnInit, OnDestroy {
       return true;
     }
   }
-
 }

--- a/src/app/series/series.component.ts
+++ b/src/app/series/series.component.ts
@@ -229,4 +229,9 @@ export class SeriesComponent implements OnInit, OnDestroy {
       return true;
     }
   }
+
+  // TODO: remove
+  tempOnFeeds(): boolean {
+    return window.location.href.endsWith('/feeds');
+  }
 }

--- a/src/app/series/series.routing.ts
+++ b/src/app/series/series.routing.ts
@@ -7,6 +7,7 @@ import { SeriesBasicComponent } from './directives/series-basic.component';
 import { SeriesTemplatesComponent } from './directives/series-templates.component';
 import { SeriesPlanComponent } from './directives/series-plan.component';
 import { SeriesPodcastComponent } from './directives/series-podcast.component';
+import { SeriesFeedsComponent } from './directives/series-feeds.component';
 import { SeriesFeedComponent } from './directives/series-feed.component';
 import { SeriesImportStatusComponent } from './directives/series-import-status.component';
 import { SeriesImportStatusCardComponent } from '../series-import-status-card/series-import-status-card.component';
@@ -18,6 +19,7 @@ const seriesChildRoutes = [
   { path: 'templates', component: SeriesTemplatesComponent },
   { path: 'plan', component: SeriesPlanComponent },
   { path: 'podcast', component: SeriesPodcastComponent },
+  { path: 'feeds', component: SeriesFeedsComponent },
   { path: 'list', component: SeriesFeedComponent },
   { path: 'import-status', component: SeriesImportStatusComponent }
 ];
@@ -51,6 +53,7 @@ export const seriesComponents: any[] = [
   SeriesTemplatesComponent,
   SeriesPlanComponent,
   SeriesPodcastComponent,
+  SeriesFeedsComponent,
   SeriesFeedComponent,
   SeriesImportStatusComponent,
   SeriesImportStatusCardComponent,

--- a/src/app/shared/model/feeder-feed.model.spec.ts
+++ b/src/app/shared/model/feeder-feed.model.spec.ts
@@ -1,0 +1,206 @@
+import { cms } from '../../../testing';
+import { FeederFeedModel } from './feeder-feed.model';
+
+describe('FeederFeedModel', () => {
+  const podcast = cms().mock('prx:podcast', { id: 1, title: 'my podcast' });
+  const data = {
+    id: 1234,
+    title: 'my-title',
+    slug: 'my-slug',
+    fileName: 'my-file.xml',
+    private: true,
+    tokens: [{ label: 'my-token', token: 'tok-1' }],
+    url: 'https://some.where/feed',
+    newFeedUrl: 'https://some.where/feed',
+    enclosurePrefix: 'http://my.prefixer/',
+    displayEpisodesCount: 100,
+    displayFullEpisodesCount: 10,
+    includeZones: ['house', 'sonic_id']
+  };
+  const doc = podcast.mock('prx-feed', data);
+
+  let feed: FeederFeedModel;
+  beforeEach(() => (feed = new FeederFeedModel(podcast, doc)));
+
+  it('checks if a feed is default', () => {
+    expect(feed.isDefault).toEqual(false);
+    feed.slug = '';
+    expect(feed.isDefault).toEqual(true);
+
+    // if feed has a blank slug but is new, it is NOT the default
+    feed.id = null;
+    expect(feed.isDefault).toEqual(false);
+  });
+
+  it('sets defaults', () => {
+    feed = new FeederFeedModel(podcast, podcast.mock('prx-feed', {}));
+
+    // just look at the interesting defaults
+    expect(feed.fileName).toEqual('feed-rss.xml');
+    expect(feed.private).toEqual(false);
+    expect(feed.tokens).toEqual([]);
+    expect(feed.billboardAds).toEqual(true);
+    expect(feed.houseAds).toEqual(true);
+    expect(feed.paidAds).toEqual(true);
+    expect(feed.sonicAds).toEqual(true);
+  });
+
+  it('round trips data', () => {
+    ['id', 'title', 'slug', 'fileName', 'private', 'tokens', 'url', 'newFeedUrl', 'enclosurePrefix'].forEach((key) => {
+      expect(feed[key]).toEqual(data[key]);
+    });
+    expect(feed.displayEpisodesCount).toEqual('100');
+    expect(feed.displayFullEpisodesCount).toEqual('10');
+    expect(feed.billboardAds).toEqual(false);
+    expect(feed.houseAds).toEqual(true);
+    expect(feed.paidAds).toEqual(false);
+    expect(feed.sonicAds).toEqual(true);
+
+    // exact same data should get returned
+    expect(feed.encode()).toEqual(data);
+  });
+
+  it('encodes included ad types', () => {
+    feed.billboardAds = true;
+    feed.houseAds = false;
+    feed.paidAds = true;
+    feed.sonicAds = true;
+    expect(feed.encode()['includeZones']).toEqual(['billboard', 'ad', 'sonic_id']);
+
+    // if all are included, encodes to null
+    feed.houseAds = true;
+    expect(feed.encode()['includeZones']).toBeNull();
+  });
+
+  it('validates titles', () => {
+    expect(feed.invalid('title')).toBeNull();
+
+    feed.title = '';
+    expect(feed.invalid('title')).toMatch(/is a required field/);
+
+    // default feeds don't need titles
+    feed.slug = '';
+    expect(feed.invalid('title')).toBeNull();
+  });
+
+  it('validates slugs', () => {
+    expect(feed.invalid('slug')).toBeNull();
+
+    feed.slug = 'images';
+    expect(feed.invalid('slug')).toMatch(/is reserved/);
+
+    feed.slug = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    expect(feed.invalid('slug')).toMatch(/is reserved/);
+
+    feed.slug = 'spaces not allowed';
+    expect(feed.invalid('slug')).toMatch(/must contain only letters, numbers, underscores and dashes/);
+  });
+
+  it('validates fileNames', () => {
+    expect(feed.invalid('fileName')).toBeNull();
+
+    feed.fileName = 'slashes/not/allowed';
+    expect(feed.invalid('fileName')).toMatch(/must contain only letters, numbers, underscores and dashes/);
+  });
+
+  it('validates tokens', () => {
+    expect(feed.invalid('tokensJson')).toBeNull();
+
+    feed.tokens = [];
+    feed.setTokens();
+    expect(feed.invalid('tokensJson')).toBeNull();
+
+    feed.tokens = [{ label: 'only-label', token: '' }];
+    feed.setTokens();
+    expect(feed.invalid('tokensJson')).toMatch(/cannot have blank fields/);
+
+    feed.tokens = [{ label: '', token: 'only-token' }];
+    feed.setTokens();
+    expect(feed.invalid('tokensJson')).toMatch(/cannot have blank fields/);
+  });
+
+  it('validates various url fields', () => {
+    expect(feed.invalid('url')).toBeNull();
+    expect(feed.invalid('newFeedUrl')).toBeNull();
+    expect(feed.invalid('enclosurePrefix')).toBeNull();
+
+    feed.url = 'some spaces';
+    feed.newFeedUrl = 'bad$stuff';
+    feed.enclosurePrefix = '***';
+    expect(feed.invalid('url')).toMatch(/not a valid url/i);
+    expect(feed.invalid('newFeedUrl')).toMatch(/not a valid url/i);
+    expect(feed.invalid('enclosurePrefix')).toMatch(/not a valid url/i);
+  });
+
+  it('validates various count fields', () => {
+    expect(feed.invalid('displayEpisodesCount')).toBeNull();
+    expect(feed.invalid('displayFullEpisodesCount')).toBeNull();
+
+    feed.displayEpisodesCount = '-1';
+    feed.displayFullEpisodesCount = 'abc';
+    expect(feed.invalid('displayEpisodesCount')).toMatch(/enter a positive number/i);
+    expect(feed.invalid('displayFullEpisodesCount')).toMatch(/enter a positive number/i);
+  });
+
+  it('returns private feed urls', () => {
+    expect(feed.privateFeedUrl()).toBeNull();
+
+    const href = 'http://test.feed/123/my-slug/my-file.xml';
+    feed.doc['_links'] = { 'prx:private-feed': { href } };
+    expect(feed.privateFeedUrl()).toEqual(href);
+
+    feed.fileName = 'else.xml';
+    expect(feed.privateFeedUrl()).toEqual('http://test.feed/123/my-slug/else.xml');
+
+    feed.slug = 'changed';
+    expect(feed.privateFeedUrl()).toEqual('http://test.feed/123/changed/else.xml');
+
+    feed.slug = '';
+    feed.doc['_links']['prx:private-feed']['href'] = href.replace('/my-slug/', '/');
+    expect(feed.privateFeedUrl()).toEqual('http://test.feed/123/else.xml');
+
+    feed.doc['_links']['prx:private-feed']['href'] = href + '{?auth}';
+    feed.doc['_links']['prx:private-feed']['templated'] = true;
+    // TODO: MockHalDoc removes the remote adapter, so we can't expand links correctly
+    // expect(feed.privateFeedUrl('token')).toEqual(href + '?auth=token');
+  });
+
+  it('returns published feed urls', () => {
+    const href = 'http://test.feed/123/my-slug/my-file.xml';
+    feed.doc['_links'] = { 'prx:private-feed': { href } };
+    expect(feed.publishedFeedUrl()).toEqual(data.url);
+
+    feed.url = '';
+    expect(feed.publishedFeedUrl()).toEqual('http://test.feed/123/my-slug/my-file.xml');
+  });
+
+  it('adds and removes tokens', () => {
+    expect(feed.tokens.length).toEqual(1);
+    expect(feed.tokensJson).toEqual(JSON.stringify(feed.tokens));
+
+    feed.addToken();
+    expect(feed.tokens.length).toEqual(2);
+    expect(feed.tokens[1].label).toEqual('');
+    expect(feed.tokens[1].token.length).toBeGreaterThan(8);
+    expect(feed.tokensJson).toEqual(JSON.stringify(feed.tokens));
+
+    feed.removeToken(1);
+    expect(feed.tokens.length).toEqual(1);
+    expect(feed.tokensJson).toEqual(JSON.stringify(feed.tokens));
+  });
+
+  it('checks token label states', () => {
+    expect(feed.labelChanged(0)).toEqual(false);
+    expect(feed.labelInvalid(0)).toEqual(false);
+    expect(feed.tokenChanged(0)).toEqual(false);
+    expect(feed.tokenInvalid(0)).toEqual(false);
+
+    feed.tokens[0].label = '';
+    feed.tokens[0].token = '';
+    feed.setTokens();
+    expect(feed.labelChanged(0)).toEqual(true);
+    expect(feed.labelInvalid(0)).toEqual(true);
+    expect(feed.tokenChanged(0)).toEqual(true);
+    expect(feed.tokenInvalid(0)).toEqual(true);
+  });
+});

--- a/src/app/shared/model/feeder-feed.model.ts
+++ b/src/app/shared/model/feeder-feed.model.ts
@@ -103,13 +103,15 @@ export class FeederFeedModel extends BaseModel {
     displayFullEpisodesCount: [POSITIVE_INT_OR_BLANK]
   };
 
+  URLS = ['url', 'newFeedUrl', 'enclosurePrefix'];
+
   constructor(podcast: HalDoc, feed?: HalDoc, loadRelated = true) {
     super();
     this.init(podcast, feed, loadRelated);
   }
 
   get isDefault(): boolean {
-    return this.id && !this.slug;
+    return !!this.id && !this.slug;
   }
 
   key() {
@@ -125,10 +127,10 @@ export class FeederFeedModel extends BaseModel {
   }
 
   decode() {
-    this.id = this.doc['id'];
-    this.title = this.doc['title'];
-    this.slug = this.doc['slug'];
-    this.fileName = this.doc['fileName'];
+    this.id = this.doc['id'] || null;
+    this.title = this.doc['title'] || '';
+    this.slug = this.doc['slug'] || '';
+    this.fileName = this.doc['fileName'] || 'feed-rss.xml';
     this.private = this.doc['private'] || false;
     this.tokensJson = JSON.stringify(this.doc['tokens'] || []);
     this.tokens = JSON.parse(this.tokensJson);
@@ -195,6 +197,8 @@ export class FeederFeedModel extends BaseModel {
       }
 
       return parts.join('/');
+    } else {
+      return null;
     }
   }
 

--- a/src/app/shared/model/feeder-feed.model.ts
+++ b/src/app/shared/model/feeder-feed.model.ts
@@ -61,6 +61,9 @@ export class FeederFeedModel extends BaseModel {
   paidAds = true;
   sonicAds = true;
 
+  // TODO COPY: url, new_feed_url, enclosure_prefix, display_episodes_count, display_full_episodes_count
+  // TODO NEW: episode_offset_seconds, include_tags, audio_format
+
   VALIDATORS = {
     title: [UNLESS_DEFAULT(REQUIRED())],
     slug: [UNLESS_DEFAULT(REQUIRED()), UNLESS_DEFAULT(FEED_SLUG)],

--- a/src/app/shared/model/feeder-feed.model.ts
+++ b/src/app/shared/model/feeder-feed.model.ts
@@ -140,10 +140,10 @@ export class FeederFeedModel extends BaseModel {
 
     // null includeZones means include them all
     const include = this.doc['includeZones'] || ['billboard', 'house', 'ad', 'sonic_id'];
-    this.billboardAds = include.includes('billboard');
-    this.houseAds = include.includes('house');
-    this.paidAds = include.includes('ad');
-    this.sonicAds = include.includes('sonic_id');
+    this.billboardAds = include.indexOf('billboard') > -1;
+    this.houseAds = include.indexOf('house') > -1;
+    this.paidAds = include.indexOf('ad') > -1;
+    this.sonicAds = include.indexOf('sonic_id') > -1;
   }
 
   encode(): {} {
@@ -180,7 +180,7 @@ export class FeederFeedModel extends BaseModel {
   }
 
   privateFeedUrl(auth?: string): string {
-    if (this.doc) {
+    if (this.doc && this.doc.has('prx:private-feed')) {
       const url = this.doc.expand('prx:private-feed', { auth });
 
       // sub in the current slug/filename
@@ -188,7 +188,7 @@ export class FeederFeedModel extends BaseModel {
       if (!this.isDefault) {
         parts[parts.length - 2] = this.slug;
       }
-      if (parts[parts.length - 1].includes('?')) {
+      if (parts[parts.length - 1].indexOf('?') > -1) {
         parts[parts.length - 1] = this.fileName + '?' + parts[parts.length - 1].split('?').pop();
       } else {
         parts[parts.length - 1] = this.fileName;

--- a/src/app/shared/model/feeder-feed.model.ts
+++ b/src/app/shared/model/feeder-feed.model.ts
@@ -1,0 +1,99 @@
+import { Observable } from 'rxjs';
+import { HalDoc } from '../../core';
+import { BaseModel, BaseInvalid, REQUIRED } from 'ngx-prx-styleguide';
+
+export const UNLESS_DEFAULT = (validator: BaseInvalid) => {
+  return (key: string, value: any, strict?: boolean, model?: any) => {
+    if (model && model.isDefault) {
+      return null;
+    } else {
+      return validator(key, value, strict, model);
+    }
+  };
+};
+
+const FEED_SLUG: BaseInvalid = (key: string, value: any): string => {
+  if (value === 'images' || value.match(/^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/)) {
+    return 'Slug is reserved';
+  } else if (value.match(/^[0-9a-zA-Z_-]+$/)) {
+    return null;
+  } else {
+    return 'Slug must contain only letters, numbers, underscores and dashes';
+  }
+};
+
+const FEED_FILE_NAME: BaseInvalid = (key: string, value: any): string => {
+  if (value.match(/^[0-9a-zA-Z_.-]+$/)) {
+    return null;
+  } else {
+    return 'File name must contain only letters, numbers, underscores and dashes';
+  }
+};
+
+export class FeederFeedModel extends BaseModel {
+  id: number;
+  title = '';
+  slug = '';
+  fileName = 'feed-rss.xml';
+  private = false;
+
+  SETABLE = ['title', 'slug', 'fileName', 'private'];
+
+  VALIDATORS = {
+    title: [UNLESS_DEFAULT(REQUIRED())],
+    slug: [UNLESS_DEFAULT(REQUIRED()), UNLESS_DEFAULT(FEED_SLUG)],
+    fileName: [REQUIRED(), FEED_FILE_NAME]
+  };
+
+  constructor(podcast: HalDoc, feed?: HalDoc, loadRelated = true) {
+    super();
+    this.init(podcast, feed, loadRelated);
+  }
+
+  get isDefault(): boolean {
+    return this.id && !this.slug;
+  }
+
+  get privateFeedUrl(): string {
+    const base = this.parent['publishedUrl'].split('/', 4).join('/');
+    if (this.isDefault) {
+      return `${base}/${this.fileName}`;
+    } else {
+      return `${base}/${this.slug}/${this.fileName}`;
+    }
+  }
+
+  key() {
+    if (this.doc) {
+      return `prx.feed.${this.doc.id}`;
+    } else {
+      return `prx.feed.new.${this.parent.id}`;
+    }
+  }
+
+  related() {
+    return {};
+  }
+
+  decode() {
+    this.id = this.doc['id'];
+    this.title = this.doc['title'];
+    this.slug = this.doc['slug'];
+    this.fileName = this.doc['fileName'];
+    this.private = this.doc['private'] || false;
+  }
+
+  encode(): {} {
+    let data = <any>{};
+    data.id = this.id;
+    data.title = this.title;
+    data.slug = this.slug;
+    data.fileName = this.fileName;
+    data.private = this.private;
+    return data;
+  }
+
+  saveNew(data: {}): Observable<HalDoc> {
+    return this.parent.create('prx:feeds', {}, data);
+  }
+}

--- a/src/app/shared/model/feeder-podcast.model.spec.ts
+++ b/src/app/shared/model/feeder-podcast.model.spec.ts
@@ -112,4 +112,20 @@ describe('FeederPodcastModel', () => {
     expect(podcast.invalid('displayEpisodesCount')).toBeFalsy();
     expect(podcast.invalid('displayFullEpisodesCount')).toBeFalsy();
   });
+
+  it('loads the feeder feeds in sorted order', () => {
+    const doc = dist.mock('some-feeder', { id: 'pod1' });
+    doc.mockItems('prx:feeds', [
+      { id: 3, title: 'feed three' },
+      { id: 1, title: 'feed one' },
+      { id: 2, title: 'feed two' }
+    ]);
+
+    const podcast = new FeederPodcastModel(series, dist, doc, false);
+    podcast.loadRelated('feeds');
+    expect(podcast.feeds.length).toEqual(3);
+    expect(podcast.feeds[0].title).toEqual('feed one');
+    expect(podcast.feeds[1].title).toEqual('feed two');
+    expect(podcast.feeds[2].title).toEqual('feed three');
+  });
 });

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -90,7 +90,7 @@ export class FeederPodcastModel extends BaseModel {
   related() {
     let feeds = observableOf([]);
 
-    if (this.doc) {
+    if (this.doc && this.doc.has('prx:feeds')) {
       feeds = this.doc.followItems('prx:feeds', { per: 999 }).pipe(
         map((docs) => {
           return docs.map((d) => new FeederFeedModel(this.doc, d)).sort((a, b) => (a.id > b.id ? 1 : -1));

--- a/src/app/shared/model/feeder-podcast.model.ts
+++ b/src/app/shared/model/feeder-podcast.model.ts
@@ -22,9 +22,9 @@ export class FeederPodcastModel extends BaseModel {
     'subCategory',
     'explicit',
     'link',
-    'newFeedUrl',
-    'publicFeedUrl',
-    'enclosurePrefix',
+    'newFeedUrl', // TODO: moved to feed
+    'publicFeedUrl', // TODO: moved to feed
+    'enclosurePrefix', // TODO: moved to feed
     'copyright',
     'complete',
     'language',
@@ -36,8 +36,8 @@ export class FeederPodcastModel extends BaseModel {
     'managingEditorName',
     'managingEditorEmail',
     'serialOrder',
-    'displayEpisodesCount',
-    'displayFullEpisodesCount'
+    'displayEpisodesCount', // TODO: moved to feed
+    'displayFullEpisodesCount' // TODO: moved to feed
   ];
   URLS = ['link', 'newFeedUrl', 'publicFeedUrl', 'enclosurePrefix'];
   category = '';

--- a/src/app/shared/model/index.ts
+++ b/src/app/shared/model/index.ts
@@ -1,5 +1,6 @@
 export * from './distribution.model';
 export * from './feeder-episode.model';
+export * from './feeder-feed.model';
 export * from './feeder-podcast.model';
 export * from './image.model';
 export * from './itunes.categories';

--- a/yarn.lock
+++ b/yarn.lock
@@ -6972,10 +6972,10 @@ ng2-dragula@^2.1.1:
     "@types/dragula" "^2.1.34"
     dragula "^3.7.2"
 
-ngx-prx-styleguide@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/ngx-prx-styleguide/-/ngx-prx-styleguide-5.1.1.tgz#ce8d05ee95ce4c4227bb11dfeffa9485b03a4760"
-  integrity sha512-gv9YHZeLmfXIyEiMrj8McpMZzuuFAs0ZF6wqLmgRE/5u+ZfQc8az8fz8HufXQ87nKGhreK9CyZd8Bb7UEQsi1A==
+ngx-prx-styleguide@5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/ngx-prx-styleguide/-/ngx-prx-styleguide-5.1.3.tgz#c7b354bfd25ec2e03cd66e678bf32c9af6f053f3"
+  integrity sha512-T1lzk2jdZEC1GW9vwwWyE+oqCRjPkFoeFeeiCTWeMcraCMtFfByktxafJ21NlZ0ShxdnvsLxo9UCJr/2roa6wQ==
   dependencies:
     "@ng-select/ng-select" "^3.7.3"
     c3 "~0.7.1"


### PR DESCRIPTION
Fixes #755.

![image](https://user-images.githubusercontent.com/1410587/159041803-76d8971e-2ae2-4838-8946-a08aa92b2b46.png)

Tackles a good chunk of the design in #748:

- [x] Feed labels (titles), slugs and filenames
- [x] Private feeds + tokens
- [x] Port podcast fields (url, new feed url, enclosure prefix, metadata limit, episode limit)
- [x] Exclude ad zones
- [ ] Keyword targeting TBD
- [ ] Episode drop offset TBD
- [ ] Audio format TBD