### PR TITLE
New Feeder UI

### DIFF
--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -1,8 +1,14 @@
 import { cit, create, cms, By } from '../../testing';
 import { DashboardComponent } from './dashboard.component';
+import { ModalService } from 'ngx-prx-styleguide';
 
 describe('DashboardComponent', () => {
   create(DashboardComponent);
+
+  provide(ModalService, {
+    alert: (a) => nil,
+    confirm: (p) => nil
+  });
 
   let auth;
   beforeEach(() => {

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -1,14 +1,11 @@
-import { cit, create, cms, By } from '../../testing';
+import { cit, create, cms, By, provide } from '../../testing';
 import { DashboardComponent } from './dashboard.component';
 import { ModalService } from 'ngx-prx-styleguide';
 
 describe('DashboardComponent', () => {
   create(DashboardComponent);
 
-  provide(ModalService, {
-    alert: (a) => nil,
-    confirm: (p) => nil
-  });
+  provide(ModalService);
 
   let auth;
   beforeEach(() => {

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -2,15 +2,14 @@ import { Component, OnInit } from '@angular/core';
 import { mergeMap } from 'rxjs/operators';
 import { CmsService, HalDoc } from '../core';
 import { SeriesModel } from '../shared';
+import { ModalService } from 'ngx-prx-styleguide';
 
 @Component({
   selector: 'publish-dashboard',
   styleUrls: ['dashboard.component.css'],
   templateUrl: 'dashboard.component.html'
 })
-
 export class DashboardComponent implements OnInit {
-
   isLoaded = false;
   totalCount: number;
   noSeries: boolean;
@@ -18,24 +17,47 @@ export class DashboardComponent implements OnInit {
   defaultAccount: HalDoc;
   series: SeriesModel[];
 
-  constructor(private cms: CmsService) {}
+  constructor(private cms: CmsService, private modal: ModalService) {}
 
   ngOnInit() {
-    this.cms.auth.pipe(
-      mergeMap((auth: HalDoc) => {
-        this.auth = auth;
-        return auth.follow('prx:default-account');
-      }),
-      mergeMap((defaultAccount: HalDoc) => {
-        this.defaultAccount = defaultAccount;
-        return this.auth.followItems('prx:series', {filters: 'v4', zoom: 'prx:image'});
-      }),
-    ).subscribe((series: HalDoc[]) => {
-      this.isLoaded = true;
-      this.totalCount = series.length ? series[0].total() : 0;
-      this.noSeries = (series.length < 1) ? true : null;
-      this.series = series.map(s => new SeriesModel(null, s, false));
-    });
+    this.cms.auth
+      .pipe(
+        mergeMap((auth: HalDoc) => {
+          this.auth = auth;
+          return auth.follow('prx:default-account');
+        }),
+        mergeMap((defaultAccount: HalDoc) => {
+          this.defaultAccount = defaultAccount;
+          return this.auth.followItems('prx:series', { filters: 'v4', zoom: 'prx:image' });
+        })
+      )
+      .subscribe((series: HalDoc[]) => {
+        this.isLoaded = true;
+        this.totalCount = series.length ? series[0].total() : 0;
+        this.noSeries = series.length < 1 ? true : null;
+        this.series = series.map((s) => new SeriesModel(null, s, false));
+
+        if (this.auth['feederUiAccess'] && this.noSeries) {
+          this.showFeederModal(this.auth['feederUiAccess']);
+        }
+      });
   }
 
+  showFeederModal(url) {
+    this.modal.show({
+      title: 'Good news everyone!',
+      body: `
+        <p>It looks like all your podcasts have been migrated to our shiny new publishing application.</p>
+        <hr/>
+        <p>Go to <strong><a href="${url}">${url}</a></strong> to access them!</p>
+        <br/>
+      `,
+      primaryButton: `Let's Goooooooooo!`,
+      buttonCallback: () => {
+        window.location.href = url;
+      }
+      // height: 400,
+      // width: 700
+    });
+  }
 }


### PR DESCRIPTION
Needs PRX/cms.prx.org#623.

Related to https://github.com/PRX/id.prx.org/pull/363, but I don't think it needs that to deploy.

If all of a user's shows (accounts) have moved to the new Feeder UI ... show them a modal and redirect them there.

![image](https://github.com/PRX/publish.prx.org/assets/1410587/948221d4-e1e5-4b4d-9316-decd587cb93d)

It's always possible that a user will have some shows in Publish and some in Feeder.  That should be fine - this only shows up once all your shows have moved.