### PR TITLE
New hostnames

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "evaporate": "^2.1.4",
     "js-sha256": "^0.9.0",
     "langmap": "0.0.14",
-    "ngx-prx-styleguide": "5.2.0",
+    "ngx-prx-styleguide": "5.2.1",
     "prosemirror-commands": "^1.1.4",
     "prosemirror-inputrules": "^1.1.2",
     "prosemirror-keymap": "^1.1.4",

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -49,7 +49,7 @@ export class DashboardComponent implements OnInit {
       body: `
         <p>It looks like all your podcasts have been migrated to our shiny new publishing application.</p>
         <hr/>
-        <p>Go to <strong><a href="${url}">${url}</a></strong> to access them!</p>
+        <p>Go to <strong><a href="${url}">Dovetail Podcasts</a></strong> to access them!</p>
         <br/>
       `,
       primaryButton: `Let's Goooooooooo!`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6972,10 +6972,10 @@ ng2-dragula@^2.1.1:
     "@types/dragula" "^2.1.34"
     dragula "^3.7.2"
 
-ngx-prx-styleguide@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/ngx-prx-styleguide/-/ngx-prx-styleguide-5.2.0.tgz#f232ce165b1d7fe67c2c6d4e4fa68c5fc8883fc4"
-  integrity sha512-LeJzyfSJWesypU0xwZXQbb+f7i2+cu3p8Xm5d0Xfsz68ug02h3LqLf/sIXlrlqbHhMq4tg75SqfHPcJKK42C5g==
+ngx-prx-styleguide@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/ngx-prx-styleguide/-/ngx-prx-styleguide-5.2.1.tgz#b3688df980f9bb9358be7bf51d29addab4c25114"
+  integrity sha512-qE0nj21MtYRzqYWqkd+jNe9ufutwGlte6RuQXEVvoIma01GZUXCyuHOzRjwABj4xX4fcAeYVdKWi3+uNz3LADg==
   dependencies:
     "@ng-select/ng-select" "^3.7.3"
     c3 "~0.7.1"


### PR DESCRIPTION
Bump styleguide, so we don't display "PRX" in front of everything in the app switcher dropdown.

Also fixes #778 - this url comes from CMS, and should automatically change to the new domain.  But I changed the displayed text to "Dovetail Podcasts" to be consistent with the dropdown.