### PR TITLE
Fix series default account

### DIFF
--- a/src/app/series/series.component.spec.ts
+++ b/src/app/series/series.component.spec.ts
@@ -64,8 +64,17 @@ describe('SeriesComponent', () => {
   cit('defaults new series to the default account', (fix, el, comp) => {
     activatedRoute.testParams = {};
     auth.mock('prx:default-account', { id: 88 });
+    auth.mockItems('prx:accounts', [{ id: 88 }]);
     fix.detectChanges();
     expect(comp.series.parent.id).toEqual(88);
+  });
+
+  cit('defaults new series to an authorized account', (fix, el, comp) => {
+    activatedRoute.testParams = {};
+    auth.mock('prx:default-account', { id: 88 });
+    auth.mockItems('prx:accounts', [{ id: 99 }]);
+    fix.detectChanges();
+    expect(comp.series.parent.id).toEqual(99);
   });
 
   cit('refuses to edit v3 series', (fix, el, comp) => {
@@ -79,6 +88,7 @@ describe('SeriesComponent', () => {
   cit('navigates to new series after save', (fix, el, comp) => {
     activatedRoute.testParams = {};
     auth.mock('prx:default-account', { id: 88 });
+    auth.mockItems('prx:accounts', [{ id: 88 }]);
     fix.detectChanges();
 
     const btn = el.queryAll(By.css('prx-button')).find((e) => {

--- a/src/app/series/series.component.ts
+++ b/src/app/series/series.component.ts
@@ -8,7 +8,7 @@ import { SeriesImportService } from './series-import.service';
 import { SeriesModel } from '../shared';
 import { NEW_SERIES_VALIDATIONS } from '../shared/model/series.model';
 
-import { map, takeUntil } from 'rxjs/operators';
+import { map, takeUntil, withLatestFrom } from 'rxjs/operators';
 
 @Component({
   providers: [TabService],
@@ -68,7 +68,13 @@ export class SeriesComponent implements OnInit, OnDestroy {
         }
       );
     } else {
-      this.cms.defaultAccount.subscribe((a) => this.setSeries(a, null));
+      this.cms.defaultAccount.pipe(withLatestFrom(this.cms.accounts)).subscribe(([defaultAccount, accounts]) => {
+        if (accounts.find((a) => a.id == defaultAccount?.id)) {
+          this.setSeries(defaultAccount, null);
+        } else {
+          this.setSeries(accounts[0], null);
+        }
+      });
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/PRX/id.prx.org/issues/375

Make sure the initial account we assign to a series is one of the authorized `prx:accounts`.  In case your default account has no `plan` in ID.