### PR TITLE
Feed overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,5 +97,4 @@ open http://publish.prx.docker
 # run tests in PhantomJS
 docker-compose run publish test
 docker-compose run publish testonce
-
 ```

--- a/src/app/series/directives/series-feeds.component.css
+++ b/src/app/series/directives/series-feeds.component.css
@@ -140,6 +140,9 @@
   margin-top: -1px;
   padding: 18px 22px 0;
 }
+.feed input[type=checkbox] {
+  margin-right: 4px;
+}
 .feed section .auth-token {
   display: flex;
   gap: 15px;

--- a/src/app/series/directives/series-feeds.component.html
+++ b/src/app/series/directives/series-feeds.component.html
@@ -25,9 +25,24 @@
           <button *ngIf="!expanded[i]" type="button" class="expand" aria-label="Expand" (click)="expand(i)"></button>
         </header>
         <section *ngIf="expanded[i]">
-          <prx-fancy-field *ngIf="!f.isDefault" required textinput [model]="f" name="title" id="title{{ i }}" label="Feed Label">
-            <div class="fancy-hint">A label for this feed, such as "Limited Items" or "Apple Subscription"</div>
+          <prx-fancy-field *ngIf="!f.isDefault" label="Overrides" required>
+            <div class="fancy-hint">
+              Override series metadata for this feed. You must provide an alternate title, but the other fields are optional.
+            </div>
+
+            <prx-fancy-field required textinput [model]="f" name="title" id="title{{ i }}" label="Title" small>
+            </prx-fancy-field>
+
+            <prx-fancy-field *ngIf="f.subtitle" textinput [model]="f" name="subtitle" id="subtitle{{ i }}" label="Teaser" small>
+            </prx-fancy-field>
+
+            <p *ngIf="!f.subtitle">
+              <input type="checkbox" (click)="f.set('subtitle', ' ')" id="alternateSubtitle{{ i }}">
+              <label for="alternateSubtitle{{ i }}">Enter an alternate teaser</label>
+            </p>
           </prx-fancy-field>
+
+          <hr>
 
           <prx-fancy-field
             *ngIf="!f.isDefault"

--- a/src/app/series/directives/series-feeds.component.html
+++ b/src/app/series/directives/series-feeds.component.html
@@ -36,9 +36,18 @@
             <prx-fancy-field *ngIf="f.subtitle" textinput [model]="f" name="subtitle" id="subtitle{{ i }}" label="Teaser" small>
             </prx-fancy-field>
 
+            <prx-fancy-field *ngIf="f.description" label="Description" small>
+              <publish-wysiwyg [model]="f" name="description" [content]="f.description" [changed]="f.changed('description')"></publish-wysiwyg>
+            </prx-fancy-field>
+
             <p *ngIf="!f.subtitle">
               <input type="checkbox" (click)="f.set('subtitle', ' ')" id="alternateSubtitle{{ i }}">
               <label for="alternateSubtitle{{ i }}">Enter an alternate teaser</label>
+            </p>
+
+            <p *ngIf="!f.description">
+              <input type="checkbox" (click)="f.set('description', ' ')" id="alternateDescription{{ i }}">
+              <label for="alternateDescription{{ i }}">Enter an alternate description</label>
             </p>
           </prx-fancy-field>
 

--- a/src/app/series/directives/series-feeds.component.html
+++ b/src/app/series/directives/series-feeds.component.html
@@ -58,9 +58,9 @@
               <input type="checkbox" (click)="f.set('summary', ' ')" id="alternateSummary{{ i }}">
               <label for="alternateSummary{{ i }}">Enter an alternate summary</label>
             </p>
-          </prx-fancy-field>
 
-          <hr>
+            <hr>
+          </prx-fancy-field>
 
           <prx-fancy-field
             *ngIf="!f.isDefault"

--- a/src/app/series/directives/series-feeds.component.html
+++ b/src/app/series/directives/series-feeds.component.html
@@ -40,6 +40,10 @@
               <publish-wysiwyg [model]="f" name="description" [content]="f.description" [changed]="f.changed('description')"></publish-wysiwyg>
             </prx-fancy-field>
 
+            <prx-fancy-field *ngIf="f.summary" label="Summary">
+              <publish-wysiwyg [model]="f" name="summary" [content]="f.summary" inputFormat="HTML" outputFormat="HTML" [changed]="f.changed('summary')"></publish-wysiwyg>
+            </prx-fancy-field>
+
             <p *ngIf="!f.subtitle">
               <input type="checkbox" (click)="f.set('subtitle', ' ')" id="alternateSubtitle{{ i }}">
               <label for="alternateSubtitle{{ i }}">Enter an alternate teaser</label>
@@ -48,6 +52,11 @@
             <p *ngIf="!f.description">
               <input type="checkbox" (click)="f.set('description', ' ')" id="alternateDescription{{ i }}">
               <label for="alternateDescription{{ i }}">Enter an alternate description</label>
+            </p>
+
+            <p *ngIf="!f.summary">
+              <input type="checkbox" (click)="f.set('summary', ' ')" id="alternateSummary{{ i }}">
+              <label for="alternateSummary{{ i }}">Enter an alternate summary</label>
             </p>
           </prx-fancy-field>
 

--- a/src/app/series/series.component.css
+++ b/src/app/series/series.component.css
@@ -20,3 +20,8 @@
 #import-button {
   margin-top: 30px;
 }
+
+/* clicking on invalid-tip should not save */
+.invalid-tip {
+  pointer-events: none;
+}

--- a/src/app/shared/model/feeder-feed.model.spec.ts
+++ b/src/app/shared/model/feeder-feed.model.spec.ts
@@ -6,6 +6,9 @@ describe('FeederFeedModel', () => {
   const data = {
     id: 1234,
     title: 'my-title',
+    subtitle: 'my-subtitle',
+    description: 'my-description',
+    summary: 'my-summary',
     slug: 'my-slug',
     fileName: 'my-file.xml',
     private: true,
@@ -49,7 +52,7 @@ describe('FeederFeedModel', () => {
   });
 
   it('round trips data', () => {
-    ['id', 'title', 'slug', 'fileName', 'private', 'tokens', 'url', 'newFeedUrl', 'enclosurePrefix', 'episodeOffsetSeconds'].forEach(
+    ['id', 'title', 'subtitle', 'description', 'summary', 'slug', 'fileName', 'private', 'tokens', 'url', 'newFeedUrl', 'enclosurePrefix', 'episodeOffsetSeconds'].forEach(
       (key) => {
         expect(feed[key]).toEqual(data[key]);
       }

--- a/src/app/shared/model/feeder-feed.model.ts
+++ b/src/app/shared/model/feeder-feed.model.ts
@@ -89,6 +89,9 @@ export class FeederFeedModel extends BaseModel {
 
   SETABLE = [
     'title',
+    'subtitle',
+    'description',
+    'summary',
     'slug',
     'fileName',
     'private',
@@ -111,6 +114,9 @@ export class FeederFeedModel extends BaseModel {
     'audioSample'
   ];
   title = '';
+  subtitle = '';
+  description = '';
+  summary = '';
   slug = '';
   fileName = 'feed-rss.xml';
   private = false;
@@ -174,6 +180,9 @@ export class FeederFeedModel extends BaseModel {
   decode() {
     this.id = this.doc['id'] || null;
     this.title = this.doc['title'] || '';
+    this.subtitle = this.doc['subtitle'] || '';
+    this.description = this.doc['description'] || '';
+    this.summary = this.doc['summary'] || '';
     this.slug = this.doc['slug'] || '';
     this.fileName = this.doc['fileName'] || 'feed-rss.xml';
     this.private = this.doc['private'] || false;
@@ -212,6 +221,9 @@ export class FeederFeedModel extends BaseModel {
     let data = <any>{};
     data.id = this.id;
     data.title = this.title;
+    data.subtitle = this.subtitle || null;
+    data.description = this.description || null;
+    data.summary = this.summary || null;
     data.slug = this.slug || null;
     data.fileName = this.fileName || null;
     data.private = this.private;


### PR DESCRIPTION
Finishing PRX/feeder.prx.org#436. Also fixed #762 with some minimal CSS.

The fields remain on their existing tabs for the default feed (`subtitle` and `description` are on "Basic Info", and `summary` is on "Podcast Info").

But for non-default feeds, you get checkboxes which show the override fields.  When you delete the content from the field, it disappears and the checkbox reappears.  (It's a bit hard to explain without trying it, but I'd say it's adequately intuitive).

![image](https://user-images.githubusercontent.com/1410587/185980131-abe6a96b-f7b9-4aa1-ab4a-e55c58990613.png)

![image](https://user-images.githubusercontent.com/1410587/185980218-a9845ca8-5af5-468b-98bd-7f811048e2a4.png)
