### PR TITLE
Validate description bytes

### DIFF
--- a/src/app/shared/model/story.model.ts
+++ b/src/app/shared/model/story.model.ts
@@ -36,7 +36,7 @@ const MIN = (min: number): BaseInvalid => {
 
 const MAXBYTES = (maxBytes: number): BaseInvalid => {
   return (key: string, value: any) => {
-    if (new TextEncoder().encode(value || '').length > maxBytes) {
+    if (typeof TextEncoder !== 'undefined' && new TextEncoder().encode(value || '').length > maxBytes) {
       return `${key} is too long`;
     } else {
       return null;

--- a/src/app/shared/model/story.model.ts
+++ b/src/app/shared/model/story.model.ts
@@ -205,7 +205,6 @@ export class StoryModel extends BaseModel implements HasUpload {
     this.releasedAt = this.doc['releasedAt'] ? new Date(this.doc['releasedAt']) : null;
 
     // count bytes of the html description
-    this.descriptionBytes = this.doc['descriptionMd'] || '';
     if (typeof TextEncoder === 'undefined') {
       this.descriptionBytes = (this.doc['description'] || '').length;
     } else {

--- a/src/app/shared/model/story.model.ts
+++ b/src/app/shared/model/story.model.ts
@@ -48,6 +48,7 @@ export class StoryModel extends BaseModel implements HasUpload {
   public cleanTitle: string;
   public shortDescription = '';
   public description = '';
+  public descriptionBytes = 0;
   public productionNotes: string;
   public tags = [];
   public status: string;

--- a/src/app/shared/model/story.model.ts
+++ b/src/app/shared/model/story.model.ts
@@ -1,9 +1,17 @@
 import { from as observableFrom, of as observableOf, Observable } from 'rxjs';
-import { map, toArray, concatAll, mergeMap} from 'rxjs/operators';
+import { map, toArray, concatAll, mergeMap } from 'rxjs/operators';
 import { HalDoc } from '../../core';
 import {
-  BaseModel, REQUIRED, LENGTH, RELATIONS, Upload, AudioVersionModel,
-  HasUpload, createGetUploads, createSetUploads, BaseInvalid
+  BaseModel,
+  REQUIRED,
+  LENGTH,
+  RELATIONS,
+  Upload,
+  AudioVersionModel,
+  HasUpload,
+  createGetUploads,
+  createSetUploads,
+  BaseInvalid
 } from 'ngx-prx-styleguide';
 import { ImageModel } from './image.model';
 import { StoryDistributionModel } from './story-distribution.model';
@@ -27,7 +35,6 @@ const MIN = (min: number): BaseInvalid => {
 };
 
 export class StoryModel extends BaseModel implements HasUpload {
-
   public id: number;
   public title: string; // show changes
   public cleanTitle: string;
@@ -47,19 +54,29 @@ export class StoryModel extends BaseModel implements HasUpload {
   public account: HalDoc;
   public distributions: StoryDistributionModel[] = [];
 
-  SETABLE = ['title', 'cleanTitle', 'shortDescription', 'description', 'tags',
-             'hasUploadMap', 'releasedAt', 'seasonNumber', 'episodeNumber', 'productionNotes'];
+  SETABLE = [
+    'title',
+    'cleanTitle',
+    'shortDescription',
+    'description',
+    'tags',
+    'hasUploadMap',
+    'releasedAt',
+    'seasonNumber',
+    'episodeNumber',
+    'productionNotes'
+  ];
 
   VALIDATORS = {
-    title:            [REQUIRED(true), LENGTH(1, 255)],
-    cleanTitle:       [LENGTH(0, 255)],
+    title: [REQUIRED(true), LENGTH(1, 255)],
+    cleanTitle: [LENGTH(0, 255)],
     shortDescription: [REQUIRED()],
-    description:      [LENGTH(0, 4000)],
-    productionNotes:  [LENGTH(0, 255)],
-    releasedAt:       [NO_UNPUBLISHING_VIA_RELEASED],
-    versions:         [RELATIONS('You must include at least 1 version of your audio')],
-    seasonNumber:     [MIN(1)],
-    episodeNumber:    [MIN(1)]
+    description: [LENGTH(0, 4000)],
+    productionNotes: [LENGTH(0, 255)],
+    releasedAt: [NO_UNPUBLISHING_VIA_RELEASED],
+    versions: [RELATIONS('You must include at least 1 version of your audio')],
+    seasonNumber: [MIN(1)],
+    episodeNumber: [MIN(1)]
   };
 
   // HasUpload mixin
@@ -98,51 +115,68 @@ export class StoryModel extends BaseModel implements HasUpload {
 
     // audio versions (with optional templates)
     if (this.doc) {
-      versions = this.doc.followItems('prx:audio-versions').pipe(mergeMap(vdocs => {
-        return observableFrom(vdocs.map(vdoc => {
-          if (vdoc.has('prx:audio-version-template')) {
-            return vdoc.follow('prx:audio-version-template').pipe(map(tdoc => {
-              return new AudioVersionModel({story: this.doc, version: vdoc, template: tdoc});
-            }));
-          } else {
-            return observableOf(new AudioVersionModel({story: this.doc, version: vdoc}));
-          }
-        })).pipe(concatAll(), toArray(), );
-      }));
+      versions = this.doc.followItems('prx:audio-versions').pipe(
+        mergeMap((vdocs) => {
+          return observableFrom(
+            vdocs.map((vdoc) => {
+              if (vdoc.has('prx:audio-version-template')) {
+                return vdoc.follow('prx:audio-version-template').pipe(
+                  map((tdoc) => {
+                    return new AudioVersionModel({ story: this.doc, version: vdoc, template: tdoc });
+                  })
+                );
+              } else {
+                return observableOf(new AudioVersionModel({ story: this.doc, version: vdoc }));
+              }
+            })
+          ).pipe(concatAll(), toArray());
+        })
+      );
     } else {
-      versions = this.getSeriesTemplates().pipe(map(tdocs => {
-        const defaultTemplate = tdocs.find((t) => t['label'].toLowerCase().match(/default/)) || tdocs[tdocs.length - 1];
-        const defaultVersion = new AudioVersionModel({series: this.parent, template: defaultTemplate});
-        defaultVersion.set('label', defaultVersion.label, true); // mark unchanged
-        return [defaultVersion];
-      }));
+      versions = this.getSeriesTemplates().pipe(
+        map((tdocs) => {
+          const defaultTemplate = tdocs.find((t) => t['label'].toLowerCase().match(/default/)) || tdocs[tdocs.length - 1];
+          const defaultVersion = new AudioVersionModel({ series: this.parent, template: defaultTemplate });
+          defaultVersion.set('label', defaultVersion.label, true); // mark unchanged
+          return [defaultVersion];
+        })
+      );
     }
 
     // image uploads
-    images = this.getUploads('prx:images').pipe(map(idocs => {
-      let models = idocs.map(docOrUuid => new ImageModel(this.doc, docOrUuid));
-      this.setUploads('prx:images', models.map(m => m.uuid));
-      return models;
-    }));
+    images = this.getUploads('prx:images').pipe(
+      map((idocs) => {
+        let models = idocs.map((docOrUuid) => new ImageModel(this.doc, docOrUuid));
+        this.setUploads(
+          'prx:images',
+          models.map((m) => m.uuid)
+        );
+        return models;
+      })
+    );
 
     // story distributions
     if (this.doc && this.doc.count('prx:distributions')) {
-      distributions = this.doc.followItems('prx:distributions').pipe(map(ddocs => {
-        return ddocs.map(d => new StoryDistributionModel(this.parent, this.doc, d));
-      }));
+      distributions = this.doc.followItems('prx:distributions').pipe(
+        map((ddocs) => {
+          return ddocs.map((d) => new StoryDistributionModel(this.parent, this.doc, d));
+        })
+      );
     } else if (this.isNew && this.parent) {
-      distributions = this.getSeriesDistribution('podcast').pipe(map(dist => {
-        if (dist) {
-          let newEpisode = new StoryDistributionModel(this.parent, this.doc);
-          newEpisode.set('kind', 'episode', true);
-          return [newEpisode];
-        } else {
-          return [];
-        }
-      }));
+      distributions = this.getSeriesDistribution('podcast').pipe(
+        map((dist) => {
+          if (dist) {
+            let newEpisode = new StoryDistributionModel(this.parent, this.doc);
+            newEpisode.set('kind', 'episode', true);
+            return [newEpisode];
+          } else {
+            return [];
+          }
+        })
+      );
     }
 
-    return {images: images, versions: versions, distributions: distributions};
+    return { images: images, versions: versions, distributions: distributions };
   }
 
   decode() {
@@ -163,7 +197,7 @@ export class StoryModel extends BaseModel implements HasUpload {
   }
 
   encode(): {} {
-    let data = <any> {};
+    let data = <any>{};
     data.title = this.title;
     data.cleanTitle = this.cleanTitle;
     data.shortDescription = this.shortDescription;
@@ -200,15 +234,19 @@ export class StoryModel extends BaseModel implements HasUpload {
 
   setPublished(published: boolean): Observable<boolean> {
     if (!published && this.doc.has('prx:unpublish')) {
-      return this.doc.follow('prx:unpublish', {method: 'post'}).pipe(map(doc => {
-        this.init(this.parent, doc, false);
-        return false;
-      }));
+      return this.doc.follow('prx:unpublish', { method: 'post' }).pipe(
+        map((doc) => {
+          this.init(this.parent, doc, false);
+          return false;
+        })
+      );
     } else if (published && this.doc.has('prx:publish')) {
-      return this.doc.follow('prx:publish', {method: 'post'}).pipe(map(doc => {
-        this.init(this.parent, doc, false);
-        return true;
-      }));
+      return this.doc.follow('prx:publish', { method: 'post' }).pipe(
+        map((doc) => {
+          this.init(this.parent, doc, false);
+          return true;
+        })
+      );
     } else {
       return observableOf(null);
     }
@@ -217,17 +255,23 @@ export class StoryModel extends BaseModel implements HasUpload {
   addImage(upload: Upload): ImageModel {
     let image = new ImageModel(this.doc, upload);
     this.images = [...this.images, image];
-    this.setUploads('prx:images', this.images.map(i => i.uuid));
+    this.setUploads(
+      'prx:images',
+      this.images.map((i) => i.uuid)
+    );
     return image;
   }
 
   removeImage(image: ImageModel) {
     if (image.isNew) {
-      this.images = this.images.filter(i => i !== image);
+      this.images = this.images.filter((i) => i !== image);
     } else {
       this.images = [...this.images]; // trigger change detection
     }
-    this.setUploads('prx:images', this.images.map(i => i.uuid));
+    this.setUploads(
+      'prx:images',
+      this.images.map((i) => i.uuid)
+    );
   }
 
   isV4(): boolean {
@@ -236,7 +280,7 @@ export class StoryModel extends BaseModel implements HasUpload {
 
   isPublished(bufferSeconds = 0): boolean {
     if (this.publishedAt) {
-      return new Date().valueOf() >= this.publishedAt.valueOf() + (bufferSeconds * 1000);
+      return new Date().valueOf() >= this.publishedAt.valueOf() + bufferSeconds * 1000;
     } else {
       return false;
     }
@@ -244,9 +288,11 @@ export class StoryModel extends BaseModel implements HasUpload {
 
   getSeriesDistribution(kind: string): Observable<HalDoc> {
     if (this.parent && this.parent.count('prx:distributions')) {
-      return this.parent.followItems('prx:distributions').pipe(map(dists => {
-        return dists.find(d => d['kind'] === kind);
-      }));
+      return this.parent.followItems('prx:distributions').pipe(
+        map((dists) => {
+          return dists.find((d) => d['kind'] === kind);
+        })
+      );
     } else {
       return observableOf(null);
     }
@@ -259,5 +305,4 @@ export class StoryModel extends BaseModel implements HasUpload {
       return observableOf([]);
     }
   }
-
 }

--- a/src/app/shared/model/story.model.ts
+++ b/src/app/shared/model/story.model.ts
@@ -34,6 +34,16 @@ const MIN = (min: number): BaseInvalid => {
   };
 };
 
+const MAXBYTES = (maxBytes: number): BaseInvalid => {
+  return (key: string, value: any) => {
+    if (new TextEncoder().encode(value || '').length > maxBytes) {
+      return `${key} is too long`;
+    } else {
+      return null;
+    }
+  };
+};
+
 export class StoryModel extends BaseModel implements HasUpload {
   public id: number;
   public title: string; // show changes
@@ -71,7 +81,7 @@ export class StoryModel extends BaseModel implements HasUpload {
     title: [REQUIRED(true), LENGTH(1, 255)],
     cleanTitle: [LENGTH(0, 255)],
     shortDescription: [REQUIRED()],
-    description: [LENGTH(0, 4000)],
+    description: [LENGTH(0, 4000), MAXBYTES(4000)],
     productionNotes: [LENGTH(0, 255)],
     releasedAt: [NO_UNPUBLISHING_VIA_RELEASED],
     versions: [RELATIONS('You must include at least 1 version of your audio')],


### PR DESCRIPTION
Validate the HTML-encoded description bytes is < 4000.

The flow goes like this:

1. User enters a description markdown of something like 3000 chars.  Frontend validations are fine with that.
2. User clicks save - CMS saves the markdown plus the HTML encoded version to the database.
3. After save, we decode the `description` field from the API (the HTML-encoded one)... calculate byte length, and highlight the field in red with the text "Description is too long"
4. Since this is a strict validation, user is prevented from publishing the episode until they fix the problem.

![image](https://github.com/PRX/publish.prx.org/assets/1410587/191138c8-a0b6-4c68-a223-fd33d3d96cf2)