### PR TITLE
Remove default podcast link

### DIFF
--- a/src/app/shared/model/distribution.model.spec.ts
+++ b/src/app/shared/model/distribution.model.spec.ts
@@ -35,11 +35,10 @@ describe('DistributionModel', () => {
     expect(dist.podcast.authorName).toEqual(account['name']);
   });
 
-  it('defaults author and link for new podcasts', () => {
+  it('defaults author for new podcasts', () => {
     let dist = new DistributionModel(series, null, true);
     expect(dist.podcast).not.toBeNull();
     expect(dist.podcast.authorName).toEqual(account['name']);
-    expect(dist.podcast.link).toEqual(alternate['href']);
   });
 
   it('loads the feeder podcast on-demand only', () => {

--- a/src/app/shared/model/distribution.model.ts
+++ b/src/app/shared/model/distribution.model.ts
@@ -56,9 +56,6 @@ export class DistributionModel extends BaseModel {
         if (account && account['name']) {
           podmodel.set('authorName', account['name'], true);
         }
-        if (!podmodel.link) {
-          podmodel.set('link', this.parent.expand('alternate'), true);
-        }
         return podmodel;
       }));
     }


### PR DESCRIPTION
Part of [Feeder migration to remove beta links](https://github.com/PRX/feeder.prx.org/issues/825)